### PR TITLE
fix(tostr): correct digitsPerLimb for LIMB_64 (was halving D&C depth)

### DIFF
--- a/src/common/Parser.cpp
+++ b/src/common/Parser.cpp
@@ -319,9 +319,18 @@ namespace BigMath
     while (r.size() > 1 && r.back() == 0)
       r.pop_back();
 
-    // Each 32-bit limb ≈ log10(2^32) ≈ 9.633 decimal digits. Overestimate is fine —
-    // used only for buffer reserve and D&C level choice.
-    SizeT approxDigits = (SizeT)((double)r.size() * 9.633) + 1;
+    // Each LimbBits-wide limb ≈ LimbBits * log10(2) decimal digits.
+    // Base2_32 = 9.633, Base2_64 = 19.266. Used for buffer reserve AND D&C
+    // chain depth — underestimating leaves the linear-leaf chunk way too big
+    // (e.g. Base2_64 with 9.633 underestimates 2×, halves chain depth, and
+    // pushes a 60k-digit value through ToStringLinearAppend, dominating
+    // runtime with __udivmodti4 libcalls).
+#if BIGMATH_LIMB_64
+    constexpr double digitsPerLimb = 19.266;
+#else
+    constexpr double digitsPerLimb = 9.633;
+#endif
+    SizeT approxDigits = (SizeT)((double)r.size() * digitsPerLimb) + 1;
 
     std::string s;
     s.reserve(approxDigits + (isNeg ? 2 : 1));

--- a/tests/performance/dispatch_tuner.cpp
+++ b/tests/performance/dispatch_tuner.cpp
@@ -22,6 +22,7 @@
 #include "biginteger/algorithms/multiplication/NTTMultiplication.h"
 #include "biginteger/algorithms/multiplication/NTTSquare.h"
 #include "biginteger/algorithms/multiplication/Toom5Multiplication.h"
+#include "biginteger/algorithms/multiplication/ToomCookMultiplication.h"
 #include "biginteger/common/Comparator.h"
 #include "biginteger/common/Util.h"
 
@@ -85,7 +86,7 @@ namespace
   void TuneMultiplication(bool full)
   {
     PrintHeader("Multiplication Dispatch");
-    cout << "limbs_each,total_limbs,classic_ms,karatsuba_ms,toom5_ms,ntt_ms,winner\n";
+    cout << "limbs_each,total_limbs,classic_ms,karatsuba_ms,toom3_ms,toom5_ms,ntt_ms,winner\n";
 
     vector<SizeT> sizes = {
         8, 16, 24, 32, 40, 48, 64, 96, 128, 192, 256, 384, 512,
@@ -123,6 +124,11 @@ namespace
         return (SizeT)r.size();
       }, reps);
 
+      double toom3Ms = BestMs([&]() {
+        auto r = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
+        return (SizeT)r.size();
+      }, reps);
+
       double toom5Ms = BestMs([&]() {
         auto r = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
         return (SizeT)r.size();
@@ -134,8 +140,8 @@ namespace
       }, reps);
 
       string winner = limbs <= 256
-                          ? Winner({{"classic", classicMs}, {"karatsuba", karaMs}, {"toom5", toom5Ms}, {"ntt", nttMs}})
-                          : Winner({{"karatsuba", karaMs}, {"toom5", toom5Ms}, {"ntt", nttMs}});
+                          ? Winner({{"classic", classicMs}, {"karatsuba", karaMs}, {"toom3", toom3Ms}, {"toom5", toom5Ms}, {"ntt", nttMs}})
+                          : Winner({{"karatsuba", karaMs}, {"toom3", toom3Ms}, {"toom5", toom5Ms}, {"ntt", nttMs}});
 
       if (!foundClassicCrossover && limbs <= 256 && karaMs < classicMs)
       {
@@ -147,7 +153,7 @@ namespace
 
       cout << limbs << ',' << limbs * 2 << ','
            << fixed << setprecision(4) << classicMs << ','
-           << karaMs << ',' << toom5Ms << ',' << nttMs << ','
+           << karaMs << ',' << toom3Ms << ',' << toom5Ms << ',' << nttMs << ','
            << winner << '\n';
       previousTotal = limbs * 2;
     }


### PR DESCRIPTION
## Summary

\`ToString\` computes \`approxDigits = r.size() * digitsPerLimb\` to size the D&C chain depth. The constant was hardcoded \`9.633 = log10(2^32)\`, which under \`LIMB_64=1\` underestimates by 2× (correct value \`19.266 = log10(2^64)\`).

The underestimate halved \`BuildDecimalDcChain\`'s depth. \`ToStringDivConquer\` then exhausted the chain too early and fell through to \`ToStringLinearAppend\` on a ~62500-digit chunk instead of the intended ~1562-digit leaf.

Linear leaf is divmod-10^18 = \`O(limbs × digits/18)\` \`__udivmodti4\` libcalls. **Sampling showed \`__udivmodti4\` = 83% of ToString samples under LIMB_64=1.**

## Numbers (100k digits, M1 Max, -O3 -march=native)

| | LIMB_64=0 baseline | LIMB_64=1 before | LIMB_64=1 after | delta |
|---|---:|---:|---:|---:|
| repro 100k×30 iters | 36.6 ms | 74.1 ms | **30.1 ms** | **−18% vs baseline** |

\`bench_vs_gmp [ToString]\` LIMB_64=1 after fix:

| size | before | after | baseline | vs GMP after |
|---|---:|---:|---:|---:|
| 10k | 1.21 ms | **0.87 ms** | 1.37 ms | 11.19× |
| 50k | 20.71 ms | **10.30 ms** | 14.15 ms | 12.10× |
| 100k | 74.88 ms | **30.22 ms** | 37.21 ms | **12.76×** (was 31.45×) |

All three sizes now BEAT Base2_32 baseline. ToString vs GMP at 100k dropped from 31.45× to 12.76× — better than the 15.84× Base2_32 baseline.

## Verification
- LIMB_64=0: 243 unit_tests, mult_correctness clean
- LIMB_64=1: 242 unit_tests, mult_correctness clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)