### PR TITLE
refactor(limbs): Add Base2_64 paths to Karatsuba + NTT (PR-D, no behavior change)

### DIFF
--- a/include/biginteger/algorithms/multiplication/ClassicMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/ClassicMultiplication.h
@@ -30,6 +30,18 @@ namespace BigMath
       return base == Base2_32 ? value >> 32 : value / base;
     }
 
+    // Base2_64 paths use ULong128 accumulators directly (a 64-bit * 64-bit
+    // product overflows ULong), so they don't go through LowDigit/NextCarry.
+    static DataT LowDigit128(ULong128 value)
+    {
+      return (DataT)(value & 0xFFFFFFFFFFFFFFFFULL);
+    }
+
+    static ULong NextCarry128(ULong128 value)
+    {
+      return (ULong)(value >> 64);
+    }
+
     static void SetOrPush(vector<DataT> &a, SizeT pos, DataT value)
     {
       if (pos < a.size())
@@ -78,6 +90,27 @@ namespace BigMath
         {
           SetOrPush(a, j, (DataT)(carry & 0xFFFFFFFFULL));
           carry >>= 32;
+          ++j;
+        }
+        return j;
+      }
+
+      // Base-2^64 fast path: 64-bit * 64-bit gives a 128-bit product. Carry is
+      // at most 2^64-1 (the high half of the previous product), so a single
+      // push suffices after the main loop.
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = aStart; j <= aEnd; ++j)
+        {
+          ULong128 p = (ULong128)a[j] * b + carry;
+          SetOrPush(a, j, LowDigit128(p));
+          carry = NextCarry128(p);
+        }
+        SizeT j = aEnd + 1;
+        if (carry)
+        {
+          SetOrPush(a, j, (DataT)carry);
           ++j;
         }
         return j;
@@ -133,6 +166,22 @@ namespace BigMath
       if (b == 0 || a.empty())
         return vector<DataT>();
       vector<DataT> w(a.size());
+
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = 0; j < a.size(); ++j)
+        {
+          ULong128 p = (ULong128)a[j] * b + carry;
+          w[j] = LowDigit128(p);
+          carry = NextCarry128(p);
+        }
+        if (carry)
+          w.push_back((DataT)carry);
+        TrimZeros(w);
+        return w;
+      }
+
       ULong carry = 0;
       for (SizeT j = 0; j < a.size(); ++j)
       {
@@ -166,6 +215,29 @@ namespace BigMath
 
       SizeT len = Len(aStart, aEnd);
       SizeT wPos = wStart;
+
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = 0; j < len; ++j)
+        {
+          ULong128 av = 0;
+          SizeT aPos = aStart + j;
+          if (aPos <= aEnd)
+            av = a[aPos];
+          ULong128 p = av * b + carry;
+          wPos = wStart + j;
+          SetOrPush(w, wPos, LowDigit128(p));
+          carry = NextCarry128(p);
+        }
+        wPos = wStart + len;
+        if (carry)
+        {
+          SetOrPush(w, wPos, (DataT)carry);
+          ++wPos;
+        }
+        return wPos;
+      }
 
       ULong carry = 0;
 
@@ -241,6 +313,28 @@ namespace BigMath
 
       SizeT k = rStart;
       SizeT lenA = aEnd - aStart + 1;
+
+      if (base == Base2_64)
+      {
+        // 64×64→128 product plus 64-bit accumulator (existing result limb) plus
+        // 64-bit carry: max sum ≤ (2^64-1)² + (2^64-1) + (2^64-1) = 2^128 - 1.
+        // Fits ULong128.
+        for (SizeT i = bStart; i <= bEnd; i++)
+        {
+          ULong carry = 0;
+          SizeT jStart = rStart + (i - bStart);
+          for (SizeT j = aStart; j <= aEnd; j++)
+          {
+            SizeT kk = jStart + (j - aStart);
+            ULong128 p = (ULong128)a[j] * b[i] + result[kk] + carry;
+            result[kk] = LowDigit128(p);
+            carry = NextCarry128(p);
+          }
+          k = jStart + lenA;
+          result[k] = (DataT)carry;
+        }
+        return k;
+      }
 
       for (SizeT i = bStart; i <= bEnd; i++)
       {

--- a/include/biginteger/algorithms/multiplication/KaratsubaMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/KaratsubaMultiplication.h
@@ -62,6 +62,28 @@ namespace BigMath
                     carry = 0;
                 }
             }
