### PR TITLE
refactor(limbs): Add Base2_64 paths to Addition/Subtraction (PR-B, no behavior change)

### DIFF
--- a/include/biginteger/common/Constants.h
+++ b/include/biginteger/common/Constants.h
@@ -9,6 +9,15 @@
 
 #include <cstdint>
 
+// Limb width selector. When 0 (default), DataT stores 32-bit values in a 64-bit
+// container — the historical layout. When 1, DataT stores true 64-bit values
+// and Base() switches to Base2_64. Foundation flag for the multi-PR 64-bit-limb
+// refactor; subsequent PRs add the 64-bit code paths gated on this macro. The
+// 32-bit path remains the default until the refactor is complete and tested.
+#ifndef BIGMATH_LIMB_64
+#define BIGMATH_LIMB_64 0
+#endif
+
 namespace BigMath
 {
   typedef int64_t Long;
@@ -47,6 +56,30 @@ namespace BigMath
     const BaseT Base2_32 = 4294967296ul; // 2^32
     // Base 2^31
     const BaseT Base2_31 = 2147483648; // 2^31
+
+    // Sentinel for Base 2^64. The numeric value 2^64 does not fit in BaseT
+    // (int64_t), so subsequent PRs use the sentinel 0 in dispatch — 0 is never
+    // a legal numeric base. Code paths that need to *use* the base value as a
+    // shift/mask (rather than just compare it) take a separate Base2_64 branch
+    // and operate on the limb directly via the LIMB_* helpers below.
+    const BaseT Base2_64 = 0;
+
+    // Per-limb width helpers. These drive the carry/borrow/shift idioms in
+    // Addition, Subtraction, ClassicMultiplication, FastDivision, etc. The
+    // helpers compile to either the historical 32-bit ops or the new 64-bit
+    // ops depending on BIGMATH_LIMB_64.
+#if BIGMATH_LIMB_64
+    constexpr SizeT LimbBits = 64;
+    constexpr ULong128 LimbBase = (ULong128)1 << 64; // 2^64
+    constexpr ULong LimbMask = 0xFFFFFFFFFFFFFFFFULL;
+    // Compile-time current Base() value, returned by BigInteger::Base().
+    constexpr BaseT CurrentBase = Base2_64;
+#else
+    constexpr SizeT LimbBits = 32;
+    constexpr ULong LimbBase = 1ULL << 32; // 2^32
+    constexpr ULong LimbMask = 0xFFFFFFFFULL;
+    constexpr BaseT CurrentBase = Base2_32;
+#endif
 }
 
 #endif

--- a/src/algorithms/Addition.cpp
+++ b/src/algorithms/Addition.cpp
@@ -34,6 +34,27 @@ namespace BigMath
       return;
     }
 
+    if (base == Base2_64)
+    {
+      ULong128 acc = b;
+      SizeT i = aStart;
+      while (acc)
+      {
+        if (i <= aEnd && i < a.size())
+        {
+          acc += a[i];
+          a[i] = (DataT)(acc & 0xFFFFFFFFFFFFFFFFULL);
+        }
+        else
+        {
+          a.push_back((DataT)(acc & 0xFFFFFFFFFFFFFFFFULL));
+        }
+        acc >>= 64;
+        ++i;
+      }
+      return;
+    }
+
     ULong sum = b;
     ULong carry = 0;
     if (aEnd >= aStart)
@@ -85,8 +106,31 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      ULong128 carry = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong128 digitOps = carry;
+        Int aPos = i + aStart;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          digitOps += a[aPos];
+        Int bPos = i + bStart;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          digitOps += b[bPos];
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)(digitOps & 0xFFFFFFFFFFFFFFFFULL);
+        carry = digitOps >> 64;
+      }
+      Int rPos = rStart + size;
+      if (carry > 0 && rPos < (Int)result.size())
+        result[rPos] += (DataT)carry;
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;
@@ -159,6 +203,11 @@ namespace BigMath
           a.push_back((DataT)(b & 0xFFFFFFFFULL));
           b >>= 32;
         }
