### PR TITLE
refactor(limbs): Add Base2_64 paths to ClassicMultiplication (PR-C, no behavior change)

### DIFF
--- a/include/biginteger/algorithms/multiplication/ClassicMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/ClassicMultiplication.h
@@ -30,6 +30,18 @@ namespace BigMath
       return base == Base2_32 ? value >> 32 : value / base;
     }
 
+    // Base2_64 paths use ULong128 accumulators directly (a 64-bit * 64-bit
+    // product overflows ULong), so they don't go through LowDigit/NextCarry.
+    static DataT LowDigit128(ULong128 value)
+    {
+      return (DataT)(value & 0xFFFFFFFFFFFFFFFFULL);
+    }
+
+    static ULong NextCarry128(ULong128 value)
+    {
+      return (ULong)(value >> 64);
+    }
+
     static void SetOrPush(vector<DataT> &a, SizeT pos, DataT value)
     {
       if (pos < a.size())
@@ -78,6 +90,27 @@ namespace BigMath
         {
           SetOrPush(a, j, (DataT)(carry & 0xFFFFFFFFULL));
           carry >>= 32;
+          ++j;
+        }
+        return j;
+      }
+
+      // Base-2^64 fast path: 64-bit * 64-bit gives a 128-bit product. Carry is
+      // at most 2^64-1 (the high half of the previous product), so a single
+      // push suffices after the main loop.
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = aStart; j <= aEnd; ++j)
+        {
+          ULong128 p = (ULong128)a[j] * b + carry;
+          SetOrPush(a, j, LowDigit128(p));
+          carry = NextCarry128(p);
+        }
+        SizeT j = aEnd + 1;
+        if (carry)
+        {
+          SetOrPush(a, j, (DataT)carry);
           ++j;
         }
         return j;
@@ -133,6 +166,22 @@ namespace BigMath
       if (b == 0 || a.empty())
         return vector<DataT>();
       vector<DataT> w(a.size());
+
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = 0; j < a.size(); ++j)
+        {
+          ULong128 p = (ULong128)a[j] * b + carry;
+          w[j] = LowDigit128(p);
+          carry = NextCarry128(p);
+        }
+        if (carry)
+          w.push_back((DataT)carry);
+        TrimZeros(w);
+        return w;
+      }
+
       ULong carry = 0;
       for (SizeT j = 0; j < a.size(); ++j)
       {
@@ -166,6 +215,29 @@ namespace BigMath
 
       SizeT len = Len(aStart, aEnd);
       SizeT wPos = wStart;
+
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = 0; j < len; ++j)
+        {
+          ULong128 av = 0;
+          SizeT aPos = aStart + j;
+          if (aPos <= aEnd)
+            av = a[aPos];
+          ULong128 p = av * b + carry;
+          wPos = wStart + j;
+          SetOrPush(w, wPos, LowDigit128(p));
+          carry = NextCarry128(p);
+        }
+        wPos = wStart + len;
+        if (carry)
+        {
+          SetOrPush(w, wPos, (DataT)carry);
+          ++wPos;
+        }
+        return wPos;
+      }
 
       ULong carry = 0;
 
@@ -241,6 +313,28 @@ namespace BigMath
 
       SizeT k = rStart;
       SizeT lenA = aEnd - aStart + 1;
