### PR TITLE
feat(ntt): multithreaded NTT, opt-in via BIGMATH_USE_THREADS

### DIFF
--- a/docs/THREAD_SAFETY.md
+++ b/docs/THREAD_SAFETY.md
@@ -1,0 +1,67 @@
+# Thread safety
+
+## Summary
+
+BigMath is **thread-safe for concurrent use of distinct objects from distinct threads**. Multiple threads may simultaneously construct, mutate, and destroy their own `BigInteger`/`BigDecimal` values without coordination. Multiple threads may also concurrently call `const` methods on a *shared* `BigInteger`, `BigDecimal`, or `NewtonDivision::Divider` instance.
+
+Concurrent mutation of the *same* object from multiple threads is **not** supported (standard data-race semantics). Wrap shared mutable instances in your own mutex if needed.
+
+## What's shared, what's not
+
+### Per-thread caches (already isolated)
+
+The library uses four `static thread_local` caches that are private to each thread. No coordination is needed; each thread pays a first-touch cost.
+
+| cache | file | what it holds |
+|---|---|---|
+| `NTTCore::BuildPlan::cache` | `include/biginteger/algorithms/multiplication/NTTCore.h` | NTT plans (size → twiddles + bit-reversal table) |
+| `NTTMultiplication::Multiply::fa,fb` | `include/biginteger/algorithms/multiplication/NTTMultiplication.h` | coefficient working buffers |
+| `NTTSquare::Square::fa` | `include/biginteger/algorithms/multiplication/NTTSquare.h` | coefficient working buffer |
+| `Pow10::cache` | `src/common/Parser.cpp` | memoized powers of 10 in current-base limbs |
+
+These caches grow monotonically (NTT plan cache is keyed by transform size; Pow10 cache is keyed by exponent). They are never invalidated mid-process and never written from outside the owning thread.
+
+For a thread-pool worker pattern, warm each pool thread by issuing one representative NTT-bound mult and one `Pow10(d)` call from each worker at startup. Otherwise the first call from each worker pays the cache-fill cost.
+
+### Read-only namespace constants
+
+Dispatch thresholds (`NTT_MULTIPLICATION_THRESHOLD`, `NEWTON_MEDIUM_B`, etc.) are `const SizeT` defined in `src/algorithms/*.cpp`. Initialized once at program start; never modified.
+
+### `NewtonDivision::Divider` (and `ReciprocalDivision::Divider`)
+
+The `Divider` class precomputes a reciprocal for a fixed divisor. Its `DivideAndRemainder` and `Divide` methods are `const`; the precomputed state is not mutated after construction. **One `Divider` instance can be safely shared across threads** as long as no thread is concurrently constructing it.
+
+Typical pattern:
+
+```cpp
+// One Divider, many concurrent divides on different numerators.
+ReciprocalDivision::Divider divider(b, BigInteger::Base());
+
+#pragma omp parallel for
+for (size_t i = 0; i < numerators.size(); ++i) {
+  auto qr = divider.DivideAndRemainder(numerators[i]);  // safe
+  ...
+}
+```
+
+### `BigInteger` / `BigDecimal` instances
+
+Each instance owns its `std::vector<DataT>` storage. Standard C++ rules apply: concurrent reads of a single instance are fine, concurrent writes (or read+write) are a data race. Operators (`+`, `-`, `*`, `/`, etc.) produce new instances and don't mutate operands, so chains like `a + b * c` from a single thread are always race-free regardless of whether `a`, `b`, `c` are shared with other threads (provided the others aren't writing).
+
+## What is NOT thread-safe
+
+- **Concurrent mutation of the same `BigInteger`/`BigDecimal` instance.** Includes `+=`, `-=`, `*=`, `/=`, `AddTo`, `SubtractFrom`, assignment.
+- **Concurrent calls to `Divider` constructor on the same memory location.** Construction does heavy precompute work; finish construction before sharing.
+- **Concurrent calls to `BigInteger::Base()` that race with a hypothetical future setter.** Currently `Base()` is a static `constexpr` and immutable; this caveat is forward-looking.
+
+## Future: opt-in internal parallelism
+
+A `BIGMATH_USE_THREADS` build flag is reserved for adding internal thread-pool-driven parallelism inside individual operations (e.g. parallel NTT butterflies, parallel `Forward(fa)`+`Forward(fb)`). When this lands:
+
+- The flag will default to **off**. Single-threaded users see zero overhead.
+- A small `BigMath::ThreadPool` will be linked in via `src/`. Public headers stay free of `<thread>` to avoid pulling pthread linkage into every consumer.
+- Pool size defaults to `min(hardware_concurrency(), 8)` — beyond 8 cores on shared-L2 architectures (M1 Max etc.), NTT working-set L2 pressure dominates over compute parallelism.
+- The thread_local caches above remain per-pool-worker. Pool warm-up at startup is recommended (issue one large mult per worker).
+- The user-facing thread safety guarantees above do not change. Internal parallelism is an implementation detail of single operation calls, not a change in the concurrency model.
+
+See [`DIVISION.md` §Improving skewed division beyond the current floor](DIVISION.md#improving-skewed-division-beyond-the-current-floor) for the design rationale and expected wins.

--- a/include/biginteger/algorithms/multiplication/NTTCore.h
+++ b/include/biginteger/algorithms/multiplication/NTTCore.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "../../common/Util.h"
+#include "../../common/Parallel.h"
 
 namespace BigMath
 {
@@ -125,49 +126,85 @@ namespace BigMath
         // Forward DIF and inverse DIT pair. The forward transform leaves data in
         // bit-reversed order; pointwise multiplication stays aligned and inverse DIT
         // returns natural-order coefficients.
+        //
+        // Under BIGMATH_USE_THREADS=1 each layer's i-blocks are split across the
+        // pool. The outer block index `i` advances by `len`, so the number of
+        // i-blocks per layer is n/len. Top layer (len==n) has 1 block — falls
+        // back to serial there; subsequent layers parallelize across blocks.
         static void Forward(std::vector<ULong> &a, const NTTPlan &plan)
         {
             Int n = (Int)a.size();
-            const std::vector<ULong> &roots = plan.forwardRoots;
+            const std::vector<ULong> *rootsPtr = &plan.forwardRoots;
             for (Int len = n; len > 1; len >>= 1)
             {
                 Int halflen = len >> 1;
                 Int stride = n / len;
-                for (Int i = 0; i < n; i += len)
-                {
-                    for (Int j = 0; j < halflen; ++j)
+                Int numBlocks = n / len;
+                ULong *aPtr = a.data();
+                const ULong *roots = rootsPtr->data();
+                auto body = [aPtr, halflen, len, stride, roots](Int bStart, Int bEnd) {
+                    for (Int b = bStart; b < bEnd; ++b)
                     {
-                        ULong u = a[i + j];
-                        ULong v = a[i + j + halflen];
-                        a[i + j] = ModularField::Add(u, v);
-                        a[i + j + halflen] = ModularField::Mul(ModularField::Sub(u, v), roots[j * stride]);
+                        Int i = b * len;
+                        for (Int j = 0; j < halflen; ++j)
+                        {
+                            ULong u = aPtr[i + j];
+                            ULong v = aPtr[i + j + halflen];
+                            aPtr[i + j] = ModularField::Add(u, v);
+                            aPtr[i + j + halflen] = ModularField::Mul(ModularField::Sub(u, v), roots[j * stride]);
+                        }
                     }
-                }
+                };
+                // Each i-block does `halflen` butterflies = ~halflen * 30 ns. Run
+                // parallel only when total work per layer crosses the threshold.
+                if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
+                    ParallelFor(numBlocks, body);
+                else
+                    body(0, numBlocks);
             }
         }
 
         static void Inverse(std::vector<ULong> &a, const NTTPlan &plan)
         {
             Int n = (Int)a.size();
-            const std::vector<ULong> &roots = plan.inverseRoots;
+            const std::vector<ULong> *rootsPtr = &plan.inverseRoots;
             for (Int len = 2; len <= n; len <<= 1)
             {
                 Int halflen = len >> 1;
                 Int stride = n / len;
-                for (Int i = 0; i < n; i += len)
-                {
-                    for (Int j = 0; j < halflen; ++j)
+                Int numBlocks = n / len;
+                ULong *aPtr = a.data();
+                const ULong *roots = rootsPtr->data();
+                auto body = [aPtr, halflen, len, stride, roots](Int bStart, Int bEnd) {
+                    for (Int b = bStart; b < bEnd; ++b)
                     {
-                        ULong u = a[i + j];
-                        ULong v = ModularField::Mul(a[i + j + halflen], roots[j * stride]);
-                        a[i + j] = ModularField::Add(u, v);
-                        a[i + j + halflen] = ModularField::Sub(u, v);
+                        Int i = b * len;
+                        for (Int j = 0; j < halflen; ++j)
+                        {
+                            ULong u = aPtr[i + j];
+                            ULong v = ModularField::Mul(aPtr[i + j + halflen], roots[j * stride]);
+                            aPtr[i + j] = ModularField::Add(u, v);
+                            aPtr[i + j + halflen] = ModularField::Sub(u, v);
+                        }
                     }
-                }
+                };
+                if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
+                    ParallelFor(numBlocks, body);
+                else
+                    body(0, numBlocks);
             }
 
-            for (Int i = 0; i < n; i++)
-                a[i] = ModularField::Mul(a[i], plan.inverseSize);
+            // Final scaling by inverse size — trivially parallel.
+            ULong *aPtr = a.data();
+            ULong invSize = plan.inverseSize;
+            auto scaleBody = [aPtr, invSize](Int s, Int e) {
+                for (Int i = s; i < e; ++i)
+                    aPtr[i] = ModularField::Mul(aPtr[i], invSize);
+            };
+            if ((SizeT)n >= ParallelMinSize())
+                ParallelFor(n, scaleBody);
+            else
+                scaleBody(0, n);
         }
     };
 }

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -161,8 +161,18 @@ namespace BigMath
                 const NTTPlan &plan = NTTCore::GetPlan((Int)n);
                 NTTCore::Forward(fa, plan);
                 NTTCore::Forward(fb, plan);