+      }
+      else if (base == Base2_64)
+      {
+        // b fits in a single 64-bit limb; one push suffices.
+        a.push_back((DataT)b);
       }
       else
       {

--- a/src/algorithms/Subtraction.cpp
+++ b/src/algorithms/Subtraction.cpp
@@ -16,6 +16,11 @@ namespace BigMath
     if (b == 0)
       return;
 
+    // For Base2_64, the limb max is 2^64-1 (= LimbMask). The original code
+    // uses `(base - b) % base` and `base - 1`, which underflows when base == 0
+    // (the Base2_64 sentinel). Use limb-mask arithmetic instead.
+    const ULong limbMax = (base == Base2_64) ? 0xFFFFFFFFFFFFFFFFULL : (ULong)(base - 1);
+
     if (aEnd >= aStart)
     {
       if (a[aStart] >= b)
@@ -26,7 +31,11 @@ namespace BigMath
       else
       {
         b -= a[aStart];
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        // (base - b) for non-Base2_64; for Base2_64 it's (2^64 - b) which
+        // equals (~b + 1), i.e. the two's-complement negation as ULong.
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -37,7 +46,9 @@ namespace BigMath
 
       if (b > 0)
       {
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -54,13 +65,13 @@ namespace BigMath
         }
         else
         {
-          a[aPos] = static_cast<DataT>(base - 1);
+          a[aPos] = static_cast<DataT>(limbMax);
           b = 1;
         }
       }
       else
       {
-        a.push_back(static_cast<DataT>(base - 1));
+        a.push_back(static_cast<DataT>(limbMax));
         b = 1;
       }
       aPos++;
@@ -85,8 +96,40 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      // 64-bit limb subtraction with explicit borrow tracking. Signed `Long`
+      // can't hold a 64-bit limb, so do unsigned arithmetic and detect borrow
+      // via comparison.
+      ULong borrow = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong ai = 0;
+        Int aPos = aStart + i;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          ai = a[aPos];
+
+        ULong bi = 0;
+        Int bPos = bStart + i;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          bi = b[bPos];
+
+        // Compute ai - bi - borrow with two-step borrow detection.
+        ULong t1 = ai - borrow;
+        ULong borrow1 = (ai < borrow) ? 1 : 0;
+        ULong diff = t1 - bi;
+        ULong borrow2 = (t1 < bi) ? 1 : 0;
+        borrow = borrow1 + borrow2;
+
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)diff;
+      }
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;

