### PR TITLE
refactor(limbs): flip BIGMATH_LIMB_64 default to 1

### DIFF
--- a/include/biginteger/common/Constants.h
+++ b/include/biginteger/common/Constants.h
@@ -9,13 +9,17 @@
 
 #include <cstdint>
 
-// Limb width selector. When 0 (default), DataT stores 32-bit values in a 64-bit
-// container — the historical layout. When 1, DataT stores true 64-bit values
-// and Base() switches to Base2_64. Foundation flag for the multi-PR 64-bit-limb
-// refactor; subsequent PRs add the 64-bit code paths gated on this macro. The
-// 32-bit path remains the default until the refactor is complete and tested.
+// Limb width selector. When 1 (default), DataT stores true 64-bit values and
+// Base() == Base2_64. When 0, DataT stores 32-bit values in a 64-bit container
+// (the historical layout) and Base() == Base2_32. The 32-bit path is kept
+// available for A/B testing and as a fallback; flip via -DBIGMATH_LIMB_64=0.
+//
+// Bench (M1 Max, -O3 -march=native, bench_vs_gmp): LIMB_64=1 matches or beats
+// LIMB_64=0 on every measured op. Wins: small/mid mul -25 to -60%, skewed div
+// -36 to -59%, parse -24 to -34%, ToString -19 to -28%. 1M NTT-bound mul is
+// flat (NTT-coefficient-bound, not limb-bound).
 #ifndef BIGMATH_LIMB_64
-#define BIGMATH_LIMB_64 0
+#define BIGMATH_LIMB_64 1
 #endif
 
 namespace BigMath


### PR DESCRIPTION
## Summary

Flips the default to 64-bit limbs. \`Base() == Base2_64\`. Opt-out via \`-DBIGMATH_LIMB_64=0\` for the legacy 32-bit path.

## Why now

All earlier PRs (#18–#27, #29) brought the 64-bit path to full feature parity with the 32-bit path:
- All algorithms native Base2_64: Add/Sub, ClassicMult, Karatsuba, NTT, Toom-3, Toom-5, all four divisions (Classic, Fast, BZ, Newton), Parser, ToString, Square family
- Dispatch thresholds tuned (PR-J)
- #29 fixed the ToString \`digitsPerLimb\` bug

LIMB_64=1 now matches or beats the Base2_32 baseline on every measured op:

| op | Base2_32 | LIMB_64=1 | delta |
|---|---:|---:|---:|
| mul 1k×1k | 0.005 | 0.002 | **−60%** |
| mul 5k×5k | 0.040 | 0.030 | −25% |
| mul 10k×10k | 0.127 | 0.093 | −27% |
| mul 1M×1M | 37.5 | 36.9 | 0 (NTT-bound) |
| div 40k/10k skewed | 2.513 | 1.040 | **−59%** |
| div 100k/10k skewed | 4.895 | 3.121 | **−36%** |
| div 500k/100k skewed | 54.26 | 53.72 | 0 |
| parse 100k | 6.551 | 4.303 | **−34%** |
| parse 1M | 115.5 | 87.6 | −24% |
| tostr 10k | 1.372 | 0.870 | **−37%** |
| tostr 50k | 14.15 | 10.30 | −27% |
| tostr 100k | 37.21 | 30.22 | **−19%** |

## Verification
- **Default LIMB_64=1**: 242 unit_tests pass, mult_correctness clean, divperf_simple match=1 across all 4 cases
- **Opt-out `-DBIGMATH_LIMB_64=0`**: 243 unit_tests pass, mult_correctness clean

Unit test count differs (242 vs 243) because \`Builder.VectorFromULong\` asserts the Base2_32 limb encoding of 2^32 and is gated under \`!BIGMATH_LIMB_64\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)