### PR TITLE
Add Toom-5 benchmark implementation

### DIFF
--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -89,7 +89,7 @@ Default thresholds (overridable via `-D...`):
 | `BIGMATH_NTT_MULTIPLICATION_THRESHOLD` | `4096` | sum of limbs | Karatsuba below, NTT above |
 | `BIGMATH_KARATSUBA_THRESHOLD` | `48` | max of operands | Inside Karatsuba: base-case cutoff |
 
-`Toom-Cook 3` is implemented and correctness-tested but **not in the default dispatch** — see [its section](#toom-cook-3) for why.
+`Toom-Cook 3` and `Toom-5` are implemented and correctness-tested but **not in the default dispatch** — see [Toom-Cook 3](#toom-cook-3) and [Toom-5](#toom-5) for why.
 
 `Square(a, base)` lives in `algorithms/Squaring.h` and has its own parallel dispatcher:
 
@@ -225,6 +225,16 @@ These eliminate per-iteration branches that the compiler was not consistently ho
 **Why it isn't in dispatch.** Toom-3's best historical case was only a small win over Karatsuba, while the NTT path dominates once operands are large enough for Toom's lower exponent to matter. Current dispatcher sweeps keep Karatsuba until roughly 2048×2048 limbs and switch to NTT from total size ~4096. There is still no measured operand-size band where Toom-3 is the production winner.
 
 Toom-3 is kept callable for cross-checking in `tests/mult_correctness.cpp` and as a reference implementation. See [Bodrato 2007](https://www.bodrato.it/papers/#WAIFI2007) for the optimal interpolation sequence (the implementation here uses the textbook +2 evaluation point rather than Bodrato's −2 variant, deliberately, since 2026's correctness rewrite chose clarity over the 1-mul-cheaper interpolation).
+
+### Toom-5
+
+**Location:** `algorithms/multiplication/Toom5Multiplication.h`.
+
+**Status:** implemented and validated, but **not in dispatch**.
+
+Toom-5 splits operands into five chunks, evaluates at `{0, ±1, ±2, ±3, 4, ∞}`, performs nine pointwise products, and interpolates coefficients `c0..c8`. The implementation uses exact small-rational interpolation over the fixed seven nontrivial points after removing `c0` and `c8`.
+
+Benchmarks show no useful production band. Below the Toom-5 threshold the function falls back to Karatsuba. At the first active point, 512×512 limbs, Toom-5 is already about 3× slower than Karatsuba (`0.1507 ms` vs `0.0488 ms` in the full dispatch tuner run). It remains slower through the pre-NTT band, so it is kept only as an experimental cross-check/benchmark candidate.
 
 ### NTT (Goldilocks prime)
 
@@ -558,6 +568,20 @@ The 2026-05 rewrite verified Toom-3 is correct. The current portable C++ dispatc
 | 4 096 | 1.3077 | 0.8010 | N |
 
 Toom-3 has no operand-size band where it has proven useful in production dispatch. Adding it to dispatch caused a 3.3× regression on `mul 5k × 5k` in earlier trials. Kept as a cross-check reference, not as a production path.
+
+### Toom-5 in dispatch
+
+The 2026-05 Toom-5 prototype was benchmarked in `dispatch_tuner --full`:
+
+| limbs | Karatsuba ms | Toom-5 ms | NTT ms | winner |
+|---|---:|---:|---:|---|
+| 256 | 0.0131 | 0.0122 | 0.0341 | Toom-5 function, but still Karatsuba internally |
+| 384 | 0.0264 | 0.0262 | 0.0874 | Toom-5 function, but still Karatsuba internally |
+| 512 | 0.0488 | 0.1507 | 0.0893 | Karatsuba |
+| 1 024 | 0.1482 | 0.3214 | 0.1926 | Karatsuba |
+| 2 048 | 0.4640 | 0.7553 | 0.3690 | NTT |
+
+The apparent wins below 512 limbs are not real Toom-5 wins because `Toom5Multiplication` falls back to Karatsuba below `BIGMATH_TOOM5_THRESHOLD = 512`. Once Toom-5 is active, interpolation/evaluation overhead dominates. Do not add Toom-5 to dispatch without new benchmark evidence.
 
 ### Lowering `NTT_MULTIPLICATION_THRESHOLD` below 4096
 

--- a/include/biginteger/algorithms/multiplication/Toom5Multiplication.h
+++ b/include/biginteger/algorithms/multiplication/Toom5Multiplication.h
@@ -1,0 +1,288 @@
+/**
+ * BigInteger Class
+ * Toom-5 multiplication: 5-way split, evaluation at {0, ±1, ±2, ±3, 4, ∞}.
+ *
+ * This implementation is intentionally kept out of dispatch until benchmarks
+ * show a stable win over Karatsuba before the NTT crossover.
+ */
+
+#ifndef TOOM5_MULTIPLICATION
+#define TOOM5_MULTIPLICATION
+
+#include <array>
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <stdexcept>
+using namespace std;
+
+#include "../../common/Util.h"
+#include "../../common/Comparator.h"
+#include "../Addition.h"
+#include "../Subtraction.h"
+#include "../Shift.h"
+#include "../multiplication/ClassicMultiplication.h"
+#include "../multiplication/KaratsubaMultiplication.h"
+
+namespace BigMath
+{
+  class Toom5Multiplication
+  {
+  private:
+#ifndef BIGMATH_TOOM5_THRESHOLD
+#define BIGMATH_TOOM5_THRESHOLD 512
+#endif
+    static const SizeT TOOM5_THRESHOLD = BIGMATH_TOOM5_THRESHOLD;
+
+    struct Signed
+    {
+      vector<DataT> mag;
+      int sign;
+    };
+
+    struct Fraction
+    {
+      long long num;
+      long long den;
+    };
+
+    static long long GcdAbs(long long a, long long b)
+    {
+      a = a < 0 ? -a : a;
+      b = b < 0 ? -b : b;
+      return std::gcd(a, b);
+    }
+
+    static Fraction Normalize(Fraction f)
+    {
+      if (f.den == 0)
+        throw std::runtime_error("invalid Toom-5 interpolation denominator");
+      if (f.den < 0)
+      {
+        f.num = -f.num;
+        f.den = -f.den;
+      }
+      long long g = GcdAbs(f.num, f.den);
+      if (g != 0)
+      {
+        f.num /= g;
+        f.den /= g;
+      }
+      return f;
+    }
+
+    static Signed MakePositive(vector<DataT> v)
+    {
+      TrimZeros(v);
+      return {std::move(v), 1};
+    }
+
+    static Signed AddSigned(Signed const &a, Signed const &b, BaseT base)
+    {
+      if (IsZero(a.mag)) return b;
+      if (IsZero(b.mag)) return a;
+      if (a.sign == b.sign)
+        return {Add(a.mag, b.mag, base), a.sign};
+      Int c = Compare(a.mag, b.mag);
+      if (c == 0) return {vector<DataT>{0}, 1};
+      if (c > 0) return {Subtract(a.mag, b.mag, base), a.sign};
+      return {Subtract(b.mag, a.mag, base), b.sign};
+    }
+
+    static Signed NegSigned(Signed v)
+    {
+      if (!IsZero(v.mag))
+        v.sign = -v.sign;
+      return v;
+    }
+
+    static Signed SubSigned(Signed const &a, Signed const &b, BaseT base)
+    {
+      return AddSigned(a, NegSigned(b), base);
+    }
+
+    static Signed MulSmall(Signed v, ULong m, BaseT base)
+    {
+      if (m == 0 || IsZero(v.mag))
+        return {vector<DataT>{0}, 1};
+      v.mag = ClassicMultiplication::Multiply(v.mag, m, base);
+      return v;
+    }
+
+    static bool DivSmallInPlace(vector<DataT> &a, ULong d, BaseT base)
+    {
+      if (d == 1 || a.empty())
+        return true;
+      ULong carry = 0;
+      if (base == Base2_32)
+      {
+        for (Int i = (Int)a.size() - 1; i >= 0; --i)
+        {
+          ULong v = ((ULong)a[i]) | (carry << 32);
+          a[i] = (DataT)(v / d);
+          carry = v % d;
+        }
+      }
+      else
+      {
+        for (Int i = (Int)a.size() - 1; i >= 0; --i)
+        {
+          ULong v = a[i] + carry * base;
+          a[i] = (DataT)(v / d);
+          carry = v % d;
+        }
+      }
+      TrimZeros(a);
+      return carry == 0;
+    }
+
+    static Signed DivSmall(Signed v, ULong d, BaseT base)
+    {
+      if (!DivSmallInPlace(v.mag, d, base))
+        throw std::runtime_error("non-exact Toom-5 interpolation division");
+      if (IsZero(v.mag))
+        v.sign = 1;
+      return v;
+    }
+
+    static void Split5(vector<DataT> const &x, SizeT k, array<vector<DataT>, 5> &parts)
+    {
+      SizeT s = x.size();
+      for (SizeT p = 0; p < 5; ++p)
+      {
+        SizeT start = p * k;
+        if (start < s)
+          parts[p].assign(x.begin() + start, x.begin() + std::min(s, start + k));
+        else
+          parts[p].assign(1, 0);
+        TrimZeros(parts[p]);
+      }
+    }
+
+    static Signed Evaluate(array<vector<DataT>, 5> const &parts, int x, BaseT base)
+    {
+      Signed acc = MakePositive(parts[4]);
+      for (Int i = 3; i >= 0; --i)
+      {
+        if (x < 0)
+          acc = NegSigned(MulSmall(acc, (ULong)(-x), base));
+        else
+          acc = MulSmall(acc, (ULong)x, base);
+        acc = AddSigned(acc, MakePositive(parts[(SizeT)i]), base);
+      }
+      return acc;
+    }
+
+    static const array<array<Fraction, 7>, 7> &InverseInterpolation()
+    {
+      static const array<array<Fraction, 7>, 7> inv = {{
+        {{{1, 1}, {-3, 5}, {-3, 10}, {1, 10}, {1, 15}, {-1, 105}, {-1, 140}}},
+        {{{3, 4}, {3, 4}, {-3, 40}, {-3, 40}, {1, 180}, {1, 180}, {0, 1}}},
+        {{{-11, 18}, {1, 15}, {89, 240}, {-71, 720}, {-4, 45}, {1, 90}, {7, 720}}},
+        {{{-13, 48}, {-13, 48}, {1, 12}, {1, 12}, {-1, 144}, {-1, 144}, {0, 1}}},
+        {{{17, 144}, {3, 80}, {-3, 40}, {-1, 360}, {17, 720}, {-1, 720}, {-1, 360}}},
+        {{{1, 48}, {1, 48}, {-1, 120}, {-1, 120}, {1, 720}, {1, 720}, {0, 1}}},
+        {{{-1, 144}, {-1, 240}, {1, 240}, {1, 720}, {-1, 720}, {-1, 5040}, {1, 5040}}}
+      }};
+      return inv;
+    }
+
+    static Signed LinearCombination(
+        array<Signed, 7> const &ys,
+        array<Fraction, 7> const &weights,
+        BaseT base)
+    {
+      ULong common = 1;
+      for (Fraction const &w : weights)
+        common = std::lcm(common, (ULong)w.den);
+
+      Signed total = {vector<DataT>{0}, 1};
+      for (SizeT i = 0; i < 7; ++i)
+      {
+        if (weights[i].num == 0)
+          continue;
+        ULong scale = common / (ULong)weights[i].den * (ULong)(weights[i].num < 0 ? -weights[i].num : weights[i].num);
+        Signed term = MulSmall(ys[i], scale, base);
+        if (weights[i].num < 0)
+          term = NegSigned(term);
+        total = AddSigned(total, term, base);
+      }
+
+      if (!DivSmallInPlace(total.mag, common, base))
+        throw std::runtime_error("non-exact Toom-5 interpolation division");
+      if (IsZero(total.mag))
+        total.sign = 1;
+      return total;
+    }
+
+  public:
+    static vector<DataT> Multiply(
+        vector<DataT> const &a,
+        vector<DataT> const &b,
+        BaseT base)
+    {
+      if (IsZero(a) || IsZero(b))
+        return vector<DataT>{0};
+      if (a.size() == 1)
+        return ClassicMultiplication::Multiply(b, a[0], base);
+      if (b.size() == 1)
+        return ClassicMultiplication::Multiply(a, b[0], base);
+
+      SizeT n = (SizeT)std::max(a.size(), b.size());
+      if (n < TOOM5_THRESHOLD)
+        return KaratsubaMultiplication::Multiply(a, b, base);
+
+      SizeT k = (n + 4) / 5;
+      array<vector<DataT>, 5> ap, bp;
+      Split5(a, k, ap);
+      Split5(b, k, bp);
+
+      vector<DataT> c0 = Multiply(ap[0], bp[0], base);
+      vector<DataT> c8 = Multiply(ap[4], bp[4], base);
+
+      constexpr int X[7] = {1, -1, 2, -2, 3, -3, 4};
+      array<Signed, 7> y{};
+      Signed C0 = MakePositive(c0);
+      Signed C8 = MakePositive(c8);
+      for (SizeT i = 0; i < 7; ++i)
+      {
+        Signed ea = Evaluate(ap, X[i], base);
+        Signed eb = Evaluate(bp, X[i], base);
+        vector<DataT> prod = Multiply(ea.mag, eb.mag, base);
+        int prodSign = IsZero(prod) ? 1 : ea.sign * eb.sign;
+        Signed value = {std::move(prod), prodSign};
+
+        Signed x8c8 = MulSmall(C8, (ULong)std::llabs((long long)X[i] * X[i] * X[i] * X[i] * X[i] * X[i] * X[i] * X[i]), base);
+        y[i] = SubSigned(SubSigned(value, C0, base), x8c8, base);
+      }
+
+      array<Signed, 9> coeff{};
+      coeff[0] = C0;
+      coeff[8] = C8;
+      const array<array<Fraction, 7>, 7> &inv = InverseInterpolation();
+      for (SizeT i = 0; i < 7; ++i)
+      {
+        try
+        {
+          coeff[i + 1] = LinearCombination(y, inv[i], base);
+        }
+        catch (std::runtime_error const &)
+        {
+          throw std::runtime_error("non-exact Toom-5 interpolation");
+        }
+      }
+
+      Signed result = coeff[0];
+      for (SizeT i = 1; i < 9; ++i)
+      {
+        Signed term = {ShiftLeft(coeff[i].mag, i * k), coeff[i].sign};
+        result = AddSigned(result, term, base);
+      }
+
+      TrimZeros(result.mag);
+      return result.mag;
+    }
+  };
+}
+
+#endif

--- a/tests/mult_correctness.cpp
+++ b/tests/mult_correctness.cpp
@@ -9,6 +9,7 @@
 #include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
 #include "biginteger/algorithms/multiplication/KaratsubaMultiplication.h"
 #include "biginteger/algorithms/multiplication/ToomCookMultiplication.h"
+#include "biginteger/algorithms/multiplication/Toom5Multiplication.h"
 #include "biginteger/algorithms/multiplication/NTTMultiplication.h"
 #include "biginteger/algorithms/multiplication/ClassicSquare.h"
 #include "biginteger/algorithms/multiplication/KaratsubaSquare.h"
@@ -41,10 +42,12 @@ static bool CheckSize(int digits)
   vector<DataT> classic = ClassicMultiplication::Multiply(av, bv, BigInteger::Base());
   vector<DataT> kara = KaratsubaMultiplication::Multiply(av, bv, BigInteger::Base());
   vector<DataT> toom = ToomCookMultiplication::Multiply(av, bv, BigInteger::Base());
+  vector<DataT> toom5 = Toom5Multiplication::Multiply(av, bv, BigInteger::Base());
   vector<DataT> ntt = NTTMultiplication::Multiply(av, bv, BigInteger::Base());
 
   bool okKara = Compare(classic, kara) == 0;
   bool okToom = Compare(classic, toom) == 0;
+  bool okToom5 = Compare(classic, toom5) == 0;
   bool okNtt = Compare(classic, ntt) == 0;
 
   // Squaring vs Multiply(a,a) cross-check (uses `a` only).
@@ -61,6 +64,7 @@ static bool CheckSize(int digits)
   cout << digits
        << " digits: kara=" << okKara
        << " toom=" << okToom
+       << " toom5=" << okToom5
        << " ntt=" << okNtt
        << " csq=" << okCsq
        << " ksq=" << okKsq
@@ -69,7 +73,7 @@ static bool CheckSize(int digits)
        << " limbs=" << av.size()
        << endl;
 
-  return okKara && okToom && okNtt && okCsq && okKsq && okNsq && okDsq;
+  return okKara && okToom && okToom5 && okNtt && okCsq && okKsq && okNsq && okDsq;
 }
 
 static bool CheckVectors(vector<DataT> const &a, vector<DataT> const &b, const char *label)
@@ -77,20 +81,23 @@ static bool CheckVectors(vector<DataT> const &a, vector<DataT> const &b, const c
   vector<DataT> classic = ClassicMultiplication::Multiply(a, b, BigInteger::Base());
   vector<DataT> kara = KaratsubaMultiplication::Multiply(a, b, BigInteger::Base());
   vector<DataT> toom = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
+  vector<DataT> toom5 = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   vector<DataT> ntt = NTTMultiplication::Multiply(a, b, BigInteger::Base());
 
   bool okKara = Compare(classic, kara) == 0;
   bool okToom = Compare(classic, toom) == 0;
+  bool okToom5 = Compare(classic, toom5) == 0;
   bool okNtt = Compare(classic, ntt) == 0;
 
   cout << label
        << ": kara=" << okKara
        << " toom=" << okToom
+       << " toom5=" << okToom5
        << " ntt=" << okNtt
        << " limbs=" << a.size() << "x" << b.size()
        << endl;
 
-  return okKara && okToom && okNtt;
+  return okKara && okToom && okToom5 && okNtt;
 }
 
 int main()

--- a/tests/performance/dispatch_tuner.cpp
+++ b/tests/performance/dispatch_tuner.cpp
@@ -21,6 +21,7 @@
 #include "biginteger/algorithms/multiplication/KaratsubaSquare.h"
 #include "biginteger/algorithms/multiplication/NTTMultiplication.h"
 #include "biginteger/algorithms/multiplication/NTTSquare.h"
+#include "biginteger/algorithms/multiplication/Toom5Multiplication.h"
 #include "biginteger/common/Comparator.h"
 #include "biginteger/common/Util.h"
 
@@ -84,7 +85,7 @@ namespace
   void TuneMultiplication(bool full)
   {
     PrintHeader("Multiplication Dispatch");
-    cout << "limbs_each,total_limbs,classic_ms,karatsuba_ms,ntt_ms,winner\n";
+    cout << "limbs_each,total_limbs,classic_ms,karatsuba_ms,toom5_ms,ntt_ms,winner\n";
 
     vector<SizeT> sizes = {
         8, 16, 24, 32, 40, 48, 64, 96, 128, 192, 256, 384, 512,
@@ -122,14 +123,19 @@ namespace
         return (SizeT)r.size();
       }, reps);
 
+      double toom5Ms = BestMs([&]() {
+        auto r = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
+        return (SizeT)r.size();
+      }, reps);
+
       double nttMs = BestMs([&]() {
         auto r = NTTMultiplication::Multiply(a, b, BigInteger::Base());
         return (SizeT)r.size();
       }, reps);
 
       string winner = limbs <= 256
-                          ? Winner({{"classic", classicMs}, {"karatsuba", karaMs}, {"ntt", nttMs}})
-                          : Winner({{"karatsuba", karaMs}, {"ntt", nttMs}});
+                          ? Winner({{"classic", classicMs}, {"karatsuba", karaMs}, {"toom5", toom5Ms}, {"ntt", nttMs}})
+                          : Winner({{"karatsuba", karaMs}, {"toom5", toom5Ms}, {"ntt", nttMs}});
 
       if (!foundClassicCrossover && limbs <= 256 && karaMs < classicMs)
       {
@@ -141,7 +147,7 @@ namespace
 
       cout << limbs << ',' << limbs * 2 << ','
            << fixed << setprecision(4) << classicMs << ','
-           << karaMs << ',' << nttMs << ','
+           << karaMs << ',' << toom5Ms << ',' << nttMs << ','
            << winner << '\n';
       previousTotal = limbs * 2;
     }

--- a/tests/unit/test_algorithms_crosscheck.cpp
+++ b/tests/unit/test_algorithms_crosscheck.cpp
@@ -24,6 +24,7 @@
 #include "biginteger/algorithms/multiplication/KaratsubaSquare.h"
 #include "biginteger/algorithms/multiplication/NTTMultiplication.h"
 #include "biginteger/algorithms/multiplication/NTTSquare.h"
+#include "biginteger/algorithms/multiplication/Toom5Multiplication.h"
 #include "biginteger/algorithms/multiplication/ToomCookMultiplication.h"
 #include "biginteger/common/Comparator.h"
 
@@ -49,9 +50,11 @@ static void CrossMul(SizeT aLimbs, SizeT bLimbs, uint64_t seed)
   auto classic = ClassicMultiplication::Multiply(a, b, BigInteger::Base());
   auto kara    = KaratsubaMultiplication::Multiply(a, b, BigInteger::Base());
   auto toom    = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
+  auto toom5   = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   auto ntt     = NTTMultiplication::Multiply(a, b, BigInteger::Base());
   ASSERT_EQ(Compare(classic, kara), 0);
   ASSERT_EQ(Compare(classic, toom), 0);
+  ASSERT_EQ(Compare(classic, toom5), 0);
   ASSERT_EQ(Compare(classic, ntt),  0);
 }
 
@@ -74,9 +77,11 @@ REGISTER_TEST(MulCross, MaxCarry257)
   auto classic = ClassicMultiplication::Multiply(a, b, BigInteger::Base());
   auto kara    = KaratsubaMultiplication::Multiply(a, b, BigInteger::Base());
   auto toom    = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
+  auto toom5   = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   auto ntt     = NTTMultiplication::Multiply(a, b, BigInteger::Base());
   ASSERT_EQ(Compare(classic, kara), 0);
   ASSERT_EQ(Compare(classic, toom), 0);
+  ASSERT_EQ(Compare(classic, toom5), 0);
   ASSERT_EQ(Compare(classic, ntt),  0);
 }
 


### PR DESCRIPTION
## Summary
- add standalone Toom5Multiplication for correctness checks and benchmarking
- include Toom-5 in multiplication correctness/unit cross-checks
- add Toom-5 timings to dispatch_tuner multiplication sweep
- document benchmark results and why Toom-5 remains out of dispatch

## Verification
- ./build/mult_correctness
- ./build/unit_tests
- ./build/dispatch_tuner --full

## Benchmark notes
Toom-5 does not improve production dispatch. It falls back to Karatsuba below 512 limbs; once active, it is slower than Karatsuba:

- 512 limbs: Karatsuba 0.0488 ms, Toom-5 0.1507 ms, NTT 0.0893 ms
- 1024 limbs: Karatsuba 0.1482 ms, Toom-5 0.3214 ms, NTT 0.1926 ms
- 2048 limbs: Karatsuba 0.4640 ms, Toom-5 0.7553 ms, NTT 0.3690 ms