+            else if (base == Base2_64)
+            {
+                // ULong128 sum to capture the carry bit on full 64-bit limbs.
+                ULong128 carry = 0;
+                for (SizeT i = 0; i < minLen; ++i)
+                {
+                    ULong128 sum = (ULong128)a[i] + b[i] + carry;
+                    r[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+                for (SizeT i = minLen; i < maxLen; ++i)
+                {
+                    ULong128 sum = (ULong128)longer[i] + carry;
+                    r[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+                for (SizeT i = maxLen; i < lenR; ++i)
+                {
+                    r[i] = (DataT)(carry & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = 0;
+                }
+            }
             else
             {
                 ULong carry = 0;
@@ -110,6 +132,23 @@ namespace BigMath
                     carry = sum >> 32;
                 }
             }
+            else if (base == Base2_64)
+            {
+                ULong128 carry = 0;
+                SizeT i = 0;
+                for (; i < shared; ++i)
+                {
+                    ULong128 sum = (ULong128)dest[i] + src[i] + carry;
+                    dest[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+                for (; i < destLen && carry; ++i)
+                {
+                    ULong128 sum = (ULong128)dest[i] + carry;
+                    dest[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+            }
             else
             {
                 ULong carry = 0;
@@ -153,6 +192,31 @@ namespace BigMath
                     Long diff = (Long)dest[i] - borrow;
                     if (diff < 0) { diff += (Long)1 << 32; borrow = 1; }
                     else borrow = 0;
+                    dest[i] = (DataT)diff;
+                }
+            }
+            else if (base == Base2_64)
+            {
+                // 64-bit limbs don't fit in signed Long; use unsigned with
+                // two-step borrow detection (matches Subtraction.cpp pattern).
+                ULong borrow = 0;
+                SizeT i = 0;
+                for (; i < shared; ++i)
+                {
+                    ULong ai = dest[i];
+                    ULong bi = src[i];
+                    ULong t1 = ai - borrow;
+                    ULong borrow1 = (ai < borrow) ? 1 : 0;
+                    ULong diff = t1 - bi;
+                    ULong borrow2 = (t1 < bi) ? 1 : 0;
+                    borrow = borrow1 + borrow2;
+                    dest[i] = (DataT)diff;
+                }
+                for (; i < destLen && borrow; ++i)
+                {
+                    ULong ai = dest[i];
+                    ULong diff = ai - borrow;
+                    borrow = (ai < borrow) ? 1 : 0;
                     dest[i] = (DataT)diff;
                 }
             }
@@ -254,6 +318,23 @@ namespace BigMath
                     SizeT lo = 2 * k;
                     if (lo < rLen) r[lo] = (DataT)(r64[k] & 0xFFFFFFFFULL);
                     if (lo + 1 < rLen) r[lo + 1] = (DataT)(r64[k] >> 32);
+                }
+            }
+            else if (base == Base2_64)
+            {
+                // Plain 64×64→128 schoolbook. No pack-to-larger trick available
+                // (would need 256-bit primitives), so just one multiply per cell.
+                for (SizeT i = 0; i < lenB; ++i)
+                {
+                    if (b[i] == 0) continue;
+                    ULong carry = 0;
+                    for (SizeT j = 0; j < lenA; ++j)
+                    {
+                        ULong128 prod = (ULong128)a[j] * b[i] + r[i + j] + carry;
+                        r[i + j] = (DataT)(prod & 0xFFFFFFFFFFFFFFFFULL);
+                        carry = (ULong)(prod >> 64);
+                    }
+                    r[i + lenA] = (DataT)carry;
                 }
             }
             else

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -68,6 +68,55 @@ namespace BigMath
             return result;
         }
 
+        // Packs four consecutive 16-bit NTT coefficients into one 64-bit limb,
+        // propagating carries through `carry`. Mirrors FinalizeBase2_32's 2-into-1
+        // pattern with a 4-slot rotor for the 64-bit case.
+        static vector<DataT> FinalizeBase2_64(const vector<ULong> &coeffs, SizeT coeffCount)
+        {
+            vector<DataT> result;
+            result.reserve(coeffCount / 4 + 2);
+
+            ULong carry = 0;
+            ULong limb_acc = 0;
+            int slot = 0; // 0..3 within the current limb
+
+            auto flush = [&result, &limb_acc, &slot](bool force)
+            {
+                if (slot == 4 || (force && slot != 0))
+                {
+                    result.push_back((DataT)limb_acc);
+                    limb_acc = 0;
+                    slot = 0;
+                }
+            };
+
+            for (SizeT i = 0; i < coeffCount; ++i)
+            {
+                ULong total = coeffs[i] + carry;
+                ULong digit = total & 0xFFFFULL;
+                carry = total >> 16;
+
+                limb_acc |= digit << (slot * 16);
+                ++slot;
+                flush(false);
+            }
+
+            while (carry > 0)
+            {
+                ULong digit = carry & 0xFFFFULL;
+                carry >>= 16;
+
+                limb_acc |= digit << (slot * 16);
+                ++slot;
+                flush(false);
+            }
+
+            flush(true);
+
+            TrimZeros(result);
+            return result;
+        }
+
     public:
         // Multiply two vectors of digits using NTT-based convolution.
         static vector<DataT> Multiply(const vector<DataT> &a, const vector<DataT> &b, BaseT base)
@@ -117,6 +166,48 @@ namespace BigMath
                 NTTCore::Inverse(fa, plan);
 
                 return FinalizeBase2_32(fa, (SizeT)coeffCount);
+            }
+            else if (base == Base2_64)
+            {
+                // Split each 64-bit limb into four 16-bit halves so coefficients
+                // stay within the Goldilocks field's accumulation bound. Same
+                // prime as Base2_32 (P = 2^64 - 2^32 + 1); convolution overflow
+                // bound is still ~2^31 limbs (≈ 16 GB operands).
+                ULong aCoeffSize = (ULong)a.size() * 4;
+                ULong bCoeffSize = (ULong)b.size() * 4;
+                ULong coeffCount = aCoeffSize + bCoeffSize - 1;
+                DataT n = (DataT)std::bit_ceil(coeffCount);
+
+                static thread_local vector<ULong> fa;
+                static thread_local vector<ULong> fb;
+                fa.assign(n, 0);
+                fb.assign(n, 0);
+
+                for (SizeT i = 0; i < a.size(); ++i)
+                {
+                    SizeT j = i * 4;
+                    fa[j]     = a[i] & 0xFFFFULL;
+                    fa[j + 1] = (a[i] >> 16) & 0xFFFFULL;
+                    fa[j + 2] = (a[i] >> 32) & 0xFFFFULL;
+                    fa[j + 3] = (a[i] >> 48) & 0xFFFFULL;
+                }
+                for (SizeT i = 0; i < b.size(); ++i)
+                {
+                    SizeT j = i * 4;
+                    fb[j]     = b[i] & 0xFFFFULL;
+                    fb[j + 1] = (b[i] >> 16) & 0xFFFFULL;
+                    fb[j + 2] = (b[i] >> 32) & 0xFFFFULL;
+                    fb[j + 3] = (b[i] >> 48) & 0xFFFFULL;
+                }
+
+                const NTTPlan &plan = NTTCore::GetPlan((Int)n);
+                NTTCore::Forward(fa, plan);
+                NTTCore::Forward(fb, plan);
+                for (Int i = 0; i < (Int)n; i++)
+                    fa[i] = ModularField::Mul(fa[i], fb[i]);
+                NTTCore::Inverse(fa, plan);
+
+                return FinalizeBase2_64(fa, (SizeT)coeffCount);
             }
             else
             {

--- a/include/biginteger/common/Constants.h
+++ b/include/biginteger/common/Constants.h
@@ -9,6 +9,15 @@
 
 #include <cstdint>
 
+// Limb width selector. When 0 (default), DataT stores 32-bit values in a 64-bit
+// container — the historical layout. When 1, DataT stores true 64-bit values
+// and Base() switches to Base2_64. Foundation flag for the multi-PR 64-bit-limb
+// refactor; subsequent PRs add the 64-bit code paths gated on this macro. The
+// 32-bit path remains the default until the refactor is complete and tested.
+#ifndef BIGMATH_LIMB_64
+#define BIGMATH_LIMB_64 0
+#endif
+
 namespace BigMath
 {
   typedef int64_t Long;
@@ -47,6 +56,30 @@ namespace BigMath
     const BaseT Base2_32 = 4294967296ul; // 2^32
     // Base 2^31
     const BaseT Base2_31 = 2147483648; // 2^31
+
+    // Sentinel for Base 2^64. The numeric value 2^64 does not fit in BaseT
+    // (int64_t), so subsequent PRs use the sentinel 0 in dispatch — 0 is never
+    // a legal numeric base. Code paths that need to *use* the base value as a
+    // shift/mask (rather than just compare it) take a separate Base2_64 branch
+    // and operate on the limb directly via the LIMB_* helpers below.
+    const BaseT Base2_64 = 0;
+
+    // Per-limb width helpers. These drive the carry/borrow/shift idioms in
+    // Addition, Subtraction, ClassicMultiplication, FastDivision, etc. The
+    // helpers compile to either the historical 32-bit ops or the new 64-bit
+    // ops depending on BIGMATH_LIMB_64.
+#if BIGMATH_LIMB_64
+    constexpr SizeT LimbBits = 64;
+    constexpr ULong128 LimbBase = (ULong128)1 << 64; // 2^64
+    constexpr ULong LimbMask = 0xFFFFFFFFFFFFFFFFULL;
+    // Compile-time current Base() value, returned by BigInteger::Base().
+    constexpr BaseT CurrentBase = Base2_64;
+#else
+    constexpr SizeT LimbBits = 32;
+    constexpr ULong LimbBase = 1ULL << 32; // 2^32
+    constexpr ULong LimbMask = 0xFFFFFFFFULL;
+    constexpr BaseT CurrentBase = Base2_32;
+#endif
 }
 
 #endif

--- a/src/algorithms/Addition.cpp
+++ b/src/algorithms/Addition.cpp
@@ -34,6 +34,27 @@ namespace BigMath
       return;
     }
 
+    if (base == Base2_64)
+    {
+      ULong128 acc = b;
+      SizeT i = aStart;
+      while (acc)
+      {
+        if (i <= aEnd && i < a.size())
+        {
+          acc += a[i];
+          a[i] = (DataT)(acc & 0xFFFFFFFFFFFFFFFFULL);
+        }
+        else
+        {
+          a.push_back((DataT)(acc & 0xFFFFFFFFFFFFFFFFULL));
+        }
+        acc >>= 64;
+        ++i;
+      }
+      return;
+    }
+
     ULong sum = b;
     ULong carry = 0;
     if (aEnd >= aStart)
@@ -85,8 +106,31 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      ULong128 carry = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong128 digitOps = carry;
+        Int aPos = i + aStart;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          digitOps += a[aPos];
+        Int bPos = i + bStart;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          digitOps += b[bPos];
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)(digitOps & 0xFFFFFFFFFFFFFFFFULL);
+        carry = digitOps >> 64;
+      }
+      Int rPos = rStart + size;
+      if (carry > 0 && rPos < (Int)result.size())
+        result[rPos] += (DataT)carry;
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;
@@ -159,6 +203,11 @@ namespace BigMath
           a.push_back((DataT)(b & 0xFFFFFFFFULL));
           b >>= 32;
         }