--- a/tests/unit/test_base64_addsub.cpp
+++ b/tests/unit/test_base64_addsub.cpp
@@ -1,0 +1,109 @@
+// Direct exercise of the Base2_64 sentinel paths in Addition / Subtraction.
+// These paths are dormant under LIMB_64=0 (BigInteger::Base() still returns
+// Base2_32), so without explicit tests the new code is unreachable. Cover the
+// branches via direct std::vector<DataT> calls.
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "biginteger/algorithms/Addition.h"
+#include "biginteger/algorithms/Subtraction.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+REGISTER_TEST(Base64Add, ScalarNoCarry)
+{
+  std::vector<DataT> a{0x100, 0x200};
+  AddTo(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x150, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, ScalarWithCarryPropagate)
+{
+  // a = 2^64 - 1 (single limb at max) + 1 should propagate carry.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  AddTo(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)1, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, MultiLimbCarryChain)
+{
+  // a = (2^64 - 1, 2^64 - 1, 0), b = (1, 0, 0) → (0, 0, 1).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(4, 0);
+  Add(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+  ASSERT_EQ((ULong)1, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Add, ScalarIntoEmptyVector)
+{
+  std::vector<DataT> a;
+  AddTo(a, (ULong)0x123456789ABCDEFULL, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0x123456789ABCDEFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarNoBorrow)
+{
+  std::vector<DataT> a{0x150, 0x200};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x100, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarBorrowPropagate)
+{
+  // a = (0, 1) - 1 = (max, 0) → trimmed to (max).
+  std::vector<DataT> a{0, 1};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, MultiLimbBorrowChain)
+{
+  // a = (0, 0, 1), b = (1, 0, 0) → (max, max, 0).
+  std::vector<DataT> a{0, 0, 1};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(3, 0);
+  Subtract(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[0]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[1]);
+  ASSERT_EQ((ULong)0, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Sub, EqualOperandsZero)
+{
+  std::vector<DataT> a{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> b{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> r(2, 0);
+  Subtract(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+}
+
+REGISTER_TEST(Base64AddSub, RoundTripRandom)
+{
+  // For a random pair (a, b), (a + b) - b == a and (a - b) + b == a.
+  std::vector<DataT> a{0xDEADBEEFCAFEBABEULL, 0x0123456789ABCDEFULL, 0x42};
+  std::vector<DataT> b{0xBADF00DDEADC0DE5ULL, 0xFEDCBA9876543210ULL, 0x07};
+
+  // Compute s = a + b, then s - b should equal a.
+  std::vector<DataT> sum(4, 0);
+  Add(a, 0, 2, b, 0, 2, sum, 0, Base2_64);
+  std::vector<DataT> back(4, 0);
+  Subtract(sum, 0, 3, b, 0, 2, back, 0, Base2_64);
+  for (SizeT i = 0; i < 3; ++i)
+    ASSERT_EQ((ULong)a[i], (ULong)back[i]);
+  // back[3] (extra high limb) must be zero.
+  ASSERT_EQ((ULong)0, (ULong)back[3]);
+}


### PR DESCRIPTION
## Summary

PR-B of the 64-bit limb refactor (stacks on PR #18 foundation). Adds `Base2_64` sentinel branches to all five entry points in `Addition` and `Subtraction`:

| function | change |
|---|---|
| `AddTo(a, aStart, aEnd, ULong b, base)` | new `Base2_64` branch |
| `Add(a, .., b, .., result, .., base)` | new `Base2_64` branch |
| `AddTo(a, ULong b, base)` (empty-a path) | new `Base2_64` branch |
| `SubtractFrom(a, aStart, aEnd, ULong b, base)` | limbMax-driven `Base2_64` path |
| `Subtract(a, .., b, .., result, .., base)` | new `Base2_64` branch |

## Patterns

- **Add carry**: `ULong128` accumulator, mask `0xFFFFFFFFFFFFFFFFULL`, shift-by-64. Mirrors the existing Base2_32 fast paths.
- **Subtract borrow**: signed `Long` cannot hold a 64-bit limb, so use two-step unsigned borrow detection:
  ```cpp
  t1 = ai - borrow;    borrow1 = (ai < borrow) ? 1 : 0;
  diff = t1 - bi;      borrow2 = (t1 < bi) ? 1 : 0;
  borrow = borrow1 + borrow2;
  ```
- **`SubtractFrom`'s `(base - b) % base` rewrite**: the sentinel `Base2_64 = 0` underflows the original expression. Replaced with `(ULong)0 - b` (two's-complement negation in unsigned arithmetic), which is mathematically `2^64 - b`.

## Dormancy

These paths are **dormant** under the default `LIMB_64=0` because `BigInteger::Base()` still returns `Base2_32` until PR-G. This PR is purely additive scaffolding.

## Tests

`tests/unit/test_base64_addsub.cpp` — 9 new tests calling the helpers with `Base2_64` directly:

- Scalar add/sub with no carry/borrow
- Scalar add with carry propagating into a new top limb (`2^64-1 + 1`)
- Multi-limb carry chain: `(max, max, 0) + (1, 0, 0) → (0, 0, 1)`
- Add into an empty vector
- Scalar borrow propagation: `(0, 1) - 1 → (max)` (trimmed)
- Multi-limb borrow chain: `(0, 0, 1) - (1, 0, 0) → (max, max, 0)`
- Equal-operand subtraction = zero
- Add-then-subtract round-trip on a random 3-limb pair

## Test plan
- [x] `cmake --build build -j8`
- [x] `./build/unit_tests` — 219 passed, 0 failed (210 baseline + 9 new)
- [x] `./build/mult_correctness` — clean
- [x] `./build/divperf_simple` — match=1 across all 4 cases
- [x] With `-DBIGMATH_LIMB_64=1`: builds clean, all 219 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)