-                for (Int i = 0; i < (Int)n; i++)
-                    fa[i] = ModularField::Mul(fa[i], fb[i]);
+                {
+                    ULong *faPtr = fa.data();
+                    ULong *fbPtr = fb.data();
+                    auto body = [faPtr, fbPtr](Int s, Int e) {
+                        for (Int i = s; i < e; ++i)
+                            faPtr[i] = ModularField::Mul(faPtr[i], fbPtr[i]);
+                    };
+                    if ((SizeT)n >= ParallelMinSize())
+                        ParallelFor((Int)n, body);
+                    else
+                        body(0, (Int)n);
+                }
                 NTTCore::Inverse(fa, plan);
 
                 return FinalizeBase2_32(fa, (SizeT)coeffCount);
@@ -203,8 +213,18 @@ namespace BigMath
                 const NTTPlan &plan = NTTCore::GetPlan((Int)n);
                 NTTCore::Forward(fa, plan);
                 NTTCore::Forward(fb, plan);
-                for (Int i = 0; i < (Int)n; i++)
-                    fa[i] = ModularField::Mul(fa[i], fb[i]);
+                {
+                    ULong *faPtr = fa.data();
+                    ULong *fbPtr = fb.data();
+                    auto body = [faPtr, fbPtr](Int s, Int e) {
+                        for (Int i = s; i < e; ++i)
+                            faPtr[i] = ModularField::Mul(faPtr[i], fbPtr[i]);
+                    };
+                    if ((SizeT)n >= ParallelMinSize())
+                        ParallelFor((Int)n, body);
+                    else
+                        body(0, (Int)n);
+                }
                 NTTCore::Inverse(fa, plan);
 
                 return FinalizeBase2_64(fa, (SizeT)coeffCount);