+
+      if (base == Base2_64)
+      {
+        // 64×64→128 product plus 64-bit accumulator (existing result limb) plus
+        // 64-bit carry: max sum ≤ (2^64-1)² + (2^64-1) + (2^64-1) = 2^128 - 1.
+        // Fits ULong128.
+        for (SizeT i = bStart; i <= bEnd; i++)
+        {
+          ULong carry = 0;
+          SizeT jStart = rStart + (i - bStart);
+          for (SizeT j = aStart; j <= aEnd; j++)
+          {
+            SizeT kk = jStart + (j - aStart);
+            ULong128 p = (ULong128)a[j] * b[i] + result[kk] + carry;
+            result[kk] = LowDigit128(p);
+            carry = NextCarry128(p);
+          }
+          k = jStart + lenA;
+          result[k] = (DataT)carry;
+        }
+        return k;
+      }
 
       for (SizeT i = bStart; i <= bEnd; i++)
       {

--- a/include/biginteger/common/Constants.h
+++ b/include/biginteger/common/Constants.h
@@ -9,6 +9,15 @@
 
 #include <cstdint>
 
+// Limb width selector. When 0 (default), DataT stores 32-bit values in a 64-bit
+// container — the historical layout. When 1, DataT stores true 64-bit values
+// and Base() switches to Base2_64. Foundation flag for the multi-PR 64-bit-limb
+// refactor; subsequent PRs add the 64-bit code paths gated on this macro. The
+// 32-bit path remains the default until the refactor is complete and tested.
+#ifndef BIGMATH_LIMB_64
+#define BIGMATH_LIMB_64 0
+#endif
+
 namespace BigMath
 {
   typedef int64_t Long;
@@ -47,6 +56,30 @@ namespace BigMath
     const BaseT Base2_32 = 4294967296ul; // 2^32
     // Base 2^31
     const BaseT Base2_31 = 2147483648; // 2^31
+
+    // Sentinel for Base 2^64. The numeric value 2^64 does not fit in BaseT
+    // (int64_t), so subsequent PRs use the sentinel 0 in dispatch — 0 is never
+    // a legal numeric base. Code paths that need to *use* the base value as a
+    // shift/mask (rather than just compare it) take a separate Base2_64 branch
+    // and operate on the limb directly via the LIMB_* helpers below.
+    const BaseT Base2_64 = 0;
+
+    // Per-limb width helpers. These drive the carry/borrow/shift idioms in
+    // Addition, Subtraction, ClassicMultiplication, FastDivision, etc. The
+    // helpers compile to either the historical 32-bit ops or the new 64-bit
+    // ops depending on BIGMATH_LIMB_64.
+#if BIGMATH_LIMB_64
+    constexpr SizeT LimbBits = 64;
+    constexpr ULong128 LimbBase = (ULong128)1 << 64; // 2^64
+    constexpr ULong LimbMask = 0xFFFFFFFFFFFFFFFFULL;
+    // Compile-time current Base() value, returned by BigInteger::Base().
+    constexpr BaseT CurrentBase = Base2_64;
+#else
+    constexpr SizeT LimbBits = 32;
+    constexpr ULong LimbBase = 1ULL << 32; // 2^32
+    constexpr ULong LimbMask = 0xFFFFFFFFULL;
+    constexpr BaseT CurrentBase = Base2_32;
+#endif
 }
 
 #endif

--- a/src/algorithms/Addition.cpp
+++ b/src/algorithms/Addition.cpp
@@ -34,6 +34,27 @@ namespace BigMath
       return;
     }
 
+    if (base == Base2_64)
+    {
+      ULong128 acc = b;
+      SizeT i = aStart;
+      while (acc)
+      {
+        if (i <= aEnd && i < a.size())
+        {
+          acc += a[i];
+          a[i] = (DataT)(acc & 0xFFFFFFFFFFFFFFFFULL);
+        }
+        else
+        {
+          a.push_back((DataT)(acc & 0xFFFFFFFFFFFFFFFFULL));
+        }
+        acc >>= 64;
+        ++i;
+      }
+      return;
+    }
+
     ULong sum = b;
     ULong carry = 0;
     if (aEnd >= aStart)
@@ -85,8 +106,31 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      ULong128 carry = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong128 digitOps = carry;
+        Int aPos = i + aStart;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          digitOps += a[aPos];
+        Int bPos = i + bStart;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          digitOps += b[bPos];
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)(digitOps & 0xFFFFFFFFFFFFFFFFULL);
+        carry = digitOps >> 64;
+      }
+      Int rPos = rStart + size;
+      if (carry > 0 && rPos < (Int)result.size())
+        result[rPos] += (DataT)carry;
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;
@@ -159,6 +203,11 @@ namespace BigMath
           a.push_back((DataT)(b & 0xFFFFFFFFULL));
           b >>= 32;
         }
