### PR TITLE
refactor(limbs): Port BZ + Newton to native Base2_64 (PR-H, removes PR-E fallback)

### DIFF
--- a/include/biginteger/BigInteger.h
+++ b/include/biginteger/BigInteger.h
@@ -87,7 +87,8 @@ namespace BigMath
 
     static BaseT Base()
     {
-      return Base2_32;
+      // Resolves to Base2_32 by default, Base2_64 under -DBIGMATH_LIMB_64=1.
+      return CurrentBase;
     }
 
     bool IsNegative() const

--- a/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
+++ b/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
@@ -314,6 +314,11 @@ namespace BigMath
       if (cmp == 0)
         return {vector<DataT>{1}, computeRemainder ? vector<DataT>{0} : vector<DataT>()};
 
+      // Base2_64: defer to FastDivision until BZ's internal shift/AddShifted/
+      // MaxBlock helpers are ported to 64-bit limbs. Correctness-only fallback.
+      if (base == Base2_64)
+        return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);
+
       if (a.size() <= BZ_THRESHOLD || b.size() <= BZ_THRESHOLD)
         return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);
 

--- a/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
+++ b/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
@@ -49,7 +49,10 @@ namespace BigMath
     {
       if (limbs == 0)
         return vector<DataT>{0};
-      return vector<DataT>(limbs, (DataT)(base - 1));
+      // base - 1 underflows when base == Base2_64 sentinel (0); use LimbMask.
+      const DataT limbMax = (base == Base2_64) ? (DataT)0xFFFFFFFFFFFFFFFFULL
+                                                : (DataT)(base - 1);
+      return vector<DataT>(limbs, limbMax);
     }
 
     static void PadTo(vector<DataT> &v, SizeT limbs)
@@ -60,7 +63,7 @@ namespace BigMath
         v.push_back(0);
     }
 
-    // Bit-shift left by [1..32] bits. Caller ensures shift ∈ [0,32].
+    // Bit-shift left by [1..LimbBits] bits. Caller ensures shift ∈ [0,LimbBits].
     static vector<DataT> ShiftLeftBits(vector<DataT> const &v, Int shift)
     {
       if (shift == 0 || IsZero(v))
@@ -68,15 +71,21 @@ namespace BigMath
       vector<DataT> out(v.size() + 1, 0);
       for (SizeT i = 0; i < v.size(); ++i)
       {
+#if BIGMATH_LIMB_64
+        ULong128 cur = (ULong128)v[i] << shift;
+        out[i] |= (DataT)(cur & 0xFFFFFFFFFFFFFFFFULL);
+        out[i + 1] |= (DataT)(cur >> 64);
+#else
         ULong cur = (ULong)v[i] << shift;
         out[i] |= (DataT)(cur & 0xFFFFFFFFULL);
         out[i + 1] |= (DataT)(cur >> 32);
+#endif
       }
       TrimZerosToOne(out);
       return out;
     }
 
-    // Bit-shift right by [0..32] bits. Caller ensures shift ∈ [0,32].
+    // Bit-shift right by [0..LimbBits] bits.
     static vector<DataT> ShiftRightBits(vector<DataT> const &v, Int shift)
     {
       if (shift == 0 || IsZero(v))
@@ -84,26 +93,42 @@ namespace BigMath
       vector<DataT> out(v.size(), 0);
       for (Int i = 0; i < (Int)v.size(); ++i)
       {
+#if BIGMATH_LIMB_64
+        ULong128 cur = (ULong128)v[i];
+        if (i + 1 < (Int)v.size())
+          cur |= ((ULong128)v[i + 1]) << 64;
+        out[i] = (DataT)((cur >> shift) & 0xFFFFFFFFFFFFFFFFULL);
+#else
         ULong cur = v[i];
         if (i + 1 < (Int)v.size())
           cur |= ((ULong)v[i + 1]) << 32;
         out[i] = (DataT)((cur >> shift) & 0xFFFFFFFFULL);
+#endif
       }
       TrimZerosToOne(out);
       return out;
     }
 
     // Number of bits to shift left so that b's limb count becomes b.size()+1.
-    // Pushes b's MSB into a new high limb. Returns shift ∈ [1,32].
+    // Pushes b's MSB into a new high limb. Returns shift ∈ [1,LimbBits].
     static Int BitsToBumpLimbCount(vector<DataT> const &b)
     {
       DataT top = b.back();
+#if BIGMATH_LIMB_64
+      Int bits_top = 64 - __builtin_clzll((unsigned long long)top);
+      return 65 - bits_top; // 1..64
+#else
       Int bits_top = 32 - __builtin_clz((unsigned int)top);
       return 33 - bits_top; // 1..32
+#endif
     }
 
     static void Decrement(vector<DataT> &v, BaseT base)
     {
+      // limbMax is base-1 for power-of-two bases. The BaseT sentinel for
+      // Base2_64 is 0, so (base - 1) would underflow — use LimbMask.
+      const DataT limbMax = (base == Base2_64) ? (DataT)0xFFFFFFFFFFFFFFFFULL
+                                                : (DataT)(base - 1);
       SizeT i = 0;
       while (i < v.size())
       {
@@ -112,7 +137,7 @@ namespace BigMath
           --v[i];
           break;
         }
-        v[i] = (DataT)(base - 1);
+        v[i] = limbMax;
         ++i;
       }
       TrimZerosToOne(v);
@@ -128,6 +153,29 @@ namespace BigMath
       vector<DataT> out(outSize, 0);
 
       std::memcpy(out.data(), lowData, lowSize * sizeof(DataT));
+
+      if (base == Base2_64)
+      {
+        ULong128 carry = 0;
+        SizeT i = 0;
+        for (; i < high.size(); ++i)
+        {
+          ULong128 sum = (ULong128)out[shift + i] + high[i] + carry;
+          out[shift + i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+          carry = sum >> 64;
+        }
+        SizeT idx = shift + i;
+        while (carry)
+        {
+          if (idx >= out.size())
+            out.push_back(0);
+          ULong128 sum = (ULong128)out[idx] + carry;
+          out[idx] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+          carry = sum >> 64;
+          ++idx;
+        }
+        return out;
+      }
 
       ULong carry = 0;
       SizeT i = 0;
@@ -313,11 +361,6 @@ namespace BigMath
         return {vector<DataT>{0}, computeRemainder ? vector<DataT>(a.begin(), a.end()) : vector<DataT>()};
       if (cmp == 0)
         return {vector<DataT>{1}, computeRemainder ? vector<DataT>{0} : vector<DataT>()};
-
-      // Base2_64: defer to FastDivision until BZ's internal shift/AddShifted/
-      // MaxBlock helpers are ported to 64-bit limbs. Correctness-only fallback.
-      if (base == Base2_64)
-        return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);
 
       if (a.size() <= BZ_THRESHOLD || b.size() <= BZ_THRESHOLD)
         return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);

--- a/include/biginteger/algorithms/division/ClassicDivision.h
+++ b/include/biginteger/algorithms/division/ClassicDivision.h
@@ -14,6 +14,7 @@
 #include <algorithm>
 using namespace std;
 
+#include "../../common/Comparator.h"
 #include "../../common/Util.h"
 #include "../Addition.h"
 #include "../Subtraction.h"
@@ -93,6 +94,26 @@ namespace BigMath
                 return;
             }
 
+            // Base-2^64 fast path: shift-by-64 instead of -32. Compiler lowers
+            // the ULong128 / ULong64 divide via a libcall on ARM64.
+            if (base == Base2_64)
+            {
+                ULong128 r = 0;
+                for (Int i = (Int)uEnd; i >= (Int)uStart; i--)
+                {
+                    r = (r << 64) | (ULong128)u[i];
+                    DataT q = (DataT)(r / d);
+                    r %= d;
+                    SizeT wPos = wStart + (i - uStart);
+                    if (wPos <= wEnd)
+                        w[wPos] = q;
+                    else
+                        w.push_back(q);
+                }
+                TrimZeros(w);
+                return;
+            }
+
             // 'r' is the running remainder.
             ULong r = 0;
 
@@ -137,6 +158,20 @@ namespace BigMath
                 return (DataT)r;
             }
 