@@ -227,8 +247,18 @@ namespace BigMath
                 const NTTPlan &plan = NTTCore::GetPlan((Int)n);
                 NTTCore::Forward(fa, plan);
                 NTTCore::Forward(fb, plan);
-                for (Int i = 0; i < (Int)n; i++)
-                    fa[i] = ModularField::Mul(fa[i], fb[i]);
+                {
+                    ULong *faPtr = fa.data();
+                    ULong *fbPtr = fb.data();
+                    auto body = [faPtr, fbPtr](Int s, Int e) {
+                        for (Int i = s; i < e; ++i)
+                            faPtr[i] = ModularField::Mul(faPtr[i], fbPtr[i]);
+                    };
+                    if ((SizeT)n >= ParallelMinSize())
+                        ParallelFor((Int)n, body);
+                    else
+                        body(0, (Int)n);
+                }
                 NTTCore::Inverse(fa, plan);
 
                 vector<DataT> c;

--- a/include/biginteger/algorithms/multiplication/NTTSquare.h
+++ b/include/biginteger/algorithms/multiplication/NTTSquare.h
@@ -169,8 +169,17 @@ namespace BigMath
 
         const NTTPlan &plan = NTTCore::GetPlan((Int)n);
         NTTCore::Forward(fa, plan);
