### PR TITLE
refactor(limbs): foundation for 64-bit limb refactor (PR-A, no behavior change)

### DIFF
--- a/include/biginteger/common/Constants.h
+++ b/include/biginteger/common/Constants.h
@@ -9,6 +9,15 @@
 
 #include <cstdint>
 
+// Limb width selector. When 0 (default), DataT stores 32-bit values in a 64-bit
+// container — the historical layout. When 1, DataT stores true 64-bit values
+// and Base() switches to Base2_64. Foundation flag for the multi-PR 64-bit-limb
+// refactor; subsequent PRs add the 64-bit code paths gated on this macro. The
+// 32-bit path remains the default until the refactor is complete and tested.
+#ifndef BIGMATH_LIMB_64
+#define BIGMATH_LIMB_64 0
+#endif
+
 namespace BigMath
 {
   typedef int64_t Long;
@@ -47,6 +56,30 @@ namespace BigMath
     const BaseT Base2_32 = 4294967296ul; // 2^32
     // Base 2^31
     const BaseT Base2_31 = 2147483648; // 2^31
+
+    // Sentinel for Base 2^64. The numeric value 2^64 does not fit in BaseT
+    // (int64_t), so subsequent PRs use the sentinel 0 in dispatch — 0 is never
+    // a legal numeric base. Code paths that need to *use* the base value as a
+    // shift/mask (rather than just compare it) take a separate Base2_64 branch
+    // and operate on the limb directly via the LIMB_* helpers below.
+    const BaseT Base2_64 = 0;
+
+    // Per-limb width helpers. These drive the carry/borrow/shift idioms in
+    // Addition, Subtraction, ClassicMultiplication, FastDivision, etc. The
+    // helpers compile to either the historical 32-bit ops or the new 64-bit
+    // ops depending on BIGMATH_LIMB_64.
+#if BIGMATH_LIMB_64
+    constexpr SizeT LimbBits = 64;
+    constexpr ULong128 LimbBase = (ULong128)1 << 64; // 2^64
+    constexpr ULong LimbMask = 0xFFFFFFFFFFFFFFFFULL;
+    // Compile-time current Base() value, returned by BigInteger::Base().
+    constexpr BaseT CurrentBase = Base2_64;
+#else
+    constexpr SizeT LimbBits = 32;
+    constexpr ULong LimbBase = 1ULL << 32; // 2^32
+    constexpr ULong LimbMask = 0xFFFFFFFFULL;
+    constexpr BaseT CurrentBase = Base2_32;
+#endif
 }
 
 #endif


### PR DESCRIPTION
## Summary

First of a 7-PR rollout to switch BigInteger limbs from base 2^32 (32-bit values in 64-bit containers) to base 2^64 (true 64-bit values). This PR is **foundation only** — no behavior change, no consumers yet.

Adds to `include/biginteger/common/Constants.h`:

- **`BIGMATH_LIMB_64`** compile flag (default `0`). Subsequent PRs gate 64-bit code paths on this macro; flipping to `1` is the final cut-over step (PR-G).
- **`Base2_64`** sentinel (value `0`). The numeric value 2^64 does not fit in `BaseT` (`int64_t`), so dispatch uses `0` — a value never legal as a real base — and code paths that need the base as a shift/mask take a separate `Base2_64` branch operating on `LimbBits` / `LimbMask` directly.
- **`LimbBits`**, **`LimbBase`**, **`LimbMask`**, **`CurrentBase`** compile-time constants that resolve to 32-bit values when `LIMB_64=0` and 64-bit values when `LIMB_64=1`.

## Why this design

The blocker for a clean 64-bit refactor is that `BaseT base` is a runtime parameter passed to ~85 function signatures across the algorithms directory. The numeric `2^64` doesn't fit in any signed 64-bit type, so we can't just bump `Base2_64`.

Two viable shapes:
1. **Sentinel approach (this PR)**: `Base2_64 = 0`, dispatched as `if (base == Base2_64)`; per-limb shifts/masks come from `LimbBits` / `LimbMask`. Minimal API churn.
2. **Compile-time templates**: drop the runtime `base` parameter, make it a template parameter. Cleaner but much larger surface change (~85 signatures).

We chose (1) for incremental rollout. The 32-bit path stays intact and remains the default through PRs B–F; only PR-G flips `LIMB_64` to default `1` and removes the 32-bit path.

## Rollout plan

| PR | Scope | Risk |
|---|---|---|
| **A** (this) | Foundation: constants, flag, helpers. No behavior change. | low |
| B | Add / Sub / Shift bit ops in 64-bit mode | medium |
| C | ClassicMultiplication 64-bit schoolbook | medium |
| D | Karatsuba + NTT (input split decision) | high |
| E | Division (Classic, Fast, BZ, Newton) — incl. Newton reciprocal seed redesign for 256-bit intermediate | high |
| F | Parser + ToString | medium |
| G | Flip `LIMB_64=1` default, remove 32-bit path | merge gate |

## Test plan

- [x] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j8` — clean
- [x] `./build/unit_tests` — 210 passed, 0 failed
- [x] `./build/mult_correctness` — clean
- [x] With `-DCMAKE_CXX_FLAGS="-DBIGMATH_LIMB_64=1"`: builds clean, 210/210 still pass, `mult_correctness` clean (no consumers yet so behavior identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)