### PR TITLE
Möller-Granlund 3-by-2 qhat in FastDivision (–11% to –35% on FastDivision band)

### DIFF
--- a/include/biginteger/algorithms/division/FastDivision.h
+++ b/include/biginteger/algorithms/division/FastDivision.h
@@ -13,6 +13,13 @@ using namespace std;
 #include "../multiplication/ClassicMultiplication.h"
 #include "ClassicDivision.h"
 
+// Möller-Granlund 3-by-2 preinverted-reciprocal qhat in the Knuth Algorithm D
+// inner loop, replacing the per-iteration 128/64 division. Default on; set to 0
+// for A/B comparison or emergency rollback.
+#ifndef BIGMATH_FASTDIV_USE_MG_QHAT
+#define BIGMATH_FASTDIV_USE_MG_QHAT 1
+#endif
+
 namespace BigMath
 {
   class FastDivision
@@ -73,6 +80,49 @@ namespace BigMath
       }
 
       u[j + n] = Digit((ULong)u[j + n] + carry, base);
+    }
+
+    // Möller-Granlund 3-by-2 reciprocal for B = 2^32. Returns
+    //   v = floor((B^3 - 1) / d) - B,  where d = d1*B + d0, d1's top bit set.
+    // Computed once per FastDivision call, amortized over the j-loop.
+    static inline DataT Reciprocal3by2_Base32(DataT d1, DataT d0)
+    {
+      ULong d = ((ULong)d1 << 32) | d0;
+      ULong128 num = ((ULong128)1 << 96) - 1; // 2^96 - 1
+      return (DataT)((ULong)(num / d) - ((ULong)1 << 32));
+    }
+
+    // M-G Algorithm 4 (3/2 division) for B = 2^32.
+    // Returns qhat = quotient digit, exact or +1 vs true digit. The caller's
+    // SubtractMul+AddBack handles the +1 case unchanged.
+    static inline DataT MGQhat_Base32(DataT u2, DataT u1, DataT u0,
+                                       DataT d1, DataT d0, DataT v)
+    {
+      // (q1, q0) = v*u2 + (u2:u1), discarding any carry-out (2-word view).
+      ULong q = (ULong)u2 * v + (((ULong)u2 << 32) | u1);
+      DataT q1 = (DataT)(q >> 32);
+      DataT q0 = (DataT)(q & 0xFFFFFFFFULL);
+
+      // 2-word remainder via modular subtraction: r = (u1:u0) - q1*(d1:d0) mod 2^64.
+      DataT r1_tmp = (DataT)((ULong)u1 - (ULong)q1 * d1);
+      ULong r = ((ULong)r1_tmp << 32) | u0;
+      ULong d_pair = ((ULong)d1 << 32) | d0;
+      r -= d_pair;
+      r -= (ULong)q1 * d0;
+      ++q1;
+
+      // First correction: if r-high >= saved q0, q1 was over-bumped; undo.
+      if ((DataT)(r >> 32) >= q0)
+      {
+        --q1;
+        r += d_pair; // 64-bit add; discard carry-out
+      }
+
+      // Second correction: residual r >= d.
+      if (r >= d_pair)
+        ++q1;
+
+      return q1;
     }
 
     static vector<DataT> MultiplyByScalar(span<const DataT> a, DataT d, BaseT base)
@@ -188,20 +238,40 @@ namespace BigMath
 
       vector<DataT> q(m + 1, 0);
 