-        for (Int i = 0; i < (Int)n; i++)
-          fa[i] = ModularField::Mul(fa[i], fa[i]);
+        {
+          ULong *faPtr = fa.data();
+          auto body = [faPtr](Int s, Int e) {
+            for (Int i = s; i < e; ++i)
+              faPtr[i] = ModularField::Mul(faPtr[i], faPtr[i]);
+          };
+          if ((SizeT)n >= ParallelMinSize())
+            ParallelFor((Int)n, body);
+          else
+            body(0, (Int)n);
+        }
         NTTCore::Inverse(fa, plan);
 
         return FinalizeBase2_32(fa, (SizeT)coeffCount);
@@ -196,8 +205,17 @@ namespace BigMath
 
         const NTTPlan &plan = NTTCore::GetPlan((Int)n);
         NTTCore::Forward(fa, plan);
-        for (Int i = 0; i < (Int)n; i++)
-          fa[i] = ModularField::Mul(fa[i], fa[i]);
+        {
+          ULong *faPtr = fa.data();
+          auto body = [faPtr](Int s, Int e) {
+            for (Int i = s; i < e; ++i)
+              faPtr[i] = ModularField::Mul(faPtr[i], faPtr[i]);
+          };
+          if ((SizeT)n >= ParallelMinSize())
+            ParallelFor((Int)n, body);
+          else
+            body(0, (Int)n);
+        }
         NTTCore::Inverse(fa, plan);
 
         return FinalizeBase2_64(fa, (SizeT)coeffCount);
@@ -214,8 +232,17 @@ namespace BigMath
 
         const NTTPlan &plan = NTTCore::GetPlan((Int)n);
         NTTCore::Forward(fa, plan);
-        for (Int i = 0; i < (Int)n; i++)
-          fa[i] = ModularField::Mul(fa[i], fa[i]);
+        {
+          ULong *faPtr = fa.data();
+          auto body = [faPtr](Int s, Int e) {
+            for (Int i = s; i < e; ++i)
+              faPtr[i] = ModularField::Mul(faPtr[i], faPtr[i]);
+          };
+          if ((SizeT)n >= ParallelMinSize())
+            ParallelFor((Int)n, body);
+          else
+            body(0, (Int)n);
+        }
         NTTCore::Inverse(fa, plan);
 
         vector<DataT> c;

--- a/include/biginteger/common/Constants.h
+++ b/include/biginteger/common/Constants.h
@@ -22,6 +22,20 @@
 #define BIGMATH_LIMB_64 1
 #endif
 