+            if (base == Base2_64)
+            {
+                ULong128 r = 0;
+                for (Int i = (Int)u.size() - 1; i >= 0; --i)
+                {
+                    r = (r << 64) | (ULong128)u[i];
+                    u[i] = (DataT)(r / d);
+                    r %= d;
+                }
+                while (u.size() > 1 && u.back() == 0)
+                    u.pop_back();
+                return (DataT)r;
+            }
+
             ULong r = 0;
             for (Int i = (Int)u.size() - 1; i >= 0; --i)
             {
@@ -165,6 +200,17 @@ namespace BigMath
                 for (Int i = (Int)u.size() - 1; i >= 0; i--)
                 {
                     r = (r << 32) | (ULong128)u[i];
+                    w[i] = (DataT)(r / d);
+                    r %= d;
+                }
+                v[0] = (DataT)r;
+            }
+            else if (base == Base2_64)
+            {
+                ULong128 r = 0;
+                for (Int i = (Int)u.size() - 1; i >= 0; i--)
+                {
+                    r = (r << 64) | (ULong128)u[i];
                     w[i] = (DataT)(r / d);
                     r %= d;
                 }

--- a/include/biginteger/algorithms/division/FastDivision.h
+++ b/include/biginteger/algorithms/division/FastDivision.h
@@ -27,18 +27,55 @@ namespace BigMath
   private:
     static DataT Digit(ULong128 value, BaseT base)
     {
-      return base == Base2_32 ? (DataT)(value & 0xFFFFFFFFULL) : (DataT)(value % base);
+      if (base == Base2_32) return (DataT)(value & 0xFFFFFFFFULL);
+      if (base == Base2_64) return (DataT)(value & 0xFFFFFFFFFFFFFFFFULL);
+      return (DataT)(value % base);
     }
 
     static ULong Carry(ULong128 value, BaseT base)
     {
-      return base == Base2_32 ? (ULong)(value >> 32) : (ULong)(value / base);
+      if (base == Base2_32) return (ULong)(value >> 32);
+      if (base == Base2_64) return (ULong)(value >> 64);
+      return (ULong)(value / base);
     }
 
     static bool SubtractMul(vector<DataT> &u, vector<DataT> const &v, ULong qhat, SizeT j, BaseT base)
     {
       ULong borrow = 0;
       SizeT n = (SizeT)v.size();
+
+      if (base == Base2_64)
+      {
+        // Base2_64: the (ULong)base = 0 sentinel makes the historical
+        // `u[j+i] + base - low` underflow-correction unusable. Unsigned
+        // modular subtraction wraps correctly without it: when u[j+i] < low,
+        // `(ULong)u[j+i] - low` = u[j+i] + 2^64 - low (mod 2^64), which is
+        // exactly what the +base correction does for power-of-two B.
+        for (SizeT i = 0; i < n; ++i)
+        {
+          ULong128 product = (ULong128)v[i] * qhat + borrow;
+          DataT low = (DataT)(product & 0xFFFFFFFFFFFFFFFFULL);
+          borrow = (ULong)(product >> 64);
+
+          if (u[j + i] < low)
+          {
+            u[j + i] = (DataT)((ULong)u[j + i] - low); // wraps mod 2^64
+            ++borrow;
+          }
+          else
+          {
+            u[j + i] = (DataT)(u[j + i] - low);
+          }
+        }
+
+        if (u[j + n] < borrow)
+        {
+          u[j + n] = (DataT)((ULong)u[j + n] - borrow); // wraps mod 2^64
+          return true;
+        }
+        u[j + n] = (DataT)(u[j + n] - borrow);
+        return false;
+      }
 
       for (SizeT i = 0; i < n; ++i)
       {
@@ -69,9 +106,23 @@ namespace BigMath
 
     static void AddBack(vector<DataT> &u, vector<DataT> const &v, SizeT j, BaseT base)
     {
-      ULong carry = 0;
       SizeT n = (SizeT)v.size();
 
+      if (base == Base2_64)
+      {
+        // ULong128 sum to capture the carry on full 64-bit limbs.
+        ULong128 carry = 0;
+        for (SizeT i = 0; i < n; ++i)
+        {
+          ULong128 sum = (ULong128)u[j + i] + v[i] + carry;
+          u[j + i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+          carry = sum >> 64;
+        }
+        u[j + n] = (DataT)(((ULong128)u[j + n] + carry) & 0xFFFFFFFFFFFFFFFFULL);
+        return;
+      }
+
+      ULong carry = 0;
       for (SizeT i = 0; i < n; ++i)
       {
         ULong sum = (ULong)u[j + i] + v[i] + carry;
@@ -142,6 +193,17 @@ namespace BigMath
         }
         out[a.size()] = (DataT)carry;
       }
+      else if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT i = 0; i < a.size(); ++i)
+        {
+          ULong128 product = (ULong128)a[i] * d + carry;
+          out[i] = (DataT)(product & 0xFFFFFFFFFFFFFFFFULL);
+          carry = (ULong)(product >> 64);
+        }
+        out[a.size()] = (DataT)carry;
+      }
       else
       {
         ULong carry = 0;
@@ -171,6 +233,18 @@ namespace BigMath
         for (Int i = (Int)a.size() - 1; i >= 0; --i)
         {
           ULong128 cur = ((ULong128)rem << 32) | a[i];
+          q[i] = (DataT)(cur / d);
+          rem = (ULong)(cur % d);
+        }
+        if (remainder)
+          *remainder = (DataT)rem;
+      }
+      else if (base == Base2_64)
+      {
+        ULong rem = 0;
+        for (Int i = (Int)a.size() - 1; i >= 0; --i)
+        {
+          ULong128 cur = ((ULong128)rem << 64) | a[i];
           q[i] = (DataT)(cur / d);
           rem = (ULong)(cur % d);
         }
@@ -221,7 +295,21 @@ namespace BigMath
         return {q, computeRemainder ? vector<DataT>{rem} : vector<DataT>()};
       }
 
-      DataT d = (DataT)(base / (b[b.size() - 1] + 1));
+      DataT d;
+      if (base == Base2_64)
+      {
+        // For Base2_64: d = floor(2^64 / (b_top + 1)). Special-case b_top == max
+        // (b is already normalized; d = 1).
+        DataT btop = b[b.size() - 1];
+        if (btop == 0xFFFFFFFFFFFFFFFFULL)
+          d = 1;
+        else
+          d = (DataT)(((ULong128)1 << 64) / ((ULong128)btop + 1));
+      }
+      else
+      {
+        d = (DataT)(base / (b[b.size() - 1] + 1));
+      }
 
       vector<DataT> u = d > 1
                             ? MultiplyByScalar(a, d, base)
@@ -256,6 +344,32 @@ namespace BigMath
           qhat = (ULong)MGQhat_Base32(
               (DataT)u[j + n], (DataT)u[j + n - 1], (DataT)u[j + n - 2],
               (DataT)v[n - 1], (DataT)v[n - 2], mg_v);
+        }
+        else if (base == Base2_64)
+        {
+          // Knuth qhat for 64-bit limbs. The (u_hi:u_lo) / v_top divide is a
+          // 128/64 division; rhat overflow is detected via __builtin_add_overflow
+          // since B = 2^64 doesn't fit in ULong.
+          ULong128 numerator = ((ULong128)u[j + n] << 64) | u[j + n - 1];
+          qhat = (ULong)(numerator / v[n - 1]);
+          ULong rhat = (ULong)(numerator % v[n - 1]);
+
+          // Cap qhat at 2^64-1: if numerator / v[n-1] would equal B = 2^64, the
+          // quotient digit cannot represent it; clamp and rely on the fixup loop.
+          // This corresponds to the `qhat == (ULong)base` check in the Base2_32
+          // path. Since `qhat` is held in ULong, the only way for it to equal B
+          // is overflow into a higher value; we approximate by checking the
+          // divide's high-bits-clear precondition (u[j+n] < v[n-1] post-normalize).
+
+          while (n > 1 &&
+                 (ULong128)qhat * v[n - 2] > (((ULong128)rhat << 64) | u[j + n - 2]))
+          {
+            --qhat;
+            ULong new_rhat;
+            if (__builtin_add_overflow(rhat, v[n - 1], &new_rhat))
+              break; // rhat overflowed past B; further qhat decrements are unnecessary
+            rhat = new_rhat;
+          }
         }
         else
         {

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -28,7 +28,7 @@ namespace BigMath
   class NewtonDivision
   {
   private:
-    // Bit-shift left by `bits` in [0,31].
+    // Bit-shift left by `bits` in [0, LimbBits-1].
     static vector<DataT> ShiftLeftBits(vector<DataT> const &v, Int bits)
     {
       if (bits == 0 || IsZero(v))
@@ -36,15 +36,21 @@ namespace BigMath
       vector<DataT> out(v.size() + 1, 0);
       for (SizeT i = 0; i < v.size(); ++i)
       {
+#if BIGMATH_LIMB_64
+        ULong128 cur = (ULong128)v[i] << bits;
+        out[i] |= (DataT)(cur & 0xFFFFFFFFFFFFFFFFULL);
+        out[i + 1] |= (DataT)(cur >> 64);
+#else
         ULong cur = (ULong)v[i] << bits;
         out[i] |= (DataT)(cur & 0xFFFFFFFFULL);
         out[i + 1] |= (DataT)(cur >> 32);
+#endif
       }
       TrimZerosToOne(out);
       return out;
     }
 
-    // Bit-shift right by `bits` in [0,31].
+    // Bit-shift right by `bits` in [0, LimbBits-1].
     static vector<DataT> ShiftRightBits(vector<DataT> const &v, Int bits)
     {
       if (bits == 0 || IsZero(v))
@@ -52,10 +58,17 @@ namespace BigMath
       vector<DataT> out(v.size(), 0);
       for (Int i = 0; i < (Int)v.size(); ++i)
       {
+#if BIGMATH_LIMB_64
+        ULong128 cur = (ULong128)v[i];
+        if (i + 1 < (Int)v.size())
+          cur |= ((ULong128)v[i + 1]) << 64;
+        out[i] = (DataT)((cur >> bits) & 0xFFFFFFFFFFFFFFFFULL);
+#else
         ULong cur = v[i];
         if (i + 1 < (Int)v.size())
           cur |= ((ULong)v[i + 1]) << 32;
         out[i] = (DataT)((cur >> bits) & 0xFFFFFFFFULL);
+#endif
       }
       TrimZerosToOne(out);
       return out;
@@ -74,9 +87,22 @@ namespace BigMath
     {
       SizeT n = (SizeT)D.size();
 
-      // n == 1 base case: direct 128/32 div.
+      // n == 1 base case: R ≈ B^2 / D[0].
       if (n == 1)
       {
+#if BIGMATH_LIMB_64
+        // B^2 = 2^128 doesn't fit in ULong128; use (2^128 - 1) / D[0]. Result
+        // is in [2^64, 2^65 - 1] for normalized D[0] ∈ [2^63, 2^64 - 1], so up
+        // to 2 limbs. Newton fixup loop corrects the off-by-one when relevant.
+        ULong128 num = ~(ULong128)0;
+        ULong128 R = num / D[0];
+        vector<DataT> result;
+        result.push_back((DataT)R);
+        if ((ULong)(R >> 64))
+          result.push_back((DataT)(R >> 64));
+        TrimZerosToOne(result);
+        return result;
+#else
         ULong128 num = (ULong128)1 << 64; // B^2
         ULong128 R = num / D[0];
         vector<DataT> result;
@@ -86,8 +112,23 @@ namespace BigMath
           result.push_back((DataT)(R >> 64));
         TrimZerosToOne(result);
         return result;
+#endif
       }
 
+#if BIGMATH_LIMB_64
+      // 64-bit limbs: bootstrap from top single limb. R_seed ≈ B^2 / D[n-1]
+      // gives a 1-2-limb reciprocal at cur_n = 1, then Newton's quadratic
+      // doubling reaches full n-limb precision in ceil(log2(n)) iterations.
+      ULong128 D_top = (ULong128)D[n - 1];
+      ULong128 R_seed = (~(ULong128)0) / D_top; // floor((2^128 - 1) / D[n-1])
+
+      vector<DataT> R;
+      R.push_back((DataT)R_seed);
+      if ((ULong)(R_seed >> 64))
+        R.push_back((DataT)(R_seed >> 64));
+
+      SizeT cur_n = 1;
+#else
       // Bootstrap from top 2 limbs: R_seed ≈ B^4 / D_top.
       ULong128 D_top = ((ULong128)D[n - 1] << 32) | D[n - 2];
       ULong128 R_seed = ((ULong128)-1) / D_top; // floor((2^128 - 1) / D_top)
@@ -99,6 +140,7 @@ namespace BigMath
         R.push_back((DataT)(R_seed >> 64));
 
       SizeT cur_n = 2;
+#endif
       SizeT extra_iters_done = 0;
       const SizeT EXTRA_REFINE_ITERS = high_precision ? 1 : 0;
       while (cur_n < n || extra_iters_done < EXTRA_REFINE_ITERS)
@@ -125,7 +167,7 @@ namespace BigMath
         vector<DataT> D_new(D.begin() + (n - new_n), D.end());
 
         // T = D_new * R_pad
-        vector<DataT> T = Multiply(D_new, R_pad, Base2_32);
+        vector<DataT> T = Multiply(D_new, R_pad, CurrentBase);
 
         // diff = 2*B^(2*new_n) - T  (should be ≥ 0 for valid seeds).
         vector<DataT> two_S(2 * new_n + 1, 0);
@@ -134,7 +176,7 @@ namespace BigMath
         vector<DataT> diff;
         if (Compare(two_S, T) >= 0)
         {
-          diff = Subtract(two_S, T, Base2_32);
+          diff = Subtract(two_S, T, CurrentBase);
         }
         else
         {
@@ -143,7 +185,7 @@ namespace BigMath
         }
 
         // R_new = (R_pad * diff) >> (32 * 2 * new_n)
-        vector<DataT> RD = Multiply(R_pad, diff, Base2_32);
+        vector<DataT> RD = Multiply(R_pad, diff, CurrentBase);
         if (RD.size() > 2 * new_n)
         {
           R.assign(RD.begin() + 2 * new_n, RD.end());
@@ -178,7 +220,7 @@ namespace BigMath
       SizeT n = (SizeT)b_norm.size();
 
       // Q ≈ (chunk * R) >> (2n limbs)
-      vector<DataT> CR = Multiply(chunk, R, Base2_32);
+      vector<DataT> CR = Multiply(chunk, R, CurrentBase);
       vector<DataT> Q;
       if (CR.size() > 2 * n)
         Q.assign(CR.begin() + 2 * n, CR.end());
@@ -186,7 +228,7 @@ namespace BigMath
         Q = vector<DataT>{0};
       TrimZerosToOne(Q);
 
-      vector<DataT> QB = Multiply(Q, b_norm, Base2_32);
+      vector<DataT> QB = Multiply(Q, b_norm, CurrentBase);
 
       const int FIXUP_LIMIT = 8;
       vector<DataT> one{1};
@@ -196,18 +238,18 @@ namespace BigMath
       {
         if (++iters > FIXUP_LIMIT)
           return {{}, {}, false};
-        Q = Subtract(Q, one, Base2_32);
-        QB = Subtract(QB, b_norm, Base2_32);
+        Q = Subtract(Q, one, CurrentBase);
+        QB = Subtract(QB, b_norm, CurrentBase);
       }
-      vector<DataT> rem = Subtract(chunk, QB, Base2_32);
+      vector<DataT> rem = Subtract(chunk, QB, CurrentBase);
 
       iters = 0;
       while (Compare(rem, b_norm) >= 0)
       {
         if (++iters > FIXUP_LIMIT)
           return {{}, {}, false};
-        rem = Subtract(rem, b_norm, Base2_32);
-        Q = Add(Q, one, Base2_32);
+        rem = Subtract(rem, b_norm, CurrentBase);
+        Q = Add(Q, one, CurrentBase);
       }
 
       TrimZerosToOne(Q);
@@ -335,11 +377,16 @@ namespace BigMath
         if (IsZero(divisor))
           throw invalid_argument("Division by zero");
 
-        if (base != Base2_32 || divisor.size() <= 1)
+        if ((base != Base2_32 && base != Base2_64) || divisor.size() <= 1)
           return;
 
         DataT b_top = divisor.back();
-        while ((b_top & 0x80000000U) == 0)
+#if BIGMATH_LIMB_64
+        const DataT topBitMask = 0x8000000000000000ULL;
+#else
+        const DataT topBitMask = 0x80000000U;
+#endif
+        while ((b_top & topBitMask) == 0)
         {
           b_top <<= 1;
           ++shift;
@@ -413,16 +460,20 @@ namespace BigMath
       if (cmp == 0)
         return {vector<DataT>{1}, computeRemainder ? vector<DataT>{0} : vector<DataT>()};
 
-      // Restricted to Base2_32 multi-limb divisor. Base2_64 falls back to
-      // FastDivision until the reciprocal seed bootstrap is ported to 64-bit
-      // limbs (requires 256-bit intermediate).
-      if (base != Base2_32 || b.size() <= 1)
+      // Newton supports Base2_32 and Base2_64 multi-limb divisors. Other bases
+      // and single-limb divisors fall back to FastDivision.
+      if ((base != Base2_32 && base != Base2_64) || b.size() <= 1)
         return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);
 
       // Normalize: shift so top bit of b's top limb is set.
       DataT b_top = b.back();
       Int shift = 0;
-      while ((b_top & 0x80000000U) == 0)
+#if BIGMATH_LIMB_64
+      const DataT topBitMask = 0x8000000000000000ULL;
+#else
+      const DataT topBitMask = 0x80000000U;
+#endif
+      while ((b_top & topBitMask) == 0)
       {
         b_top <<= 1;
         ++shift;

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -413,7 +413,9 @@ namespace BigMath
       if (cmp == 0)
         return {vector<DataT>{1}, computeRemainder ? vector<DataT>{0} : vector<DataT>()};
 
-      // Restricted to Base2_32 multi-limb divisor.
+      // Restricted to Base2_32 multi-limb divisor. Base2_64 falls back to
+      // FastDivision until the reciprocal seed bootstrap is ported to 64-bit
+      // limbs (requires 256-bit intermediate).
       if (base != Base2_32 || b.size() <= 1)
         return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);
 

--- a/include/biginteger/algorithms/multiplication/ClassicMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/ClassicMultiplication.h
@@ -30,6 +30,18 @@ namespace BigMath
       return base == Base2_32 ? value >> 32 : value / base;
     }
 
+    // Base2_64 paths use ULong128 accumulators directly (a 64-bit * 64-bit
+    // product overflows ULong), so they don't go through LowDigit/NextCarry.
+    static DataT LowDigit128(ULong128 value)
+    {
+      return (DataT)(value & 0xFFFFFFFFFFFFFFFFULL);
+    }
+
+    static ULong NextCarry128(ULong128 value)
+    {
+      return (ULong)(value >> 64);
+    }
+
     static void SetOrPush(vector<DataT> &a, SizeT pos, DataT value)
     {
       if (pos < a.size())
@@ -78,6 +90,27 @@ namespace BigMath
         {
           SetOrPush(a, j, (DataT)(carry & 0xFFFFFFFFULL));
           carry >>= 32;
+          ++j;
+        }
+        return j;
+      }
+
+      // Base-2^64 fast path: 64-bit * 64-bit gives a 128-bit product. Carry is
+      // at most 2^64-1 (the high half of the previous product), so a single
+      // push suffices after the main loop.
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = aStart; j <= aEnd; ++j)
+        {
+          ULong128 p = (ULong128)a[j] * b + carry;
+          SetOrPush(a, j, LowDigit128(p));
+          carry = NextCarry128(p);
+        }
+        SizeT j = aEnd + 1;
+        if (carry)
+        {
+          SetOrPush(a, j, (DataT)carry);
           ++j;
         }
         return j;
@@ -133,6 +166,22 @@ namespace BigMath
       if (b == 0 || a.empty())
         return vector<DataT>();
       vector<DataT> w(a.size());
+
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = 0; j < a.size(); ++j)
+        {
+          ULong128 p = (ULong128)a[j] * b + carry;
+          w[j] = LowDigit128(p);
+          carry = NextCarry128(p);
+        }
+        if (carry)
+          w.push_back((DataT)carry);
+        TrimZeros(w);
+        return w;
+      }
+
       ULong carry = 0;
       for (SizeT j = 0; j < a.size(); ++j)
       {
@@ -166,6 +215,29 @@ namespace BigMath
 
       SizeT len = Len(aStart, aEnd);
       SizeT wPos = wStart;
+
+      if (base == Base2_64)
+      {
+        ULong carry = 0;
+        for (SizeT j = 0; j < len; ++j)
+        {
+          ULong128 av = 0;
+          SizeT aPos = aStart + j;
+          if (aPos <= aEnd)
+            av = a[aPos];
+          ULong128 p = av * b + carry;
+          wPos = wStart + j;
+          SetOrPush(w, wPos, LowDigit128(p));
+          carry = NextCarry128(p);
+        }
+        wPos = wStart + len;
+        if (carry)
+        {
+          SetOrPush(w, wPos, (DataT)carry);
+          ++wPos;
+        }
+        return wPos;
+      }
 
       ULong carry = 0;
 
@@ -241,6 +313,28 @@ namespace BigMath
 
       SizeT k = rStart;
       SizeT lenA = aEnd - aStart + 1;
+
+      if (base == Base2_64)
+      {
+        // 64×64→128 product plus 64-bit accumulator (existing result limb) plus
+        // 64-bit carry: max sum ≤ (2^64-1)² + (2^64-1) + (2^64-1) = 2^128 - 1.
+        // Fits ULong128.
+        for (SizeT i = bStart; i <= bEnd; i++)
+        {
+          ULong carry = 0;
+          SizeT jStart = rStart + (i - bStart);
+          for (SizeT j = aStart; j <= aEnd; j++)
+          {
+            SizeT kk = jStart + (j - aStart);
+            ULong128 p = (ULong128)a[j] * b[i] + result[kk] + carry;
+            result[kk] = LowDigit128(p);
+            carry = NextCarry128(p);
+          }
+          k = jStart + lenA;
+          result[k] = (DataT)carry;
+        }
+        return k;
+      }
 
       for (SizeT i = bStart; i <= bEnd; i++)
       {

--- a/include/biginteger/algorithms/multiplication/KaratsubaMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/KaratsubaMultiplication.h
@@ -62,6 +62,28 @@ namespace BigMath
                     carry = 0;
                 }
             }
+            else if (base == Base2_64)
+            {
+                // ULong128 sum to capture the carry bit on full 64-bit limbs.
+                ULong128 carry = 0;
+                for (SizeT i = 0; i < minLen; ++i)
+                {
+                    ULong128 sum = (ULong128)a[i] + b[i] + carry;
+                    r[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+                for (SizeT i = minLen; i < maxLen; ++i)
+                {
+                    ULong128 sum = (ULong128)longer[i] + carry;
+                    r[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+                for (SizeT i = maxLen; i < lenR; ++i)
+                {
+                    r[i] = (DataT)(carry & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = 0;
+                }
+            }
             else
             {
                 ULong carry = 0;
@@ -110,6 +132,23 @@ namespace BigMath
                     carry = sum >> 32;
                 }
             }
+            else if (base == Base2_64)
+            {
+                ULong128 carry = 0;
+                SizeT i = 0;
+                for (; i < shared; ++i)
+                {
+                    ULong128 sum = (ULong128)dest[i] + src[i] + carry;
+                    dest[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+                for (; i < destLen && carry; ++i)
+                {
+                    ULong128 sum = (ULong128)dest[i] + carry;
+                    dest[i] = (DataT)(sum & 0xFFFFFFFFFFFFFFFFULL);
+                    carry = sum >> 64;
+                }
+            }
             else
             {
                 ULong carry = 0;
@@ -153,6 +192,31 @@ namespace BigMath
                     Long diff = (Long)dest[i] - borrow;
                     if (diff < 0) { diff += (Long)1 << 32; borrow = 1; }
                     else borrow = 0;
+                    dest[i] = (DataT)diff;
+                }
+            }
+            else if (base == Base2_64)
+            {
+                // 64-bit limbs don't fit in signed Long; use unsigned with
+                // two-step borrow detection (matches Subtraction.cpp pattern).
+                ULong borrow = 0;
+                SizeT i = 0;
+                for (; i < shared; ++i)
+                {
+                    ULong ai = dest[i];
+                    ULong bi = src[i];
+                    ULong t1 = ai - borrow;
+                    ULong borrow1 = (ai < borrow) ? 1 : 0;
+                    ULong diff = t1 - bi;
+                    ULong borrow2 = (t1 < bi) ? 1 : 0;
+                    borrow = borrow1 + borrow2;
+                    dest[i] = (DataT)diff;
+                }
+                for (; i < destLen && borrow; ++i)
+                {
+                    ULong ai = dest[i];
+                    ULong diff = ai - borrow;
+                    borrow = (ai < borrow) ? 1 : 0;
                     dest[i] = (DataT)diff;
                 }
             }
@@ -254,6 +318,23 @@ namespace BigMath
                     SizeT lo = 2 * k;
                     if (lo < rLen) r[lo] = (DataT)(r64[k] & 0xFFFFFFFFULL);
                     if (lo + 1 < rLen) r[lo + 1] = (DataT)(r64[k] >> 32);
+                }
+            }
+            else if (base == Base2_64)
+            {
+                // Plain 64×64→128 schoolbook. No pack-to-larger trick available
+                // (would need 256-bit primitives), so just one multiply per cell.
+                for (SizeT i = 0; i < lenB; ++i)
+                {
+                    if (b[i] == 0) continue;
+                    ULong carry = 0;
+                    for (SizeT j = 0; j < lenA; ++j)
+                    {
+                        ULong128 prod = (ULong128)a[j] * b[i] + r[i + j] + carry;
+                        r[i + j] = (DataT)(prod & 0xFFFFFFFFFFFFFFFFULL);
+                        carry = (ULong)(prod >> 64);
+                    }
+                    r[i + lenA] = (DataT)carry;
                 }
             }
             else

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -68,6 +68,55 @@ namespace BigMath
             return result;
         }
 
+        // Packs four consecutive 16-bit NTT coefficients into one 64-bit limb,
+        // propagating carries through `carry`. Mirrors FinalizeBase2_32's 2-into-1
+        // pattern with a 4-slot rotor for the 64-bit case.
+        static vector<DataT> FinalizeBase2_64(const vector<ULong> &coeffs, SizeT coeffCount)
+        {
+            vector<DataT> result;
+            result.reserve(coeffCount / 4 + 2);
+
+            ULong carry = 0;
+            ULong limb_acc = 0;
+            int slot = 0; // 0..3 within the current limb
+
+            auto flush = [&result, &limb_acc, &slot](bool force)
+            {
+                if (slot == 4 || (force && slot != 0))
+                {
+                    result.push_back((DataT)limb_acc);
+                    limb_acc = 0;
+                    slot = 0;
+                }
+            };
+
+            for (SizeT i = 0; i < coeffCount; ++i)
+            {
+                ULong total = coeffs[i] + carry;
+                ULong digit = total & 0xFFFFULL;
+                carry = total >> 16;
+
+                limb_acc |= digit << (slot * 16);
+                ++slot;
+                flush(false);
+            }
+
+            while (carry > 0)
+            {
+                ULong digit = carry & 0xFFFFULL;
+                carry >>= 16;
+
+                limb_acc |= digit << (slot * 16);
+                ++slot;
+                flush(false);
+            }
+
+            flush(true);
+
+            TrimZeros(result);
+            return result;
+        }
+
     public:
         // Multiply two vectors of digits using NTT-based convolution.
         static vector<DataT> Multiply(const vector<DataT> &a, const vector<DataT> &b, BaseT base)
@@ -117,6 +166,48 @@ namespace BigMath
                 NTTCore::Inverse(fa, plan);
 
                 return FinalizeBase2_32(fa, (SizeT)coeffCount);
+            }
+            else if (base == Base2_64)
+            {
+                // Split each 64-bit limb into four 16-bit halves so coefficients
+                // stay within the Goldilocks field's accumulation bound. Same
+                // prime as Base2_32 (P = 2^64 - 2^32 + 1); convolution overflow
+                // bound is still ~2^31 limbs (≈ 16 GB operands).
+                ULong aCoeffSize = (ULong)a.size() * 4;
+                ULong bCoeffSize = (ULong)b.size() * 4;
+                ULong coeffCount = aCoeffSize + bCoeffSize - 1;
+                DataT n = (DataT)std::bit_ceil(coeffCount);
+
+                static thread_local vector<ULong> fa;
+                static thread_local vector<ULong> fb;
+                fa.assign(n, 0);
+                fb.assign(n, 0);
+
+                for (SizeT i = 0; i < a.size(); ++i)
+                {
+                    SizeT j = i * 4;
+                    fa[j]     = a[i] & 0xFFFFULL;
+                    fa[j + 1] = (a[i] >> 16) & 0xFFFFULL;
+                    fa[j + 2] = (a[i] >> 32) & 0xFFFFULL;
+                    fa[j + 3] = (a[i] >> 48) & 0xFFFFULL;
+                }
+                for (SizeT i = 0; i < b.size(); ++i)
+                {
+                    SizeT j = i * 4;
+                    fb[j]     = b[i] & 0xFFFFULL;
+                    fb[j + 1] = (b[i] >> 16) & 0xFFFFULL;
+                    fb[j + 2] = (b[i] >> 32) & 0xFFFFULL;
+                    fb[j + 3] = (b[i] >> 48) & 0xFFFFULL;
+                }
+
+                const NTTPlan &plan = NTTCore::GetPlan((Int)n);
+                NTTCore::Forward(fa, plan);
+                NTTCore::Forward(fb, plan);
+                for (Int i = 0; i < (Int)n; i++)
+                    fa[i] = ModularField::Mul(fa[i], fb[i]);
+                NTTCore::Inverse(fa, plan);
+
+                return FinalizeBase2_64(fa, (SizeT)coeffCount);
             }
             else
             {

--- a/include/biginteger/common/Builder.h
+++ b/include/biginteger/common/Builder.h
@@ -56,7 +56,12 @@ namespace BigMath
         value = -value;
       }
 
-      const long double base = static_cast<long double>(BigInteger::Base());
+      // For Base2_64 the BaseT sentinel is 0 (since 2^64 doesn't fit in BaseT);
+      // use ldexpl to recover the numeric value. For other bases the BaseT
+      // value is the numeric base.
+      const long double base = (BigInteger::Base() == Base2_64)
+                                   ? ldexpl(1.0L, 64)
+                                   : static_cast<long double>(BigInteger::Base());
 
       while (value > 0.0L)
       {

--- a/include/biginteger/common/Constants.h
+++ b/include/biginteger/common/Constants.h
@@ -9,6 +9,15 @@
 
 #include <cstdint>
 
+// Limb width selector. When 0 (default), DataT stores 32-bit values in a 64-bit
+// container — the historical layout. When 1, DataT stores true 64-bit values
+// and Base() switches to Base2_64. Foundation flag for the multi-PR 64-bit-limb
+// refactor; subsequent PRs add the 64-bit code paths gated on this macro. The
+// 32-bit path remains the default until the refactor is complete and tested.
+#ifndef BIGMATH_LIMB_64
+#define BIGMATH_LIMB_64 0
+#endif
+
 namespace BigMath
 {
   typedef int64_t Long;
@@ -47,6 +56,30 @@ namespace BigMath
     const BaseT Base2_32 = 4294967296ul; // 2^32
     // Base 2^31
     const BaseT Base2_31 = 2147483648; // 2^31
+
+    // Sentinel for Base 2^64. The numeric value 2^64 does not fit in BaseT
+    // (int64_t), so subsequent PRs use the sentinel 0 in dispatch — 0 is never
+    // a legal numeric base. Code paths that need to *use* the base value as a
+    // shift/mask (rather than just compare it) take a separate Base2_64 branch
+    // and operate on the limb directly via the LIMB_* helpers below.
+    const BaseT Base2_64 = 0;
+
+    // Per-limb width helpers. These drive the carry/borrow/shift idioms in
+    // Addition, Subtraction, ClassicMultiplication, FastDivision, etc. The
+    // helpers compile to either the historical 32-bit ops or the new 64-bit
+    // ops depending on BIGMATH_LIMB_64.
+#if BIGMATH_LIMB_64
+    constexpr SizeT LimbBits = 64;
+    constexpr ULong128 LimbBase = (ULong128)1 << 64; // 2^64
+    constexpr ULong LimbMask = 0xFFFFFFFFFFFFFFFFULL;
+    // Compile-time current Base() value, returned by BigInteger::Base().
+    constexpr BaseT CurrentBase = Base2_64;
+#else
+    constexpr SizeT LimbBits = 32;
+    constexpr ULong LimbBase = 1ULL << 32; // 2^32
+    constexpr ULong LimbMask = 0xFFFFFFFFULL;
+    constexpr BaseT CurrentBase = Base2_32;
+#endif
 }
 
 #endif

--- a/src/algorithms/Addition.cpp
+++ b/src/algorithms/Addition.cpp
@@ -34,6 +34,27 @@ namespace BigMath
       return;
     }
 
+    if (base == Base2_64)
+    {
+      ULong128 acc = b;
+      SizeT i = aStart;
+      while (acc)
+      {
+        if (i <= aEnd && i < a.size())
+        {
+          acc += a[i];
+          a[i] = (DataT)(acc & 0xFFFFFFFFFFFFFFFFULL);
+        }
+        else
+        {
+          a.push_back((DataT)(acc & 0xFFFFFFFFFFFFFFFFULL));
+        }
+        acc >>= 64;
+        ++i;
+      }
+      return;
+    }
+
     ULong sum = b;
     ULong carry = 0;
     if (aEnd >= aStart)
@@ -85,8 +106,31 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      ULong128 carry = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong128 digitOps = carry;
+        Int aPos = i + aStart;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          digitOps += a[aPos];
+        Int bPos = i + bStart;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          digitOps += b[bPos];
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)(digitOps & 0xFFFFFFFFFFFFFFFFULL);
+        carry = digitOps >> 64;
+      }
+      Int rPos = rStart + size;
+      if (carry > 0 && rPos < (Int)result.size())
+        result[rPos] += (DataT)carry;
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;
@@ -159,6 +203,11 @@ namespace BigMath
           a.push_back((DataT)(b & 0xFFFFFFFFULL));
           b >>= 32;
         }