+      }
+      else if (base == Base2_64)
+      {
+        // b fits in a single 64-bit limb; one push suffices.
+        a.push_back((DataT)b);
       }
       else
       {

--- a/src/algorithms/Subtraction.cpp
+++ b/src/algorithms/Subtraction.cpp
@@ -16,6 +16,11 @@ namespace BigMath
     if (b == 0)
       return;
 
+    // For Base2_64, the limb max is 2^64-1 (= LimbMask). The original code
+    // uses `(base - b) % base` and `base - 1`, which underflows when base == 0
+    // (the Base2_64 sentinel). Use limb-mask arithmetic instead.
+    const ULong limbMax = (base == Base2_64) ? 0xFFFFFFFFFFFFFFFFULL : (ULong)(base - 1);
+
     if (aEnd >= aStart)
     {
       if (a[aStart] >= b)
@@ -26,7 +31,11 @@ namespace BigMath
       else
       {
         b -= a[aStart];
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        // (base - b) for non-Base2_64; for Base2_64 it's (2^64 - b) which
+        // equals (~b + 1), i.e. the two's-complement negation as ULong.
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -37,7 +46,9 @@ namespace BigMath
 
       if (b > 0)
       {
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -54,13 +65,13 @@ namespace BigMath
         }
         else
         {
-          a[aPos] = static_cast<DataT>(base - 1);
+          a[aPos] = static_cast<DataT>(limbMax);
           b = 1;
         }
       }
       else
       {
-        a.push_back(static_cast<DataT>(base - 1));
+        a.push_back(static_cast<DataT>(limbMax));
         b = 1;
       }
       aPos++;
@@ -85,8 +96,40 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      // 64-bit limb subtraction with explicit borrow tracking. Signed `Long`
+      // can't hold a 64-bit limb, so do unsigned arithmetic and detect borrow
+      // via comparison.
+      ULong borrow = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong ai = 0;
+        Int aPos = aStart + i;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          ai = a[aPos];
+
+        ULong bi = 0;
+        Int bPos = bStart + i;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          bi = b[bPos];
+
+        // Compute ai - bi - borrow with two-step borrow detection.
+        ULong t1 = ai - borrow;
+        ULong borrow1 = (ai < borrow) ? 1 : 0;
+        ULong diff = t1 - bi;
+        ULong borrow2 = (t1 < bi) ? 1 : 0;
+        borrow = borrow1 + borrow2;
+
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)diff;
+      }
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;