+// Opt-in internal parallelism for NTT-bound operations. When 0 (default),
+// the library is single-threaded — zero overhead. When 1, NTT Forward,
+// Inverse, and pointwise multiply use a small thread pool. See
+// docs/THREAD_SAFETY.md for the full thread-safety model.
+//
+// Pool size auto-detected at runtime, capped at BIGMATH_MAX_THREADS.
+#ifndef BIGMATH_USE_THREADS
+#define BIGMATH_USE_THREADS 0
+#endif
+
+#ifndef BIGMATH_MAX_THREADS
+#define BIGMATH_MAX_THREADS 8
+#endif
+
 namespace BigMath
 {
   typedef int64_t Long;

--- a/include/biginteger/common/Parallel.h
+++ b/include/biginteger/common/Parallel.h
@@ -1,0 +1,76 @@
+/**
+ * BigMath: Internal parallel-for helper for NTT-bound ops.
+ *
+ * Gated on BIGMATH_USE_THREADS=1. When unset (default), all calls reduce to
+ * the serial body inline — zero overhead.
+ *
+ * Implementation uses a small persistent thread pool defined in
+ * src/common/Parallel.cpp. The pool is created on first use (lazy init),
+ * sized to min(hardware_concurrency(), BIGMATH_MAX_THREADS). Each worker
+ * spins on a condition variable; dispatch latency is ~5µs per call.
+ *
+ * Public header stays free of <thread>/<mutex> includes so consumers don't
+ * pick up pthread linkage unless they opt in via BIGMATH_USE_THREADS=1.
+ *
+ * S. M. Mahbub Murshed (murshed@gmail.com)
+ */
+
+#ifndef BIGMATH_PARALLEL
+#define BIGMATH_PARALLEL
+
+#include "Util.h"
+
+namespace BigMath
+{
+#if BIGMATH_USE_THREADS
+
+  // Number of worker threads in the pool, fixed for lifetime of process.
+  // Workers + the calling thread cooperate, so effective parallelism is
+  // NumThreads() in total (workers do chunks 1..N-1, caller does chunk 0).
+  SizeT ParallelNumThreads();
+
+  // Run `body(start, end)` over chunks of [0, total). The interval is split
+  // into approximately NumThreads()-sized chunks; small `total` may use fewer
+  // chunks (or stay serial) to avoid dispatch overhead exceeding work cost.
+  //
+  // `body` must be thread-safe with respect to other concurrent invocations
+  // of itself — each chunk gets disjoint [start, end). Capture-by-reference
+  // any shared state.
+  //
+  // Threshold: if `total < ParallelMinSize()`, runs serially in the caller.
+  void ParallelFor(Int total, void (*body)(Int start, Int end, void *ctx), void *ctx);
+
+  // Convenience overload for stateful lambdas. Compiles to the same
+  // function-pointer dispatch via a trampoline.
+  template <typename F>
+  inline void ParallelFor(Int total, F &&body)
+  {
+    struct Ctx { F f; };
+    Ctx ctx{std::forward<F>(body)};
+    auto tramp = +[](Int s, Int e, void *p) {
+      static_cast<Ctx *>(p)->f(s, e);
+    };
+    ParallelFor(total, tramp, &ctx);
+  }
+
+  // Cutoff below which ParallelFor runs serially. Tuned to roughly match
+  // the per-dispatch overhead (~5µs * N threads).
+  SizeT ParallelMinSize();
+
+#else
+
+  // Stubs for the single-threaded build. Always returns 1 / runs serially.
+  inline SizeT ParallelNumThreads() { return 1; }
+  inline SizeT ParallelMinSize() { return 0; }
+
+  template <typename F>
+  inline void ParallelFor(Int total, F &&body)
+  {
+    if (total > 0)
+      body(Int{0}, total);
+  }
+
+#endif
+}
+
+#endif

--- a/src/common/Parallel.cpp
+++ b/src/common/Parallel.cpp
@@ -1,0 +1,178 @@
+/**
+ * BigMath: Internal thread pool for parallel NTT.
+ *
+ * Compiled only when BIGMATH_USE_THREADS=1. Lazy-initialized on first call.
+ * Workers spin-wait on a condition variable for low dispatch latency.
+ *
+ * S. M. Mahbub Murshed (murshed@gmail.com)
+ */
+
+#include "biginteger/common/Parallel.h"
+
+#if BIGMATH_USE_THREADS
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace BigMath
+{
+  namespace
+  {
+    class ThreadPool
+    {
+    public:
+      ThreadPool()
+      {
+        unsigned hw = std::thread::hardware_concurrency();
+        if (hw == 0) hw = 4;
+        if (hw > BIGMATH_MAX_THREADS) hw = BIGMATH_MAX_THREADS;
+        if (hw < 1) hw = 1;
+        numThreads = hw;
+
+        if (numThreads > 1)
+        {
+          workers.reserve(numThreads - 1);
+          for (SizeT i = 1; i < numThreads; ++i)
+            workers.emplace_back([this, i] { WorkerLoop((Int)i); });
+        }
+      }
+
+      ~ThreadPool()
+      {
+        {
+          std::lock_guard<std::mutex> lk(m);
+          shutdown = true;
+          generation++;
+        }
+        cv.notify_all();
+        for (auto &t : workers) t.join();
+      }
+
+      SizeT NumThreads() const { return numThreads; }
+
+      // Dispatch `numChunks` parallel calls of body(start, end). The caller
+      // thread runs chunk 0; workers 1..numChunks-1 run the others. Blocks
+      // until all chunks complete.
+      void RunChunks(Int numChunks, Int total, void (*body)(Int, Int, void *), void *ctx)
+      {
+        if (numChunks <= 1)
+        {
+          body(0, total, ctx);
+          return;
+        }
+        if ((SizeT)numChunks > numThreads) numChunks = (Int)numThreads;
+
+        // Publish work.
+        {
+          std::lock_guard<std::mutex> lk(m);
+          curBody = body;
+          curCtx = ctx;
+          curTotal = total;
+          curChunks = numChunks;
+          remaining = numChunks - 1; // caller does chunk 0
+          generation++;
+        }
+        cv.notify_all();
+
+        // Caller runs chunk 0 itself.
+        Int chunkSize = (total + numChunks - 1) / numChunks;
+        Int s0 = 0;
+        Int e0 = std::min(total, chunkSize);
+        body(s0, e0, ctx);
+
+        // Wait for workers.
+        std::unique_lock<std::mutex> lk(m);
+        doneCv.wait(lk, [this] { return remaining == 0; });
+      }
+
+    private:
+      void WorkerLoop(Int workerId)
+      {
+        Long lastSeen = 0;
+        for (;;)
+        {
+          void (*body)(Int, Int, void *) = nullptr;
+          void *ctx = nullptr;
+          Int total = 0;
+          Int chunks = 0;
+          {
+            std::unique_lock<std::mutex> lk(m);
+            cv.wait(lk, [this, &lastSeen] { return generation != lastSeen || shutdown; });
+            if (shutdown) return;
+            lastSeen = generation;
+            body = curBody;
+            ctx = curCtx;
+            total = curTotal;
+            chunks = curChunks;
+          }
+
+          if (workerId < chunks)
+          {
+            Int chunkSize = (total + chunks - 1) / chunks;
+            Int s = workerId * chunkSize;
+            Int e = std::min(total, s + chunkSize);
+            if (s < e) body(s, e, ctx);
+          }
+
+          {
+            std::lock_guard<std::mutex> lk(m);
+            if (workerId < chunks)
+              --remaining;
+          }
+          if (workerId < chunks)
+            doneCv.notify_one();
+        }
+      }
+
+      SizeT numThreads = 1;
+      std::vector<std::thread> workers;
+      std::mutex m;
+      std::condition_variable cv;
+      std::condition_variable doneCv;
+      Long generation = 0;
+      bool shutdown = false;
+
+      void (*curBody)(Int, Int, void *) = nullptr;
+      void *curCtx = nullptr;
+      Int curTotal = 0;
+      Int curChunks = 0;
+      Int remaining = 0;
+    };
+
+    ThreadPool &Pool()
+    {
+      static ThreadPool p;
+      return p;
+    }
+  }
+
+  SizeT ParallelNumThreads()
+  {
+    return Pool().NumThreads();
+  }
+
+  SizeT ParallelMinSize()
+  {
+    // Below ~4 KiB of work, dispatch overhead exceeds the parallel win.
+    return 4096;
+  }
+
+  void ParallelFor(Int total, void (*body)(Int start, Int end, void *ctx), void *ctx)
+  {
+    if (total <= 0) return;
+    SizeT n = Pool().NumThreads();
+    if (n <= 1 || (SizeT)total < ParallelMinSize())
+    {
+      body(0, total, ctx);
+      return;
+    }
+    Pool().RunChunks((Int)n, total, body, ctx);
+  }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds an opt-in internal thread pool that parallelizes NTT hot paths. Gated on \`BIGMATH_USE_THREADS=1\` at build time (default 0). When unset, all calls reduce to inline serial loops — **zero overhead for single-threaded builds**.

## Stacks on
- PR #32 (\`docs/THREAD_SAFETY.md\`) — model spec for the new internal parallelism

## Architecture

- **\`include/biginteger/common/Parallel.h\`**: forward decls + serial stubs. Does NOT pull \`<thread>\`/\`<mutex>\` into public headers at default build.
- **\`src/common/Parallel.cpp\`**: lazy-init \`ThreadPool\` with persistent workers. Pool size = \`min(hardware_concurrency(), BIGMATH_MAX_THREADS=8)\`. Workers spin on a condition variable; dispatch latency ~5µs. Caller thread participates (chunk 0); total parallelism = \`NumThreads()\`.
- **\`ParallelMinSize = 4096\`** elements; below this, \`ParallelFor\` runs the body serially.

Parallelism points:
- \`NTTCore::Forward\` / \`Inverse\`: each layer's i-blocks parallelized when \`n/2 ≥ MinSize\` and > 1 block.
- \`Inverse\` final scaling loop.
- \`NTTMultiplication\` + \`NTTSquare\` pointwise multiply.

Thread safety: leverages existing \`thread_local\` caches (NTT plans, fa/fb, Pow10) — each worker fills its own on first touch.

## Bench (M1 Max, -O3 -march=native, default 8-thread pool)

| op | single | threads | delta |
|---|---:|---:|---:|
| **mul 1M×1M** | 36.51 ms | **27.91 ms** | **−24%** |
| **mul 500k×500k** | 17.69 ms | **13.79 ms** | **−22%** |
| **mul 1M/100k skewed** | 16.06 ms | **12.38 ms** | **−23%** |
| mul 100k×100k | 3.48 ms | 3.25 ms | −7% |
| div 500k/100k | 53.69 ms | 52.62 ms | −2% |
| parse 1M | 88.20 ms | 83.36 ms | −5% |
| tostr 100k | 30.24 ms | 31.83 ms | +5% (noise) |
| **div 200k/50k** | 20.93 ms | **23.15 ms** | **+11% ↑** |

**Wins: large NTT-bound mults 22–24%.** Newton-bound div regressed at 200k/50k (+11%) because Newton's iteration sizes mostly stay below \`ParallelMinSize\` — early iters pay lambda-capture overhead without crossing the parallel threshold. Mitigation (raise threshold or skip dispatch check for Newton-internal NTT) is a follow-up tuning PR.

## Verification

- **Default (\`BIGMATH_USE_THREADS=0\`)**: 242 unit_tests pass, mult_correctness clean. No bench change vs prior master.
- **\`BIGMATH_USE_THREADS=1\`**: 242 unit_tests pass, mult_correctness clean. Bench wins above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)