+      }
+      else if (base == Base2_64)
+      {
+        // b fits in a single 64-bit limb; one push suffices.
+        a.push_back((DataT)b);
       }
       else
       {

--- a/src/algorithms/Subtraction.cpp
+++ b/src/algorithms/Subtraction.cpp
@@ -16,6 +16,11 @@ namespace BigMath
     if (b == 0)
       return;
 
+    // For Base2_64, the limb max is 2^64-1 (= LimbMask). The original code
+    // uses `(base - b) % base` and `base - 1`, which underflows when base == 0
+    // (the Base2_64 sentinel). Use limb-mask arithmetic instead.
+    const ULong limbMax = (base == Base2_64) ? 0xFFFFFFFFFFFFFFFFULL : (ULong)(base - 1);
+
     if (aEnd >= aStart)
     {
       if (a[aStart] >= b)
@@ -26,7 +31,11 @@ namespace BigMath
       else
       {
         b -= a[aStart];
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        // (base - b) for non-Base2_64; for Base2_64 it's (2^64 - b) which
+        // equals (~b + 1), i.e. the two's-complement negation as ULong.
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -37,7 +46,9 @@ namespace BigMath
 
       if (b > 0)
       {
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -54,13 +65,13 @@ namespace BigMath
         }
         else
         {
-          a[aPos] = static_cast<DataT>(base - 1);
+          a[aPos] = static_cast<DataT>(limbMax);
           b = 1;
         }
       }
       else
       {
-        a.push_back(static_cast<DataT>(base - 1));
+        a.push_back(static_cast<DataT>(limbMax));
         b = 1;
       }
       aPos++;
@@ -85,8 +96,40 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      // 64-bit limb subtraction with explicit borrow tracking. Signed `Long`
+      // can't hold a 64-bit limb, so do unsigned arithmetic and detect borrow
+      // via comparison.
+      ULong borrow = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong ai = 0;
+        Int aPos = aStart + i;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          ai = a[aPos];
+
+        ULong bi = 0;
+        Int bPos = bStart + i;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          bi = b[bPos];
+
+        // Compute ai - bi - borrow with two-step borrow detection.
+        ULong t1 = ai - borrow;
+        ULong borrow1 = (ai < borrow) ? 1 : 0;
+        ULong diff = t1 - bi;
+        ULong borrow2 = (t1 < bi) ? 1 : 0;
+        borrow = borrow1 + borrow2;
+
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)diff;
+      }
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;