--- a/tests/unit/test_base64_addsub.cpp
+++ b/tests/unit/test_base64_addsub.cpp
@@ -1,0 +1,109 @@
+// Direct exercise of the Base2_64 sentinel paths in Addition / Subtraction.
+// These paths are dormant under LIMB_64=0 (BigInteger::Base() still returns
+// Base2_32), so without explicit tests the new code is unreachable. Cover the
+// branches via direct std::vector<DataT> calls.
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "biginteger/algorithms/Addition.h"
+#include "biginteger/algorithms/Subtraction.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+REGISTER_TEST(Base64Add, ScalarNoCarry)
+{
+  std::vector<DataT> a{0x100, 0x200};
+  AddTo(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x150, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, ScalarWithCarryPropagate)
+{
+  // a = 2^64 - 1 (single limb at max) + 1 should propagate carry.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  AddTo(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)1, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, MultiLimbCarryChain)
+{
+  // a = (2^64 - 1, 2^64 - 1, 0), b = (1, 0, 0) → (0, 0, 1).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(4, 0);
+  Add(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+  ASSERT_EQ((ULong)1, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Add, ScalarIntoEmptyVector)
+{
+  std::vector<DataT> a;
+  AddTo(a, (ULong)0x123456789ABCDEFULL, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0x123456789ABCDEFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarNoBorrow)
+{
+  std::vector<DataT> a{0x150, 0x200};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x100, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarBorrowPropagate)
+{
+  // a = (0, 1) - 1 = (max, 0) → trimmed to (max).
+  std::vector<DataT> a{0, 1};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, MultiLimbBorrowChain)
+{
+  // a = (0, 0, 1), b = (1, 0, 0) → (max, max, 0).
+  std::vector<DataT> a{0, 0, 1};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(3, 0);
+  Subtract(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[0]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[1]);
+  ASSERT_EQ((ULong)0, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Sub, EqualOperandsZero)
+{
+  std::vector<DataT> a{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> b{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> r(2, 0);
+  Subtract(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+}
+
+REGISTER_TEST(Base64AddSub, RoundTripRandom)
+{
+  // For a random pair (a, b), (a + b) - b == a and (a - b) + b == a.
+  std::vector<DataT> a{0xDEADBEEFCAFEBABEULL, 0x0123456789ABCDEFULL, 0x42};
+  std::vector<DataT> b{0xBADF00DDEADC0DE5ULL, 0xFEDCBA9876543210ULL, 0x07};
+
+  // Compute s = a + b, then s - b should equal a.
+  std::vector<DataT> sum(4, 0);
+  Add(a, 0, 2, b, 0, 2, sum, 0, Base2_64);
+  std::vector<DataT> back(4, 0);
+  Subtract(sum, 0, 3, b, 0, 2, back, 0, Base2_64);
+  for (SizeT i = 0; i < 3; ++i)
+    ASSERT_EQ((ULong)a[i], (ULong)back[i]);
+  // back[3] (extra high limb) must be zero.
+  ASSERT_EQ((ULong)0, (ULong)back[3]);
+}

--- a/tests/unit/test_base64_mult.cpp
+++ b/tests/unit/test_base64_mult.cpp
@@ -1,0 +1,113 @@
+// Direct exercise of the Base2_64 sentinel paths in ClassicMultiplication.
+// Dormant under LIMB_64=0 default; covered here via explicit Base2_64 calls.
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+REGISTER_TEST(Base64Mult, ScalarSmall)
+{
+  // (3 + 5*B) * 7 = 21 + 35*B.
+  std::vector<DataT> a{3, 5};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)7, Base2_64);
+  ASSERT_EQ((ULong)21, (ULong)a[0]);
+  ASSERT_EQ((ULong)35, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarCarryToNewLimb)
+{
+  // (2^64 - 1) * 2 = 2*(2^64-1) = 0xFFFFFFFFFFFFFFFE + (1 << 64).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)2, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)1, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarMaxByMax)
+{
+  // (2^64 - 1) * (2^64 - 1) = 2^128 - 2^65 + 1
+  //                         = (1, max-1) in (high, low) base-2^64 = limbs[1]=max-1, limbs[0]=1.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)0xFFFFFFFFFFFFFFFFULL, Base2_64);
+  ASSERT_EQ((ULong)1, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, VectorScalarRangeForm)
+{
+  // a = (10, 20, 30), b = 100, into fresh w.
+  std::vector<DataT> a{10, 20, 30};
+  std::vector<DataT> w(4, 0);
+  ClassicMultiplication::Multiply(a, 0, 2, (ULong)100, w, 0, 3, Base2_64);
+  ASSERT_EQ((ULong)1000, (ULong)w[0]);
+  ASSERT_EQ((ULong)2000, (ULong)w[1]);
+  ASSERT_EQ((ULong)3000, (ULong)w[2]);
+  ASSERT_EQ((ULong)0, (ULong)w[3]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductSmall)
+{
+  // (3 + 5*B) * (7 + 11*B) = 21 + 33*B + 35*B + 55*B^2 = 21 + 68*B + 55*B^2.
+  std::vector<DataT> a{3, 5};
+  std::vector<DataT> b{7, 11};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)21, (ULong)r[0]);
+  ASSERT_EQ((ULong)68, (ULong)r[1]);
+  ASSERT_EQ((ULong)55, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductCarryChain)
+{
+  // (max, max) * (1, 0) — single-limb b — should give (max, max, 0, 0) shifted.
+  // Actually with b = (1, 0): result = a * 1 = (max, max, 0, 0).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> b{1, 0};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[0]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[1]);
+  ASSERT_EQ((ULong)0, (ULong)r[2]);
+  ASSERT_EQ((ULong)0, (ULong)r[3]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductMaxByMax2Limb)
+{
+  // (max, max) * (max, max) = (2^128 - 1)² = 2^256 - 2^129 + 1.
+  // Decomposing in base 2^64: low=1, then -2 (i.e. max-1 with borrow), then max, then max.
+  // Concretely: 2^256 - 2^129 + 1 = (..., r3, r2, r1, r0).
+  //   r0 = 1
+  //   r1 = 0
+  //   r2 = max - 1   (= 2^64 - 2)
+  //   r3 = max       (= 2^64 - 1)
+  // Verify by checking sum: r0 + r1*B + r2*B^2 + r3*B^3
+  //   = 1 + 0 + (B-2)*B^2 + (B-1)*B^3
+  //   = 1 + B^3 - 2*B^2 + B^4 - B^3
+  //   = 1 - 2*B^2 + B^4
+  //   = B^4 - 2*B^2 + 1
+  //   = (B^2 - 1)² = (2^128 - 1)². Matches.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> b{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)1, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)r[2]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[3]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarZeroIsZero)
+{
+  std::vector<DataT> a{0xDEADBEEFCAFEBABEULL, 0x1234};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)0, Base2_64);
+  // Implementation sets the range to a single zero limb when b == 0.
+  ASSERT_EQ((ULong)0, (ULong)a[0]);
+}


### PR DESCRIPTION
## Summary

PR-C of the 64-bit limb refactor (stacks on #18 + #19). Adds `Base2_64` sentinel branches to all four entries of `ClassicMultiplication`:

| function | change |
|---|---|
| `MultiplyTo(a, aStart, aEnd, DataT b, base)` | new `Base2_64` branch |
| `Multiply(span<DataT> a, DataT b, base)` | new `Base2_64` branch |
| `Multiply(a, .., ULong b, w, .., base)` | new `Base2_64` branch |
| `Multiply(a, .., b, .., result, .., base)` | new `Base2_64` branch (full schoolbook) |

## Patterns

- 64 × 64 → 128 product **overflows `ULong`**, so the `Base2_64` paths use a `ULong128` accumulator:
  ```cpp
  ULong128 p = (ULong128)a[j] * b + carry [+ result[k]];
  result = (DataT)(p & 0xFFFFFFFFFFFFFFFFULL);
  carry  = (ULong)(p >> 64);
  ```
- New private helpers `LowDigit128` / `NextCarry128` extract the limb and the high half from a `ULong128` product. The existing `LowDigit` / `NextCarry` on `ULong` stay for `Base2_32` and the generic path.
- Final carry is at most `2^64 - 1` (a single limb), so one push suffices vs the `Base2_32` path's `while (carry) carry >>= 32` chain.
- Full vector × vector schoolbook accumulator fits cleanly in `ULong128`: max sum per cell `= (2^64-1)² + (2^64-1) + (2^64-1) = 2^128 - 1`.

## Tests

`tests/unit/test_base64_mult.cpp` — 8 new cases:
- small scalar `(3, 5) × 7 = (21, 35)`
- scalar carry into new limb `(max) × 2 = (max-1, 1)`
- max × max producing `(1, max-1)`
- range-form scalar
- full small product `(3, 5) × (7, 11) = (21, 68, 55)`
- single-limb carry chain
- max × max 2-limb producing `(1, 0, max-1, max)`
- zero × anything = zero

All 8 pass; total 227 (= 219 baseline + 8).

## Test plan
- [x] `cmake --build build -j8`
- [x] `./build/unit_tests` — 227 passed, 0 failed
- [x] `./build/mult_correctness` — clean
- [x] `./build/divperf_simple` — match=1 across all 4 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)