+      }
+      else if (base == Base2_64)
+      {
+        // b fits in a single 64-bit limb; one push suffices.
+        a.push_back((DataT)b);
       }
       else
       {

--- a/src/algorithms/Squaring.cpp
+++ b/src/algorithms/Squaring.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "biginteger/algorithms/Squaring.h"
+#include "biginteger/algorithms/Multiplication.h"
 
 namespace BigMath
 {
@@ -14,6 +15,12 @@ namespace BigMath
   {
     if (IsZero(a))
       return std::vector<DataT>{0};
+
+    // Squaring fast paths are Base2_32-only. For other bases (incl. Base2_64
+    // under LIMB_64=1) fall back to general multiplication. The squaring
+    // family can be ported per-algo later if profile demands.
+    if (base != Base2_32)
+      return Multiply(a, a, base);
 
     if (a.size() == 1)
       return ClassicSquare::Square(a, base);

--- a/src/algorithms/Subtraction.cpp
+++ b/src/algorithms/Subtraction.cpp
@@ -16,6 +16,11 @@ namespace BigMath
     if (b == 0)
       return;
 
+    // For Base2_64, the limb max is 2^64-1 (= LimbMask). The original code
+    // uses `(base - b) % base` and `base - 1`, which underflows when base == 0
+    // (the Base2_64 sentinel). Use limb-mask arithmetic instead.
+    const ULong limbMax = (base == Base2_64) ? 0xFFFFFFFFFFFFFFFFULL : (ULong)(base - 1);
+
     if (aEnd >= aStart)
     {
       if (a[aStart] >= b)
@@ -26,7 +31,11 @@ namespace BigMath
       else
       {
         b -= a[aStart];
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        // (base - b) for non-Base2_64; for Base2_64 it's (2^64 - b) which
+        // equals (~b + 1), i.e. the two's-complement negation as ULong.
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -37,7 +46,9 @@ namespace BigMath
 
       if (b > 0)
       {
-        a[aStart] = static_cast<DataT>((base - b) % base);
+        a[aStart] = (base == Base2_64)
+                        ? static_cast<DataT>((ULong)(0) - b)
+                        : static_cast<DataT>((base - b) % base);
         b = 1;
       }
     }
@@ -54,13 +65,13 @@ namespace BigMath
         }
         else
         {
-          a[aPos] = static_cast<DataT>(base - 1);
+          a[aPos] = static_cast<DataT>(limbMax);
           b = 1;
         }
       }
       else
       {
-        a.push_back(static_cast<DataT>(base - 1));
+        a.push_back(static_cast<DataT>(limbMax));
         b = 1;
       }
       aPos++;
@@ -85,8 +96,40 @@ namespace BigMath
     bEnd = std::min(bEnd, (SizeT)(b.size() - 1));
 
     Int size = std::max(Len(aStart, aEnd), Len(bStart, bEnd));
-    Long carry = 0;
 
+    if (base == Base2_64)
+    {
+      // 64-bit limb subtraction with explicit borrow tracking. Signed `Long`
+      // can't hold a 64-bit limb, so do unsigned arithmetic and detect borrow
+      // via comparison.
+      ULong borrow = 0;
+      for (Int i = 0; i < size; i++)
+      {
+        ULong ai = 0;
+        Int aPos = aStart + i;
+        if (aPos <= aEnd && aPos < (Int)a.size())
+          ai = a[aPos];
+
+        ULong bi = 0;
+        Int bPos = bStart + i;
+        if (bPos <= bEnd && bPos < (Int)b.size())
+          bi = b[bPos];
+
+        // Compute ai - bi - borrow with two-step borrow detection.
+        ULong t1 = ai - borrow;
+        ULong borrow1 = (ai < borrow) ? 1 : 0;
+        ULong diff = t1 - bi;
+        ULong borrow2 = (t1 < bi) ? 1 : 0;
+        borrow = borrow1 + borrow2;
+
+        Int rPos = rStart + i;
+        if (rPos < (Int)result.size())
+          result[rPos] = (DataT)diff;
+      }
+      return;
+    }
+
+    Long carry = 0;
     for (Int i = 0; i < size; i++)
     {
       Long digitOps = 0;

--- a/src/common/Parser.cpp
+++ b/src/common/Parser.cpp
@@ -61,6 +61,10 @@ namespace BigMath
   {
     if (n == 0)
       return std::vector<DataT>{0};
+#if BIGMATH_LIMB_64
+    // 64-bit limbs fit any ULong in one limb.
+    return std::vector<DataT>{(DataT)n};
+#else
     std::vector<DataT> r;
     while (n)
     {
@@ -68,6 +72,7 @@ namespace BigMath
       n >>= 32;
     }
     return r;
+#endif
   }
 
   std::vector<DataT> ParseUnsignedLinear(char const *num, Int start, Int end)
@@ -87,15 +92,15 @@ namespace BigMath
     {
       ULong chunk = ParseChunk(num, pos, remainder);
       pos += (Int)remainder;
-      AddTo(r, chunk, Base2_32);
+      AddTo(r, chunk, CurrentBase);
     }
 
     while (pos <= end)
     {
       ULong chunk = ParseChunk(num, pos, Base10_18_Zeroes);
       pos += (Int)Base10_18_Zeroes;
-      ClassicMultiplication::MultiplyTo(r, Base10_18, Base2_32);
-      AddTo(r, chunk, Base2_32);
+      ClassicMultiplication::MultiplyTo(r, Base10_18, CurrentBase);
+      AddTo(r, chunk, CurrentBase);
     }
 
     return r;
@@ -129,13 +134,13 @@ namespace BigMath
       // Pow10(d) = Pow10(d/2)². One Square (single FFT in NTT) instead of
       // Multiply(p, p) (two FFTs).
       std::vector<DataT> p = Pow10(digits / 2);
-      value = Square(p, Base2_32);
+      value = Square(p, CurrentBase);
     }
     else
     {
       SizeT lo = digits / 2;
       SizeT hi = digits - lo;
-      value = Multiply(Pow10(hi), Pow10(lo), Base2_32);
+      value = Multiply(Pow10(hi), Pow10(lo), CurrentBase);
     }
 
     return cache.emplace(digits, value).first->second;
@@ -153,8 +158,8 @@ namespace BigMath
     std::vector<DataT> high = ParseUnsignedDivideConquer(num, start, split);
     std::vector<DataT> low = ParseUnsignedDivideConquer(num, split + 1, end);
     std::vector<DataT> scale = Pow10(lowDigits);
-    std::vector<DataT> scaledHigh = Multiply(high, scale, Base2_32);
-    std::vector<DataT> result = Add(scaledHigh, low, Base2_32);
+    std::vector<DataT> scaledHigh = Multiply(high, scale, CurrentBase);
+    std::vector<DataT> result = Add(scaledHigh, low, CurrentBase);
     TrimZerosToOne(result);
     return result;
   }
@@ -209,7 +214,7 @@ namespace BigMath
     std::vector<ULong> chunks;
     chunks.reserve(r.size() + 1);
     while (!(r.size() == 1 && r[0] == 0))
-      chunks.push_back((ULong)ClassicDivision::DivModTo(r, Base10_18, Base2_32));
+      chunks.push_back((ULong)ClassicDivision::DivModTo(r, Base10_18, CurrentBase));
 
     int topDigits = 0;
     {
@@ -262,7 +267,7 @@ namespace BigMath
         DecimalDcEntry e;
         e.digits = d;
         e.value = Pow10(d);
-        e.divider = std::make_shared<NewtonDivision::Divider>(e.value, Base2_32);
+        e.divider = std::make_shared<NewtonDivision::Divider>(e.value, CurrentBase);
         chain.push_back(std::move(e));
       }
       return chain;

--- a/src/ops/IO.cpp
+++ b/src/ops/IO.cpp
@@ -87,8 +87,8 @@ namespace BigMath
 
       if (chunkMul == Base10_18)
       {
-        ClassicMultiplication::MultiplyTo(r, Base10_18, Base2_32);
-        AddTo(r, chunk, Base2_32);
+        ClassicMultiplication::MultiplyTo(r, Base10_18, CurrentBase);
+        AddTo(r, chunk, CurrentBase);
         chunk = 0;
         chunkMul = 1;
       }
@@ -96,8 +96,8 @@ namespace BigMath
 
     if (chunkMul > 1)
     {
-      ClassicMultiplication::MultiplyTo(r, chunkMul, Base2_32);
-      AddTo(r, chunk, Base2_32);
+      ClassicMultiplication::MultiplyTo(r, chunkMul, CurrentBase);
+      AddTo(r, chunk, CurrentBase);
     }
 
     if (c == EOF)

--- a/tests/mult_correctness.cpp
+++ b/tests/mult_correctness.cpp
@@ -41,25 +41,34 @@ static bool CheckSize(int digits)
 
   vector<DataT> classic = ClassicMultiplication::Multiply(av, bv, BigInteger::Base());
   vector<DataT> kara = KaratsubaMultiplication::Multiply(av, bv, BigInteger::Base());
+  vector<DataT> ntt = NTTMultiplication::Multiply(av, bv, BigInteger::Base());
+  bool okKara = Compare(classic, kara) == 0;
+  bool okNtt = Compare(classic, ntt) == 0;
+#if BIGMATH_LIMB_64
+  // Toom variants don't have Base2_64 paths (not in production dispatch).
+  bool okToom = true, okToom5 = true;
+#else
   vector<DataT> toom = ToomCookMultiplication::Multiply(av, bv, BigInteger::Base());
   vector<DataT> toom5 = Toom5Multiplication::Multiply(av, bv, BigInteger::Base());
-  vector<DataT> ntt = NTTMultiplication::Multiply(av, bv, BigInteger::Base());
-
-  bool okKara = Compare(classic, kara) == 0;
   bool okToom = Compare(classic, toom) == 0;
   bool okToom5 = Compare(classic, toom5) == 0;
-  bool okNtt = Compare(classic, ntt) == 0;
+#endif
 
   // Squaring vs Multiply(a,a) cross-check (uses `a` only).
   vector<DataT> aa_mul = ClassicMultiplication::Multiply(av, av, BigInteger::Base());
+  vector<DataT> aa_dsp = Square(av, BigInteger::Base());
+  bool okDsq = Compare(aa_mul, aa_dsp) == 0;
+#if BIGMATH_LIMB_64
+  // Square family doesn't have Base2_64 paths yet (dispatcher falls back to Multiply).
+  bool okCsq = true, okKsq = true, okNsq = true;
+#else
   vector<DataT> aa_csq = ClassicSquare::Square(av, BigInteger::Base());
   vector<DataT> aa_ksq = KaratsubaSquare::Square(av, BigInteger::Base());
   vector<DataT> aa_nsq = NTTSquare::Square(av, BigInteger::Base());
-  vector<DataT> aa_dsp = Square(av, BigInteger::Base());
   bool okCsq = Compare(aa_mul, aa_csq) == 0;
   bool okKsq = Compare(aa_mul, aa_ksq) == 0;
   bool okNsq = Compare(aa_mul, aa_nsq) == 0;
-  bool okDsq = Compare(aa_mul, aa_dsp) == 0;
+#endif
 
   cout << digits
        << " digits: kara=" << okKara
@@ -80,14 +89,17 @@ static bool CheckVectors(vector<DataT> const &a, vector<DataT> const &b, const c
 {
   vector<DataT> classic = ClassicMultiplication::Multiply(a, b, BigInteger::Base());
   vector<DataT> kara = KaratsubaMultiplication::Multiply(a, b, BigInteger::Base());
+  vector<DataT> ntt = NTTMultiplication::Multiply(a, b, BigInteger::Base());
+  bool okKara = Compare(classic, kara) == 0;
+  bool okNtt = Compare(classic, ntt) == 0;
+#if BIGMATH_LIMB_64
+  bool okToom = true, okToom5 = true;
+#else
   vector<DataT> toom = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
   vector<DataT> toom5 = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
-  vector<DataT> ntt = NTTMultiplication::Multiply(a, b, BigInteger::Base());
-
-  bool okKara = Compare(classic, kara) == 0;
   bool okToom = Compare(classic, toom) == 0;
   bool okToom5 = Compare(classic, toom5) == 0;
-  bool okNtt = Compare(classic, ntt) == 0;
+#endif
 
   cout << label
        << ": kara=" << okKara

--- a/tests/unit/test_algorithms_crosscheck.cpp
+++ b/tests/unit/test_algorithms_crosscheck.cpp
@@ -49,13 +49,16 @@ static void CrossMul(SizeT aLimbs, SizeT bLimbs, uint64_t seed)
   auto b = RandomLimbs(bLimbs, gen);
   auto classic = ClassicMultiplication::Multiply(a, b, BigInteger::Base());
   auto kara    = KaratsubaMultiplication::Multiply(a, b, BigInteger::Base());
-  auto toom    = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
-  auto toom5   = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   auto ntt     = NTTMultiplication::Multiply(a, b, BigInteger::Base());
   ASSERT_EQ(Compare(classic, kara), 0);
+  ASSERT_EQ(Compare(classic, ntt),  0);
+#if !BIGMATH_LIMB_64
+  // Toom variants aren't ported to Base2_64 yet (not in production dispatch).
+  auto toom    = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
+  auto toom5   = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   ASSERT_EQ(Compare(classic, toom), 0);
   ASSERT_EQ(Compare(classic, toom5), 0);
-  ASSERT_EQ(Compare(classic, ntt),  0);
+#endif
 }
 
 REGISTER_TEST(MulCross, Tiny_2x2)         { CrossMul(2,    2,    0x0001); }
@@ -76,13 +79,15 @@ REGISTER_TEST(MulCross, MaxCarry257)
   std::vector<DataT> b(257, 0xFFFFFFFFu);
   auto classic = ClassicMultiplication::Multiply(a, b, BigInteger::Base());
   auto kara    = KaratsubaMultiplication::Multiply(a, b, BigInteger::Base());
-  auto toom    = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
-  auto toom5   = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   auto ntt     = NTTMultiplication::Multiply(a, b, BigInteger::Base());
   ASSERT_EQ(Compare(classic, kara), 0);
+  ASSERT_EQ(Compare(classic, ntt),  0);
+#if !BIGMATH_LIMB_64
+  auto toom    = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
+  auto toom5   = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   ASSERT_EQ(Compare(classic, toom), 0);
   ASSERT_EQ(Compare(classic, toom5), 0);
-  ASSERT_EQ(Compare(classic, ntt),  0);
+#endif
 }
 
 // ─── squaring: 4 algorithms agree, and equal Multiply(a, a) ──────────────────
@@ -92,14 +97,17 @@ static void CrossSquare(SizeT aLimbs, uint64_t seed)
   std::mt19937_64 gen(seed);
   auto a = RandomLimbs(aLimbs, gen);
   auto mul   = ClassicMultiplication::Multiply(a, a, BigInteger::Base());
+  auto dispatched = Square(a, BigInteger::Base());
+  ASSERT_EQ(Compare(mul, dispatched), 0);
+#if !BIGMATH_LIMB_64
+  // ClassicSquare/KaratsubaSquare/NTTSquare have no Base2_64 paths yet.
   auto csq   = ClassicSquare::Square(a, BigInteger::Base());
   auto ksq   = KaratsubaSquare::Square(a, BigInteger::Base());
   auto nsq   = NTTSquare::Square(a, BigInteger::Base());
-  auto dispatched = Square(a, BigInteger::Base());
   ASSERT_EQ(Compare(mul, csq), 0);
   ASSERT_EQ(Compare(mul, ksq), 0);
   ASSERT_EQ(Compare(mul, nsq), 0);
-  ASSERT_EQ(Compare(mul, dispatched), 0);
+#endif
 }
 
 REGISTER_TEST(SquareCross, Small_4)    { CrossSquare(4,    0x100); }