--- a/tests/unit/test_base64_addsub.cpp
+++ b/tests/unit/test_base64_addsub.cpp
@@ -1,0 +1,109 @@
+// Direct exercise of the Base2_64 sentinel paths in Addition / Subtraction.
+// These paths are dormant under LIMB_64=0 (BigInteger::Base() still returns
+// Base2_32), so without explicit tests the new code is unreachable. Cover the
+// branches via direct std::vector<DataT> calls.
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "biginteger/algorithms/Addition.h"
+#include "biginteger/algorithms/Subtraction.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+REGISTER_TEST(Base64Add, ScalarNoCarry)
+{
+  std::vector<DataT> a{0x100, 0x200};
+  AddTo(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x150, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, ScalarWithCarryPropagate)
+{
+  // a = 2^64 - 1 (single limb at max) + 1 should propagate carry.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  AddTo(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)1, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, MultiLimbCarryChain)
+{
+  // a = (2^64 - 1, 2^64 - 1, 0), b = (1, 0, 0) → (0, 0, 1).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(4, 0);
+  Add(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+  ASSERT_EQ((ULong)1, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Add, ScalarIntoEmptyVector)
+{
+  std::vector<DataT> a;
+  AddTo(a, (ULong)0x123456789ABCDEFULL, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0x123456789ABCDEFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarNoBorrow)
+{
+  std::vector<DataT> a{0x150, 0x200};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x100, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarBorrowPropagate)
+{
+  // a = (0, 1) - 1 = (max, 0) → trimmed to (max).
+  std::vector<DataT> a{0, 1};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, MultiLimbBorrowChain)
+{
+  // a = (0, 0, 1), b = (1, 0, 0) → (max, max, 0).
+  std::vector<DataT> a{0, 0, 1};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(3, 0);
+  Subtract(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[0]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[1]);
+  ASSERT_EQ((ULong)0, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Sub, EqualOperandsZero)
+{
+  std::vector<DataT> a{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> b{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> r(2, 0);
+  Subtract(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+}
+
+REGISTER_TEST(Base64AddSub, RoundTripRandom)
+{
+  // For a random pair (a, b), (a + b) - b == a and (a - b) + b == a.
+  std::vector<DataT> a{0xDEADBEEFCAFEBABEULL, 0x0123456789ABCDEFULL, 0x42};
+  std::vector<DataT> b{0xBADF00DDEADC0DE5ULL, 0xFEDCBA9876543210ULL, 0x07};
+
+  // Compute s = a + b, then s - b should equal a.
+  std::vector<DataT> sum(4, 0);
+  Add(a, 0, 2, b, 0, 2, sum, 0, Base2_64);
+  std::vector<DataT> back(4, 0);
+  Subtract(sum, 0, 3, b, 0, 2, back, 0, Base2_64);
+  for (SizeT i = 0; i < 3; ++i)
+    ASSERT_EQ((ULong)a[i], (ULong)back[i]);
+  // back[3] (extra high limb) must be zero.
+  ASSERT_EQ((ULong)0, (ULong)back[3]);
+}

--- a/tests/unit/test_base64_kara_ntt.cpp
+++ b/tests/unit/test_base64_kara_ntt.cpp
@@ -1,0 +1,126 @@
+// Direct exercise of Base2_64 sentinel paths in KaratsubaMultiplication and
+// NTTMultiplication. Dormant under LIMB_64=0 default; covered here via explicit
+// Base2_64 calls. Cross-checked against the schoolbook ClassicMultiplication
+// Base2_64 path (covered in test_base64_mult.cpp).
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
+#include "biginteger/algorithms/multiplication/KaratsubaMultiplication.h"
+#include "biginteger/algorithms/multiplication/NTTMultiplication.h"
+#include "biginteger/common/Comparator.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+static std::vector<DataT> RandomLimbs64(SizeT n, std::mt19937_64 &gen)
+{
+  std::uniform_int_distribution<uint64_t> dist(0, 0xFFFFFFFFFFFFFFFFULL);
+  std::vector<DataT> v(n);
+  for (SizeT i = 0; i < n; ++i)
+    v[i] = dist(gen);
+  if (v.back() == 0)
+    v.back() = 1;
+  return v;
+}
+
+static std::vector<DataT> ClassicProduct(std::vector<DataT> const &a, std::vector<DataT> const &b)
+{
+  std::vector<DataT> r(a.size() + b.size() + 1, 0);
+  ClassicMultiplication::Multiply(a, 0, (SizeT)a.size() - 1, b, 0, (SizeT)b.size() - 1, r, 0, Base2_64);
+  while (r.size() > 1 && r.back() == 0)
+    r.pop_back();
+  return r;
+}
+
+static bool LimbVectorsEqual(std::vector<DataT> const &x, std::vector<DataT> const &y)
+{
+  auto trim = [](std::vector<DataT> v)
+  {
+    while (v.size() > 1 && v.back() == 0)
+      v.pop_back();
+    return v;
+  };
+  auto xt = trim(x);
+  auto yt = trim(y);
+  if (xt.size() != yt.size())
+    return false;
+  for (SizeT i = 0; i < xt.size(); ++i)
+    if (xt[i] != yt[i])
+      return false;
+  return true;
+}
+
+REGISTER_TEST(Base64Kara, AgainstClassicSmall)
+{
+  std::mt19937_64 gen(0xC0FFEEULL);
+  // 50 limbs > KARATSUBA_THRESHOLD (48), so recursion is exercised.
+  auto a = RandomLimbs64(50, gen);
+  auto b = RandomLimbs64(50, gen);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(k, c));
+}
+
+REGISTER_TEST(Base64Kara, AgainstClassicMidUnbalanced)
+{
+  std::mt19937_64 gen(0xBEEFCAFEULL);
+  auto a = RandomLimbs64(200, gen);
+  auto b = RandomLimbs64(73, gen);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(k, c));
+}
+
+REGISTER_TEST(Base64Kara, AgainstClassicMaxFill)
+{
+  // Worst-case carry: every limb is 2^64-1.
+  std::vector<DataT> a(60, 0xFFFFFFFFFFFFFFFFULL);
+  std::vector<DataT> b(60, 0xFFFFFFFFFFFFFFFFULL);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(k, c));
+}
+
+REGISTER_TEST(Base64Ntt, AgainstClassicSmall)
+{
+  std::mt19937_64 gen(0xDEADBEEFULL);
+  auto a = RandomLimbs64(40, gen);
+  auto b = RandomLimbs64(40, gen);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(n, c));
+}
+
+REGISTER_TEST(Base64Ntt, AgainstClassicMidUnbalanced)
+{
+  std::mt19937_64 gen(0xBADDF00DULL);
+  auto a = RandomLimbs64(256, gen);
+  auto b = RandomLimbs64(97, gen);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(n, c));
+}
+
+REGISTER_TEST(Base64Ntt, AgainstClassicMaxFill)
+{
+  std::vector<DataT> a(128, 0xFFFFFFFFFFFFFFFFULL);
+  std::vector<DataT> b(128, 0xFFFFFFFFFFFFFFFFULL);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(n, c));
+}
+
+REGISTER_TEST(Base64Ntt, KaratsubaVsNttAgree)
+{
+  std::mt19937_64 gen(0xABCDEFULL);
+  auto a = RandomLimbs64(150, gen);
+  auto b = RandomLimbs64(150, gen);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  ASSERT_TRUE(LimbVectorsEqual(k, n));
+}

--- a/tests/unit/test_base64_mult.cpp
+++ b/tests/unit/test_base64_mult.cpp
@@ -1,0 +1,113 @@
+// Direct exercise of the Base2_64 sentinel paths in ClassicMultiplication.
+// Dormant under LIMB_64=0 default; covered here via explicit Base2_64 calls.
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+REGISTER_TEST(Base64Mult, ScalarSmall)
+{
+  // (3 + 5*B) * 7 = 21 + 35*B.
+  std::vector<DataT> a{3, 5};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)7, Base2_64);
+  ASSERT_EQ((ULong)21, (ULong)a[0]);
+  ASSERT_EQ((ULong)35, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarCarryToNewLimb)
+{
+  // (2^64 - 1) * 2 = 2*(2^64-1) = 0xFFFFFFFFFFFFFFFE + (1 << 64).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)2, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)1, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarMaxByMax)
+{
+  // (2^64 - 1) * (2^64 - 1) = 2^128 - 2^65 + 1
+  //                         = (1, max-1) in (high, low) base-2^64 = limbs[1]=max-1, limbs[0]=1.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)0xFFFFFFFFFFFFFFFFULL, Base2_64);
+  ASSERT_EQ((ULong)1, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, VectorScalarRangeForm)
+{
+  // a = (10, 20, 30), b = 100, into fresh w.
+  std::vector<DataT> a{10, 20, 30};
+  std::vector<DataT> w(4, 0);
+  ClassicMultiplication::Multiply(a, 0, 2, (ULong)100, w, 0, 3, Base2_64);
+  ASSERT_EQ((ULong)1000, (ULong)w[0]);
+  ASSERT_EQ((ULong)2000, (ULong)w[1]);
+  ASSERT_EQ((ULong)3000, (ULong)w[2]);
+  ASSERT_EQ((ULong)0, (ULong)w[3]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductSmall)
+{
+  // (3 + 5*B) * (7 + 11*B) = 21 + 33*B + 35*B + 55*B^2 = 21 + 68*B + 55*B^2.
+  std::vector<DataT> a{3, 5};
+  std::vector<DataT> b{7, 11};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)21, (ULong)r[0]);
+  ASSERT_EQ((ULong)68, (ULong)r[1]);
+  ASSERT_EQ((ULong)55, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductCarryChain)
+{
+  // (max, max) * (1, 0) — single-limb b — should give (max, max, 0, 0) shifted.
+  // Actually with b = (1, 0): result = a * 1 = (max, max, 0, 0).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> b{1, 0};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[0]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[1]);
+  ASSERT_EQ((ULong)0, (ULong)r[2]);
+  ASSERT_EQ((ULong)0, (ULong)r[3]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductMaxByMax2Limb)
+{
+  // (max, max) * (max, max) = (2^128 - 1)² = 2^256 - 2^129 + 1.
+  // Decomposing in base 2^64: low=1, then -2 (i.e. max-1 with borrow), then max, then max.
+  // Concretely: 2^256 - 2^129 + 1 = (..., r3, r2, r1, r0).
+  //   r0 = 1
+  //   r1 = 0
+  //   r2 = max - 1   (= 2^64 - 2)
+  //   r3 = max       (= 2^64 - 1)
+  // Verify by checking sum: r0 + r1*B + r2*B^2 + r3*B^3
+  //   = 1 + 0 + (B-2)*B^2 + (B-1)*B^3
+  //   = 1 + B^3 - 2*B^2 + B^4 - B^3
+  //   = 1 - 2*B^2 + B^4
+  //   = B^4 - 2*B^2 + 1
+  //   = (B^2 - 1)² = (2^128 - 1)². Matches.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> b{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)1, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)r[2]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[3]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarZeroIsZero)
+{
+  std::vector<DataT> a{0xDEADBEEFCAFEBABEULL, 0x1234};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)0, Base2_64);
+  // Implementation sets the range to a single zero limb when b == 0.
+  ASSERT_EQ((ULong)0, (ULong)a[0]);
+}


### PR DESCRIPTION
## Summary

PR-D of the 64-bit limb refactor (stacks on #18, #19, #20). Adds `Base2_64` sentinel branches to `KaratsubaMultiplication` and `NTTMultiplication`.

## Karatsuba

`AddPtr`, `AddToPtr`: `ULong128` carry, shift-by-64, full-64-bit mask. Same pattern as Add/Sub PR-B.

`SubtractFromPtr`: signed `Long` cannot hold a 64-bit limb, so the `Base2_64` branch uses unsigned arithmetic with two-step borrow detection (same pattern as `Subtraction.cpp`).

`MultiplyClassicPtr` leaf: plain 64 × 64 → 128 schoolbook per cell. No pack-into-larger-limb trick is available for a 64-bit base (would need 256-bit primitives), so each cell is one `ULong128` multiply rather than the `Base2_32` path's 4-into-1 pair-pack hybrid.

## NTT — input split design

The `Base2_32` path splits each 32-bit limb into **two** 16-bit Goldilocks coefficients to stay inside the prime's accumulation bound. For 64-bit limbs the matching choice is **four 16-bit coefficients per limb**, same prime (`P = 2^64 − 2^32 + 1`), same `NTTCore` plan caching. Convolution accumulation bound is still ~2^31 limbs (≈ 16 GB operands).

Alternative considered: 2 × 32-bit coefficients per limb. Rejected — coefficient × coefficient would be `2^64`, which doesn't fit in the Goldilocks field. Would require a different prime and a full NTT rewrite. Out of scope; the 4 × 16-bit split costs 2 × more coefficients in the NTT (slightly larger transforms) but reuses every line of `NTTCore` unchanged.

New `FinalizeBase2_64` reassembles four consecutive 16-bit chunks into one 64-bit limb, carrying as it goes. Mirrors `FinalizeBase2_32`'s rotor pattern with a 4-slot accumulator.

## Tests

`tests/unit/test_base64_kara_ntt.cpp` — 7 new cross-check cases:

| test | inputs | check |
|---|---|---|
| `Base64Kara.AgainstClassicSmall` | 50 × 50 limbs (above threshold) | == schoolbook |
| `Base64Kara.AgainstClassicMidUnbalanced` | 200 × 73 | == schoolbook |
| `Base64Kara.AgainstClassicMaxFill` | 60 × 60 all-max-limb | == schoolbook |
| `Base64Ntt.AgainstClassicSmall` | 40 × 40 | == schoolbook |
| `Base64Ntt.AgainstClassicMidUnbalanced` | 256 × 97 | == schoolbook |
| `Base64Ntt.AgainstClassicMaxFill` | 128 × 128 all-max-limb | == schoolbook |
| `Base64Ntt.KaratsubaVsNttAgree` | 150 × 150 | Kara == NTT direct |

## Test plan
- [x] `cmake --build build -j8`
- [x] `./build/unit_tests` — 234 passed, 0 failed (227 baseline + 7)
- [x] `./build/mult_correctness` — clean
- [x] `./build/divperf_simple` — match=1 across all 4 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)