+      bool useMG = false;
+      DataT mg_v = 0;
+#if BIGMATH_FASTDIV_USE_MG_QHAT
+      if (base == Base2_32 && n >= 2)
+      {
+        useMG = true;
+        mg_v = Reciprocal3by2_Base32((DataT)v[n - 1], (DataT)v[n - 2]);
+      }
+#endif
+
       for (Int j = (Int)m; j >= 0; --j)
       {
-        ULong128 numerator = (ULong128)u[j + n] * (ULong)base + u[j + n - 1];
-        ULong qhat = (ULong)(numerator / v[n - 1]);
-        ULong rhat = (ULong)(numerator % v[n - 1]);
-
-        while (qhat == (ULong)base ||
-               (n > 1 && (ULong128)qhat * v[n - 2] >
-                             (ULong128)rhat * (ULong)base + u[j + n - 2]))
+        ULong qhat;
+        if (useMG)
         {
-          --qhat;
-          rhat += v[n - 1];
-          if (rhat >= (ULong)base)
-            break;
+          qhat = (ULong)MGQhat_Base32(
+              (DataT)u[j + n], (DataT)u[j + n - 1], (DataT)u[j + n - 2],
+              (DataT)v[n - 1], (DataT)v[n - 2], mg_v);
+        }
+        else
+        {
+          ULong128 numerator = (ULong128)u[j + n] * (ULong)base + u[j + n - 1];
+          qhat = (ULong)(numerator / v[n - 1]);
+          ULong rhat = (ULong)(numerator % v[n - 1]);
+
+          while (qhat == (ULong)base ||
+                 (n > 1 && (ULong128)qhat * v[n - 2] >
+                               (ULong128)rhat * (ULong)base + u[j + n - 2]))
+          {
+            --qhat;
+            rhat += v[n - 1];
+            if (rhat >= (ULong)base)
+              break;
+          }
         }
 
         if (SubtractMul(u, v, qhat, (SizeT)j, base))


### PR DESCRIPTION
## Summary

Replace the per-iteration 128/64 division in `FastDivision`'s Knuth Algorithm D qhat estimation with Möller-Granlund 3-by-2 preinverted reciprocal (Möller & Granlund, *Improved division by invariant integers*, 2011, Algorithms 2 & 4).

- 64-bit reciprocal precomputed once per `FastDivision` call from the two normalized top divisor limbs
- Per inner-loop iteration: one multiply-add + two correction branches, **no division**
- Output is exact or `qhat+1`; existing `SubtractMul`+`AddBack` handles the +1 path unchanged

Gated by `BIGMATH_FASTDIV_USE_MG_QHAT` (default `1`). Activates only when `base == Base2_32` and `n >= 2`. Non-Base2_32 dispatchers keep the original Knuth qhat path verbatim. Compile with `-DBIGMATH_FASTDIV_USE_MG_QHAT=0` for A/B comparison or emergency rollback.

## Benchmark deltas (M1 Max, `-O3 -march=native`)

`divperf_simple` (FastDivision in isolation):

| case | master ms | M-G ms | delta |
|---|---:|---:|---:|
| 1024x512 | 0.464 | 0.443 | −4.5% |
| 4096x2048 | 11.48 | 7.44 | **−35%** |
| 8192x512 | 9.64 | 7.78 | **−19%** |
| 16384x512 | 15.92 | 14.15 | −11% |

`dispatch_tuner --full` division table: row `1024,512,2.00` flips winner `bz → fast` as M-G closes the qhat gap. Newton/BZ-band rows unchanged (those don't route through `FastDivision` in production dispatch).

`bench_vs_gmp` [division, balanced]:

| size | master ms | M-G ms | BM/GMP |
|---|---:|---:|---:|
| div 1000x1000 digits | 0.001 | 0.001 | 22.3× |
| div 5000x5000 digits | 0.003 | 0.003 | 19.7× |
| div 10000x10000 digits | 0.021 | 0.022 | 63× |

Balanced large cases short-circuit (a≈b path returns early), so user-visible BigMath time is sub-millisecond and noise-dominated. Newton/BZ-band skewed `bench_vs_gmp` numbers are unchanged because those paths don't go through `FastDivision`.

## Algorithm reference

Möller, N. & Granlund, T. (2011). *Improved division by invariant integers*. IEEE Trans. Comput., 60(2), 165–175. The implementation follows the GMP-style 3-by-2 mac/sub pattern from `gmp-impl.h`'s `udiv_qr_3by2`, adapted to the codebase's 32-bit limb / 64-bit container layout.

## Verification

- `mult_correctness` — all `kara=1 toom=1 toom5=1 ntt=1 csq=1 ksq=1 nsq=1 dsq=1`
- `unit_tests` — 210 passed, 0 failed
- `divperf_simple` — all four cases `match=1`
- `bench_vs_gmp` — all division rows present and consistent with baseline (numbers above)
- `dispatch_tuner --full` — division section completes; winner stable

`div_correctness` passes deterministic cases (`less-than`, `scalar-max`, `max-64x32`) and the random sweep through `256x97` (i.e. all cases reached). The pre-existing `random 1024x513` entry in that suite hangs in `BurnikelZieglerDivision::Divide2nByN`'s recursive lambda on **master too** — verified by running `./build/div_correctness` on a fresh `git stash`-clean master rebuild and capturing the stack with `sample(1)`. The hang is independent of this change and tracked separately.

## Test plan
- [x] `cmake --build build -j8`
- [x] `./build/mult_correctness`
- [x] `./build/unit_tests`
- [x] `./build/divperf_simple` (validates match=1 + measures speedup)
- [x] `./build/bench_vs_gmp` (division balanced + skewed)
- [x] `./build/dispatch_tuner --full`
- [x] A/B verified by building with `-DBIGMATH_FASTDIV_USE_MG_QHAT=0` and confirming Knuth path is taken (rollback lever works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)