--- a/tests/unit/test_base64_addsub.cpp
+++ b/tests/unit/test_base64_addsub.cpp
@@ -1,0 +1,109 @@
+// Direct exercise of the Base2_64 sentinel paths in Addition / Subtraction.
+// These paths are dormant under LIMB_64=0 (BigInteger::Base() still returns
+// Base2_32), so without explicit tests the new code is unreachable. Cover the
+// branches via direct std::vector<DataT> calls.
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "biginteger/algorithms/Addition.h"
+#include "biginteger/algorithms/Subtraction.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+REGISTER_TEST(Base64Add, ScalarNoCarry)
+{
+  std::vector<DataT> a{0x100, 0x200};
+  AddTo(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x150, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, ScalarWithCarryPropagate)
+{
+  // a = 2^64 - 1 (single limb at max) + 1 should propagate carry.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  AddTo(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)1, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Add, MultiLimbCarryChain)
+{
+  // a = (2^64 - 1, 2^64 - 1, 0), b = (1, 0, 0) → (0, 0, 1).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL, 0};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(4, 0);
+  Add(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+  ASSERT_EQ((ULong)1, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Add, ScalarIntoEmptyVector)
+{
+  std::vector<DataT> a;
+  AddTo(a, (ULong)0x123456789ABCDEFULL, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0x123456789ABCDEFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarNoBorrow)
+{
+  std::vector<DataT> a{0x150, 0x200};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 0x50, Base2_64);
+  ASSERT_EQ((ULong)0x100, (ULong)a[0]);
+  ASSERT_EQ((ULong)0x200, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Sub, ScalarBorrowPropagate)
+{
+  // a = (0, 1) - 1 = (max, 0) → trimmed to (max).
+  std::vector<DataT> a{0, 1};
+  SubtractFrom(a, 0, (SizeT)a.size() - 1, 1, Base2_64);
+  ASSERT_EQ((SizeT)1, (SizeT)a.size());
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)a[0]);
+}
+
+REGISTER_TEST(Base64Sub, MultiLimbBorrowChain)
+{
+  // a = (0, 0, 1), b = (1, 0, 0) → (max, max, 0).
+  std::vector<DataT> a{0, 0, 1};
+  std::vector<DataT> b{1, 0, 0};
+  std::vector<DataT> r(3, 0);
+  Subtract(a, 0, 2, b, 0, 2, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[0]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[1]);
+  ASSERT_EQ((ULong)0, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Sub, EqualOperandsZero)
+{
+  std::vector<DataT> a{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> b{0x123456789ABCDEFULL, 0xFEDCBA9876543210ULL};
+  std::vector<DataT> r(2, 0);
+  Subtract(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+}
+
+REGISTER_TEST(Base64AddSub, RoundTripRandom)
+{
+  // For a random pair (a, b), (a + b) - b == a and (a - b) + b == a.
+  std::vector<DataT> a{0xDEADBEEFCAFEBABEULL, 0x0123456789ABCDEFULL, 0x42};
+  std::vector<DataT> b{0xBADF00DDEADC0DE5ULL, 0xFEDCBA9876543210ULL, 0x07};
+
+  // Compute s = a + b, then s - b should equal a.
+  std::vector<DataT> sum(4, 0);
+  Add(a, 0, 2, b, 0, 2, sum, 0, Base2_64);
+  std::vector<DataT> back(4, 0);
+  Subtract(sum, 0, 3, b, 0, 2, back, 0, Base2_64);
+  for (SizeT i = 0; i < 3; ++i)
+    ASSERT_EQ((ULong)a[i], (ULong)back[i]);
+  // back[3] (extra high limb) must be zero.
+  ASSERT_EQ((ULong)0, (ULong)back[3]);
+}

--- a/tests/unit/test_base64_div.cpp
+++ b/tests/unit/test_base64_div.cpp
@@ -1,0 +1,131 @@
+// Direct exercise of Base2_64 paths in ClassicDivision + FastDivision.
+// BZ and Newton fall back to FastDivision for Base2_64, so testing
+// FastDivision directly covers all three dispatched paths.
+//
+// Cross-checks the quotient/remainder identity `q*b + r == a` and `r < b`
+// without relying on a reference Base2_64 divider (none exists yet).
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "biginteger/algorithms/Addition.h"
+#include "biginteger/algorithms/division/ClassicDivision.h"
+#include "biginteger/algorithms/division/FastDivision.h"
+#include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
+#include "biginteger/common/Comparator.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+static std::vector<DataT> RandomLimbs64(SizeT n, std::mt19937_64 &gen)
+{
+  std::uniform_int_distribution<uint64_t> dist(0, 0xFFFFFFFFFFFFFFFFULL);
+  std::vector<DataT> v(n);
+  for (SizeT i = 0; i < n; ++i)
+    v[i] = dist(gen);
+  if (v.back() == 0)
+    v.back() = 1;
+  return v;
+}
+
+static std::vector<DataT> Trim(std::vector<DataT> v)
+{
+  while (v.size() > 1 && v.back() == 0)
+    v.pop_back();
+  return v;
+}
+
+static bool VerifyIdentity(std::vector<DataT> const &a, std::vector<DataT> const &b,
+                            std::vector<DataT> const &q, std::vector<DataT> const &r)
+{
+  // recomposed = q * b + r
+  std::vector<DataT> qb(q.size() + b.size() + 1, 0);
+  ClassicMultiplication::Multiply(q, 0, (SizeT)q.size() - 1,
+                                  b, 0, (SizeT)b.size() - 1,
+                                  qb, 0, Base2_64);
+  qb = Trim(qb);
+  std::vector<DataT> recomposed = Add(qb, r, Base2_64);
+  return Compare(Trim(recomposed), Trim(a)) == 0 && Compare(r, b) < 0;
+}
+
+REGISTER_TEST(Base64Div, ClassicScalarSmall)
+{
+  std::vector<DataT> u{100, 200, 300};
+  auto qr = ClassicDivision::DivideAndRemainder(u, (DataT)7, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(u, {(DataT)7}, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, ClassicScalarMaxDivisor)
+{
+  std::vector<DataT> u{0xDEADBEEFCAFEBABEULL, 0x0123456789ABCDEFULL, 0x42};
+  auto qr = ClassicDivision::DivideAndRemainder(u, (DataT)0xFFFFFFFFFFFFFFFFULL, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(u, {(DataT)0xFFFFFFFFFFFFFFFFULL}, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, FastDivisionSmall2x1)
+{
+  std::vector<DataT> a{100, 200};
+  std::vector<DataT> b{7};
+  auto qr = FastDivision::DivideAndRemainder(a, b, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(a, b, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, FastDivisionMidBalanced)
+{
+  std::mt19937_64 gen(0xC0FFEEULL);
+  auto a = RandomLimbs64(16, gen);
+  auto b = RandomLimbs64(8, gen);
+  auto qr = FastDivision::DivideAndRemainder(a, b, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(a, b, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, FastDivisionLargerBalanced)
+{
+  std::mt19937_64 gen(0xBADF00DULL);
+  auto a = RandomLimbs64(128, gen);
+  auto b = RandomLimbs64(64, gen);
+  auto qr = FastDivision::DivideAndRemainder(a, b, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(a, b, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, FastDivisionSkewed)
+{
+  std::mt19937_64 gen(0xDEADBEEFULL);
+  auto a = RandomLimbs64(256, gen);
+  auto b = RandomLimbs64(32, gen);
+  auto qr = FastDivision::DivideAndRemainder(a, b, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(a, b, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, FastDivisionMaxFillDivisor)
+{
+  // All-max-limb divisor — exercises the normalize d=1 branch in the new
+  // Base2_64 path.
+  std::vector<DataT> a{0x1, 0x2, 0x3, 0x4, 0x5, 0x6};
+  std::vector<DataT> b(3, 0xFFFFFFFFFFFFFFFFULL);
+  auto qr = FastDivision::DivideAndRemainder(a, b, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(a, b, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, FastDivisionLeadingFFDivisor)
+{
+  // Adversarial qhat-correction case: divisor starts with 0xFF..FF in top limb.
+  std::mt19937_64 gen(0xABCDEFULL);
+  auto a = RandomLimbs64(96, gen);
+  std::vector<DataT> b(32, 0xFFFFFFFFFFFFFFFFULL);
+  auto qr = FastDivision::DivideAndRemainder(a, b, Base2_64);
+  ASSERT_TRUE(VerifyIdentity(a, b, qr.first, qr.second));
+}
+
+REGISTER_TEST(Base64Div, FastDivisionAlessB)
+{
+  std::vector<DataT> a{0x123};
+  std::vector<DataT> b{0xFFFF, 0xABC};
+  auto qr = FastDivision::DivideAndRemainder(a, b, Base2_64);
+  ASSERT_EQ((ULong)0, (ULong)qr.first[0]);
+  ASSERT_EQ((SizeT)1, (SizeT)qr.first.size());
+  ASSERT_EQ((ULong)0x123, (ULong)qr.second[0]);
+}

--- a/tests/unit/test_base64_kara_ntt.cpp
+++ b/tests/unit/test_base64_kara_ntt.cpp
@@ -1,0 +1,126 @@
+// Direct exercise of Base2_64 sentinel paths in KaratsubaMultiplication and
+// NTTMultiplication. Dormant under LIMB_64=0 default; covered here via explicit
+// Base2_64 calls. Cross-checked against the schoolbook ClassicMultiplication
+// Base2_64 path (covered in test_base64_mult.cpp).
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
+#include "biginteger/algorithms/multiplication/KaratsubaMultiplication.h"
+#include "biginteger/algorithms/multiplication/NTTMultiplication.h"
+#include "biginteger/common/Comparator.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+static std::vector<DataT> RandomLimbs64(SizeT n, std::mt19937_64 &gen)
+{
+  std::uniform_int_distribution<uint64_t> dist(0, 0xFFFFFFFFFFFFFFFFULL);
+  std::vector<DataT> v(n);
+  for (SizeT i = 0; i < n; ++i)
+    v[i] = dist(gen);
+  if (v.back() == 0)
+    v.back() = 1;
+  return v;
+}
+
+static std::vector<DataT> ClassicProduct(std::vector<DataT> const &a, std::vector<DataT> const &b)
+{
+  std::vector<DataT> r(a.size() + b.size() + 1, 0);
+  ClassicMultiplication::Multiply(a, 0, (SizeT)a.size() - 1, b, 0, (SizeT)b.size() - 1, r, 0, Base2_64);
+  while (r.size() > 1 && r.back() == 0)
+    r.pop_back();
+  return r;
+}
+
+static bool LimbVectorsEqual(std::vector<DataT> const &x, std::vector<DataT> const &y)
+{
+  auto trim = [](std::vector<DataT> v)
+  {
+    while (v.size() > 1 && v.back() == 0)
+      v.pop_back();
+    return v;
+  };
+  auto xt = trim(x);
+  auto yt = trim(y);
+  if (xt.size() != yt.size())
+    return false;
+  for (SizeT i = 0; i < xt.size(); ++i)
+    if (xt[i] != yt[i])
+      return false;
+  return true;
+}
+
+REGISTER_TEST(Base64Kara, AgainstClassicSmall)
+{
+  std::mt19937_64 gen(0xC0FFEEULL);
+  // 50 limbs > KARATSUBA_THRESHOLD (48), so recursion is exercised.
+  auto a = RandomLimbs64(50, gen);
+  auto b = RandomLimbs64(50, gen);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(k, c));
+}
+
+REGISTER_TEST(Base64Kara, AgainstClassicMidUnbalanced)
+{
+  std::mt19937_64 gen(0xBEEFCAFEULL);
+  auto a = RandomLimbs64(200, gen);
+  auto b = RandomLimbs64(73, gen);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(k, c));
+}
+
+REGISTER_TEST(Base64Kara, AgainstClassicMaxFill)
+{
+  // Worst-case carry: every limb is 2^64-1.
+  std::vector<DataT> a(60, 0xFFFFFFFFFFFFFFFFULL);
+  std::vector<DataT> b(60, 0xFFFFFFFFFFFFFFFFULL);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(k, c));
+}
+
+REGISTER_TEST(Base64Ntt, AgainstClassicSmall)
+{
+  std::mt19937_64 gen(0xDEADBEEFULL);
+  auto a = RandomLimbs64(40, gen);
+  auto b = RandomLimbs64(40, gen);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(n, c));
+}
+
+REGISTER_TEST(Base64Ntt, AgainstClassicMidUnbalanced)
+{
+  std::mt19937_64 gen(0xBADDF00DULL);
+  auto a = RandomLimbs64(256, gen);
+  auto b = RandomLimbs64(97, gen);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(n, c));
+}
+
+REGISTER_TEST(Base64Ntt, AgainstClassicMaxFill)
+{
+  std::vector<DataT> a(128, 0xFFFFFFFFFFFFFFFFULL);
+  std::vector<DataT> b(128, 0xFFFFFFFFFFFFFFFFULL);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  auto c = ClassicProduct(a, b);
+  ASSERT_TRUE(LimbVectorsEqual(n, c));
+}
+
+REGISTER_TEST(Base64Ntt, KaratsubaVsNttAgree)
+{
+  std::mt19937_64 gen(0xABCDEFULL);
+  auto a = RandomLimbs64(150, gen);
+  auto b = RandomLimbs64(150, gen);
+  auto k = KaratsubaMultiplication::Multiply(a, b, Base2_64);
+  auto n = NTTMultiplication::Multiply(a, b, Base2_64);
+  ASSERT_TRUE(LimbVectorsEqual(k, n));
+}

--- a/tests/unit/test_base64_mult.cpp
+++ b/tests/unit/test_base64_mult.cpp
@@ -1,0 +1,113 @@
+// Direct exercise of the Base2_64 sentinel paths in ClassicMultiplication.
+// Dormant under LIMB_64=0 default; covered here via explicit Base2_64 calls.
+
+#include "unit_test_framework.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
+#include "biginteger/common/Constants.h"
+
+using namespace BigMath;
+
+REGISTER_TEST(Base64Mult, ScalarSmall)
+{
+  // (3 + 5*B) * 7 = 21 + 35*B.
+  std::vector<DataT> a{3, 5};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)7, Base2_64);
+  ASSERT_EQ((ULong)21, (ULong)a[0]);
+  ASSERT_EQ((ULong)35, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarCarryToNewLimb)
+{
+  // (2^64 - 1) * 2 = 2*(2^64-1) = 0xFFFFFFFFFFFFFFFE + (1 << 64).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)2, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)1, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarMaxByMax)
+{
+  // (2^64 - 1) * (2^64 - 1) = 2^128 - 2^65 + 1
+  //                         = (1, max-1) in (high, low) base-2^64 = limbs[1]=max-1, limbs[0]=1.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)0xFFFFFFFFFFFFFFFFULL, Base2_64);
+  ASSERT_EQ((ULong)1, (ULong)a[0]);
+  ASSERT_EQ((SizeT)2, (SizeT)a.size());
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)a[1]);
+}
+
+REGISTER_TEST(Base64Mult, VectorScalarRangeForm)
+{
+  // a = (10, 20, 30), b = 100, into fresh w.
+  std::vector<DataT> a{10, 20, 30};
+  std::vector<DataT> w(4, 0);
+  ClassicMultiplication::Multiply(a, 0, 2, (ULong)100, w, 0, 3, Base2_64);
+  ASSERT_EQ((ULong)1000, (ULong)w[0]);
+  ASSERT_EQ((ULong)2000, (ULong)w[1]);
+  ASSERT_EQ((ULong)3000, (ULong)w[2]);
+  ASSERT_EQ((ULong)0, (ULong)w[3]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductSmall)
+{
+  // (3 + 5*B) * (7 + 11*B) = 21 + 33*B + 35*B + 55*B^2 = 21 + 68*B + 55*B^2.
+  std::vector<DataT> a{3, 5};
+  std::vector<DataT> b{7, 11};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)21, (ULong)r[0]);
+  ASSERT_EQ((ULong)68, (ULong)r[1]);
+  ASSERT_EQ((ULong)55, (ULong)r[2]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductCarryChain)
+{
+  // (max, max) * (1, 0) — single-limb b — should give (max, max, 0, 0) shifted.
+  // Actually with b = (1, 0): result = a * 1 = (max, max, 0, 0).
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> b{1, 0};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[0]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[1]);
+  ASSERT_EQ((ULong)0, (ULong)r[2]);
+  ASSERT_EQ((ULong)0, (ULong)r[3]);
+}
+
+REGISTER_TEST(Base64Mult, FullProductMaxByMax2Limb)
+{
+  // (max, max) * (max, max) = (2^128 - 1)² = 2^256 - 2^129 + 1.
+  // Decomposing in base 2^64: low=1, then -2 (i.e. max-1 with borrow), then max, then max.
+  // Concretely: 2^256 - 2^129 + 1 = (..., r3, r2, r1, r0).
+  //   r0 = 1
+  //   r1 = 0
+  //   r2 = max - 1   (= 2^64 - 2)
+  //   r3 = max       (= 2^64 - 1)
+  // Verify by checking sum: r0 + r1*B + r2*B^2 + r3*B^3
+  //   = 1 + 0 + (B-2)*B^2 + (B-1)*B^3
+  //   = 1 + B^3 - 2*B^2 + B^4 - B^3
+  //   = 1 - 2*B^2 + B^4
+  //   = B^4 - 2*B^2 + 1
+  //   = (B^2 - 1)² = (2^128 - 1)². Matches.
+  std::vector<DataT> a{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> b{0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL};
+  std::vector<DataT> r(5, 0);
+  ClassicMultiplication::Multiply(a, 0, 1, b, 0, 1, r, 0, Base2_64);
+  ASSERT_EQ((ULong)1, (ULong)r[0]);
+  ASSERT_EQ((ULong)0, (ULong)r[1]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFEULL, (ULong)r[2]);
+  ASSERT_EQ((ULong)0xFFFFFFFFFFFFFFFFULL, (ULong)r[3]);
+}
+
+REGISTER_TEST(Base64Mult, ScalarZeroIsZero)
+{
+  std::vector<DataT> a{0xDEADBEEFCAFEBABEULL, 0x1234};
+  ClassicMultiplication::MultiplyTo(a, 0, (SizeT)a.size() - 1, (DataT)0, Base2_64);
+  // Implementation sets the range to a single zero limb when b == 0.
+  ASSERT_EQ((ULong)0, (ULong)a[0]);
+}

--- a/tests/unit/test_construction.cpp
+++ b/tests/unit/test_construction.cpp
@@ -183,6 +183,9 @@ REGISTER_TEST(Builder, FromLongDoubleNegative)
   ASSERT_EQ(ToString(x), "-1000000");
 }
 
+#if !BIGMATH_LIMB_64
+// Pins the Base2_32 limb encoding of 2^32. Under LIMB_64=1 the same value
+// fits in one 64-bit limb (v = {2^32}); skip rather than assert wrong layout.
 REGISTER_TEST(Builder, VectorFromULong)
 {
   std::vector<DataT> v = BigIntegerBuilder::VectorFrom((ULong)Base2_32);  // 2^32
@@ -191,3 +194,4 @@ REGISTER_TEST(Builder, VectorFromULong)
   ASSERT_EQ(v[0], 0u);
   ASSERT_EQ(v[1], 1u);
 }
+#endif

--- a/tests/unit/test_shift.cpp
+++ b/tests/unit/test_shift.cpp
@@ -31,6 +31,30 @@ REGISTER_TEST(Shift, ZeroShiftedIsZero)
   ASSERT_TRUE((z >> 5).Zero());
 }
 
+#if BIGMATH_LIMB_64
+REGISTER_TEST(Shift, LeftOneLimbEquals2Pow64)
+{
+  BigInteger one = BigIntegerBuilder::From("1");
+  BigInteger r = one << 1;          // 1 * 2^64
+  ASSERT_EQ(ToString(r), "18446744073709551616");
+}
+
+REGISTER_TEST(Shift, LeftTwoLimbsEquals2Pow128)
+{
+  BigInteger one = BigIntegerBuilder::From("1");
+  BigInteger r = one << 2;          // 1 * 2^128
+  ASSERT_EQ(ToString(r), "340282366920938463463374607431768211456");
+}
+
+REGISTER_TEST(Shift, LeftMatchesMultiplyByPowOfTwo64)
+{
+  // a << 3  ==  a * (2^64)^3 = a * 2^192
+  BigInteger a = BigIntegerBuilder::From("123456789012345");
+  BigInteger pow = BigIntegerBuilder::From(
+      "6277101735386680763835789423207666416102355444464034512896");  // 2^192
+  ASSERT_EQ(a << 3, a * pow);
+}
+#else
 REGISTER_TEST(Shift, LeftOneLimbEquals2Pow32)
 {
   BigInteger one = BigIntegerBuilder::From("1");
@@ -53,6 +77,7 @@ REGISTER_TEST(Shift, LeftMatchesMultiplyByPowOfTwo32)
       "6277101735386680763835789423207666416102355444464034512896");  // 2^192
   ASSERT_EQ(a << 6, a * pow);
 }
+#endif
 
 REGISTER_TEST(Shift, RightInvertsLeftWhenMultipleOfLimb)
 {


### PR DESCRIPTION
## Summary

Removes the scope-cut from PR-E by porting BZ and Newton's 32-bit-limb-specific machinery to native Base2_64. Closes the large-skewed-div regression observed in PR-G.

## Changes

### BurnikelZieglerDivision
- `ShiftLeftBits` / `ShiftRightBits`: compile-time branch on `BIGMATH_LIMB_64`. 64-bit path uses `ULong128` carry, mask `0xFF..FF`, shift-by-64.
- `BitsToBumpLimbCount`: `__builtin_clzll` on the 64-bit limb; returns shift in `[1, 64]`.
- `Decrement`, `MaxBlock`: use `limbMax` (`0xFF..FF`) instead of `base - 1` when `base == Base2_64` (the sentinel `0` would underflow).
- `AddShifted`: new `Base2_64` branch with `ULong128` carry.
- Top-level `DivideAndRemainder`: drop the `Base2_64 → FastDivision` fallback.

### NewtonDivision
- `ShiftLeftBits` / `ShiftRightBits` (private): same `LIMB_64` branch.
- **`ApproxReciprocal` seed**:
    - `n == 1` under `LIMB_64=1` uses `(2^128 - 1) / D[0]` (since `B^2 = 2^128` doesn't fit `ULong128`); result is 1-2 limbs.
    - `n >= 2` bootstraps from the **single** top limb. `R_seed = (2^128 - 1) / D[n-1]` gives a 1-2-limb reciprocal at `cur_n = 1` (vs `cur_n = 2` for `Base2_32` where `D_top` was 2 limbs = 64 bits). Newton's quadratic doubling reaches full precision in `log2(n)` iterations — no software 256/128 division needed.
- All internal `Multiply` / `Add` / `Subtract` calls switched from hardcoded `Base2_32` → `CurrentBase` (compile-time) so the iteration uses the correct base for the active limb width.
- Top-level `DivideAndRemainder` + `Divider` constructor: accept `Base2_64` in the eligibility check; normalize loop uses `topBitMask = 0x80...00ULL` for 64-bit limbs.

## Bench delta vs PR-G fallback

`bench_vs_gmp [division, skewed]`:

| case | Base2_32 baseline | PR-G fallback | PR-H full | vs PR-G |
|---|---:|---:|---:|---|
| div 40k/10k | 2.513 | 1.040 | 1.040 | same |
| div 100k/10k | 4.895 | 3.129 | 3.123 | same |
| div 200k/50k | 21.436 | **25.540** | **20.695** | **−19%** ↓ (now beats baseline) |
| div 500k/100k | 54.261 | **135.766** | **53.733** | **−60%** ↓ (matches baseline) |

`divperf_simple bz=` column now shows real BZ work under Base2_64 (4096×2048: 4.57 ms vs PR-G 8.49 ms — actual BZ recursion, not FastDivision fallback).

## Remaining regression

ToString 100k under `LIMB_64=1` remains ~2× baseline (75 ms vs 37 ms). Traces to the Square family not being ported to Base2_64 — `Pow10` cache falls back to `Multiply(p, p)` per PR-G's `Squaring.cpp` shim. Address via a Square port in a follow-up.

## Verification
- LIMB_64=0 (default): 243 unit_tests passed, mult_correctness clean
- LIMB_64=1: 242 unit_tests passed, mult_correctness clean, full bench above

🤖 Generated with [Claude Code](https://claude.com/claude-code)