### PR TITLE
feat(ntt): multi-prime CRT NTT, opt-in via BIGMATH_NTT_CRT

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -9,6 +9,7 @@
 #include "../../common/Util.h"
 #include "ClassicMultiplication.h"
 #include "NTTCore.h"
+#include "NTTMultiplicationCrt.h"
 
 using namespace std;
 
@@ -130,6 +131,13 @@ namespace BigMath
             // If a is a single digit, use the scalar multiplication
             if (a.size() == 1)
                 return ClassicMultiplication::Multiply(b, a[0], base);
+
+#if BIGMATH_NTT_CRT
+            // Multi-prime CRT NTT (three 30-bit primes, 32-bit coefficient split).
+            // Halves coefficient count vs Goldilocks at the cost of 3 parallel
+            // transforms + CRT reconstruction. See NTTMultiplicationCrt.h.
+            return NttCrt::Multiply(a, b, base);
+#endif
 
             // If the base is Base2_32, we split each 32-bit limb into two 16-bit halves
             // to avoid overflow in the 64-bit prime field.

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -1,0 +1,408 @@
+/**
+ * BigMath: Multi-prime CRT NTT multiplication.
+ *
+ * Alternate to Goldilocks NTT (NTTMultiplication.h). Three 30-bit primes
+ * (998244353, 985661441, 754974721) with 32-bit coefficient splitting:
+ * each 64-bit input limb → 2 coefficients (vs Goldilocks' 4). Halves the
+ * NTT length at the cost of 3 parallel transforms + CRT reconstruction.
+ *
+ * Trade-off vs Goldilocks:
+ *   - 3 transforms × NTT(N/2) work each = ~1.5× more transform layers,
+ *     BUT each layer runs on 32-bit modular ops (single MUL + simple
+ *     reduce) rather than ULong128 Goldilocks mul+reduce.
+ *   - Coefficients fit in 32-bit lanes → better cache density.
+ *   - Combined modulus = p1·p2·p3 ≈ 2^90, comfortably holds 32×32 product
+ *     summed over up to 2^26 ≈ 67 M coefficients.
+ *
+ * Gated on BIGMATH_NTT_CRT=1. Default off; selected at compile time in
+ * NTTMultiplication's dispatch when the macro is set.
+ *
+ * S. M. Mahbub Murshed (murshed@gmail.com)
+ */
+
+#ifndef BIGMATH_NTT_CRT
+#define BIGMATH_NTT_CRT 0
+#endif
+
+#ifndef NTT_MULTIPLICATION_CRT
+#define NTT_MULTIPLICATION_CRT
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "../../common/Parallel.h"
+#include "../../common/Util.h"
+#include "ClassicMultiplication.h"
+
+namespace BigMath
+{
+  namespace NttCrt
+  {
+    // ─── Modular field over a single 30-bit NTT prime ────────────────────────
+
+    template <UInt P>
+    struct ModField
+    {
+      static_assert(P > 0, "prime must be non-zero");
+
+      static constexpr UInt Prime = P;
+
+      static inline UInt Add(UInt a, UInt b)
+      {
+        UInt s = a + b;
+        if (s >= P) s -= P;
+        return s;
+      }
+
+      static inline UInt Sub(UInt a, UInt b)
+      {
+        // Both inputs in [0, P); diff in (-P, P); add P if negative.
+        return a >= b ? a - b : a + P - b;
+      }
+
+      static inline UInt Mul(UInt a, UInt b)
+      {
+        return (UInt)(((ULong)a * b) % P);
+      }
+
+      static UInt Power(UInt base, UInt exp)
+      {
+        UInt r = 1;
+        base %= P;
+        while (exp > 0)
+        {
+          if (exp & 1) r = Mul(r, base);
+          base = Mul(base, base);
+          exp >>= 1;
+        }
+        return r;
+      }
+
+      static UInt Inv(UInt a) { return Power(a, P - 2); }
+    };
+
+    // Three 30-bit NTT-friendly primes used for the CRT scheme.
+    // Each P-1 is divisible by a large power of 2, supporting NTT lengths up
+    // to that power (p1: 2^23, p2: 2^22, p3: 2^24).
+    constexpr UInt P1 = 998244353;
+    constexpr UInt P2 = 985661441;
+    constexpr UInt P3 = 754974721;
+    constexpr UInt G1 = 3;
+    constexpr UInt G2 = 3;
+    constexpr UInt G3 = 11;
+
+    using F1 = ModField<P1>;
+    using F2 = ModField<P2>;
+    using F3 = ModField<P3>;
+
+    // ─── NTT core templated by ModField ──────────────────────────────────────
+
+    template <typename F>
+    struct Plan
+    {
+      std::vector<UInt> forwardRoots;
+      std::vector<UInt> inverseRoots;
+      UInt invSize = 1;
+    };
+
+    template <typename F, UInt G>
+    inline std::vector<UInt> BuildRoots(Int n, bool invert)
+    {
+      UInt root = F::Power(G, (F::Prime - 1) / (UInt)n);
+      if (invert) root = F::Inv(root);
+      std::vector<UInt> r(n / 2);
+      r[0] = 1;
+      for (Int k = 1; k < n / 2; ++k) r[k] = F::Mul(r[k - 1], root);
+      return r;
+    }
+
+    template <typename F, UInt G>
+    inline Plan<F> BuildPlan(Int n)
+    {
+      Plan<F> p;
+      p.forwardRoots = BuildRoots<F, G>(n, false);
+      p.inverseRoots = BuildRoots<F, G>(n, true);
+      p.invSize = F::Inv((UInt)n);
+      return p;
+    }
+
+    template <typename F, UInt G>
+    inline const Plan<F> &GetPlan(Int n)
+    {
+      static thread_local std::unordered_map<Int, Plan<F>> cache;
+      auto it = cache.find(n);
+      if (it != cache.end()) return it->second;
+      return cache.emplace(n, BuildPlan<F, G>(n)).first->second;
+    }
+
+    template <typename F>
+    inline void Forward(std::vector<UInt> &a, const Plan<F> &plan)
+    {
+      Int n = (Int)a.size();
+      const UInt *roots = plan.forwardRoots.data();
+      for (Int len = n; len > 1; len >>= 1)
+      {
+        Int halflen = len >> 1;
+        Int stride = n / len;
+        Int numBlocks = n / len;
+        UInt *aPtr = a.data();
+        auto body = [aPtr, halflen, len, stride, roots](Int bStart, Int bEnd) {
+          for (Int b = bStart; b < bEnd; ++b)
+          {
+            Int i = b * len;
+            for (Int j = 0; j < halflen; ++j)
+            {
+              UInt u = aPtr[i + j];
+              UInt v = aPtr[i + j + halflen];
+              aPtr[i + j] = F::Add(u, v);
+              aPtr[i + j + halflen] = F::Mul(F::Sub(u, v), roots[j * stride]);
+            }
+          }
+        };
+        if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
+          ParallelFor(numBlocks, body);
+        else
+          body(0, numBlocks);
+      }
+    }
+
+    template <typename F>
+    inline void Inverse(std::vector<UInt> &a, const Plan<F> &plan)
+    {
+      Int n = (Int)a.size();
+      const UInt *roots = plan.inverseRoots.data();
+      for (Int len = 2; len <= n; len <<= 1)
+      {
+        Int halflen = len >> 1;
+        Int stride = n / len;
+        Int numBlocks = n / len;
+        UInt *aPtr = a.data();
+        auto body = [aPtr, halflen, len, stride, roots](Int bStart, Int bEnd) {
+          for (Int b = bStart; b < bEnd; ++b)
+          {
+            Int i = b * len;
+            for (Int j = 0; j < halflen; ++j)
+            {
+              UInt u = aPtr[i + j];
+              UInt v = F::Mul(aPtr[i + j + halflen], roots[j * stride]);
+              aPtr[i + j] = F::Add(u, v);
+              aPtr[i + j + halflen] = F::Sub(u, v);
+            }
+          }
+        };
+        if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
+          ParallelFor(numBlocks, body);
+        else
+          body(0, numBlocks);
+      }
+
+      UInt *aPtr = a.data();
+      UInt invSize = plan.invSize;
+      auto scale = [aPtr, invSize](Int s, Int e) {
+        for (Int i = s; i < e; ++i) aPtr[i] = F::Mul(aPtr[i], invSize);
+      };
+      if ((SizeT)n >= ParallelMinSize())
+        ParallelFor(n, scale);
+      else
+        scale(0, n);
+    }
+
+    // ─── Garner CRT reconstruction ───────────────────────────────────────────
+    //
+    // Given residues r1, r2, r3 with r_i = x mod p_i, recover x in
+    // [0, p1·p2·p3). Output as (low64, mid64, high64) for downstream carry
+    // propagation; total bit-width ≈ 90, fits two 64-bit words.
+
+    struct InvTable
+    {
+      UInt p1_inv_mod_p2;  // p1^-1 mod p2
+      UInt p1_inv_mod_p3;  // p1^-1 mod p3
+      UInt p2_inv_mod_p3;  // p2^-1 mod p3
+      ULong p1_long = P1;
+      ULong128 p1p2 = (ULong128)P1 * P2;
+    };
+
+    inline const InvTable &GarnerInverses()
+    {
+      static const InvTable inv = []() {
+        InvTable t;
+        t.p1_inv_mod_p2 = F2::Inv(P1 % P2);
+        t.p1_inv_mod_p3 = F3::Inv(P1 % P3);
+        t.p2_inv_mod_p3 = F3::Inv(P2 % P3);
+        return t;
+      }();
+      return inv;
+    }
+
+    // Reconstruct full convolution coefficient from three residues.
+    // Returns the value as ULong128 (fits in ~90 bits comfortably).
+    inline ULong128 Garner(UInt r1, UInt r2, UInt r3, const InvTable &inv)
+    {
+      // u1 = r1                                  (mod p1)
+      // u2 = (r2 - r1) * p1^-1                   (mod p2)
+      // u3 = ((r3 - r1) * p1^-1 - u2) * p2^-1    (mod p3)
+      // x  = u1 + p1*u2 + p1*p2*u3
+      UInt u1 = r1;
+
+      UInt diff2 = F2::Sub(r2 % P2, r1 % P2);
+      UInt u2 = F2::Mul(diff2, inv.p1_inv_mod_p2);
+
+      UInt diff3 = F3::Sub(r3 % P3, r1 % P3);
+      UInt tmp = F3::Mul(diff3, inv.p1_inv_mod_p3);
+      UInt u3 = F3::Mul(F3::Sub(tmp, u2 % P3), inv.p2_inv_mod_p3);
+
+      return (ULong128)u1 + (ULong128)P1 * u2 + inv.p1p2 * u3;
+    }
+
+    // ─── Public Multiply ─────────────────────────────────────────────────────
+
+    inline std::vector<DataT> Multiply(const std::vector<DataT> &a,
+                                       const std::vector<DataT> &b,
+                                       BaseT base)
+    {
+      if (IsZero(a) || IsZero(b)) return std::vector<DataT>();
+      if (a.size() == 1) return ClassicMultiplication::Multiply(b, a[0], base);
+      if (b.size() == 1) return ClassicMultiplication::Multiply(a, b[0], base);
+
+      // Split into 32-bit coefficients. Works for Base2_32 (1 coeff per limb)
+      // and Base2_64 (2 coeffs per limb). Pre-CRT bounds: each coefficient is
+      // < 2^32, convolution sum at length N is < N · 2^64.
+      bool b64 = (base == Base2_64);
+      SizeT coeffsPerLimb = b64 ? 2u : 1u;
+
+      ULong aCoeffSize = (ULong)a.size() * coeffsPerLimb;
+      ULong bCoeffSize = (ULong)b.size() * coeffsPerLimb;
+      ULong coeffCount = aCoeffSize + bCoeffSize - 1;
+      Int n = (Int)std::bit_ceil(coeffCount);
+
+      // Three parallel transforms.
+      static thread_local std::vector<UInt> fa1, fb1, fa2, fb2, fa3, fb3;
+      fa1.assign(n, 0); fb1.assign(n, 0);
+      fa2.assign(n, 0); fb2.assign(n, 0);
+      fa3.assign(n, 0); fb3.assign(n, 0);
+
+      auto pack = [&](const std::vector<DataT> &v, std::vector<UInt> &dst1,
+                      std::vector<UInt> &dst2, std::vector<UInt> &dst3) {
+        if (b64)
+        {
+          for (SizeT i = 0; i < v.size(); ++i)
+          {
+            SizeT j = i * 2;
+            UInt lo = (UInt)(v[i] & 0xFFFFFFFFULL);
+            UInt hi = (UInt)((v[i] >> 32) & 0xFFFFFFFFULL);
+            dst1[j]     = lo % P1; dst1[j + 1] = hi % P1;
+            dst2[j]     = lo % P2; dst2[j + 1] = hi % P2;
+            dst3[j]     = lo % P3; dst3[j + 1] = hi % P3;
+          }
+        }
+        else
+        {
+          // Base2_32: each limb is already a 32-bit value.
+          for (SizeT i = 0; i < v.size(); ++i)
+          {
+            UInt vv = (UInt)v[i];
+            dst1[i] = vv % P1;
+            dst2[i] = vv % P2;
+            dst3[i] = vv % P3;
+          }
+        }
+      };
+
+      pack(a, fa1, fa2, fa3);
+      pack(b, fb1, fb2, fb3);
+
+      const auto &plan1 = GetPlan<F1, G1>(n);
+      const auto &plan2 = GetPlan<F2, G2>(n);
+      const auto &plan3 = GetPlan<F3, G3>(n);
+
+      Forward<F1>(fa1, plan1); Forward<F1>(fb1, plan1);
+      Forward<F2>(fa2, plan2); Forward<F2>(fb2, plan2);
+      Forward<F3>(fa3, plan3); Forward<F3>(fb3, plan3);
+
+      {
+        UInt *p1a = fa1.data(), *p1b = fb1.data();
+        UInt *p2a = fa2.data(), *p2b = fb2.data();
+        UInt *p3a = fa3.data(), *p3b = fb3.data();
+        auto body = [p1a, p1b, p2a, p2b, p3a, p3b](Int s, Int e) {
+          for (Int i = s; i < e; ++i)
+          {
+            p1a[i] = F1::Mul(p1a[i], p1b[i]);
+            p2a[i] = F2::Mul(p2a[i], p2b[i]);
+            p3a[i] = F3::Mul(p3a[i], p3b[i]);
+          }
+        };
+        if ((SizeT)n >= ParallelMinSize()) ParallelFor(n, body);
+        else body(0, n);
+      }
+
+      Inverse<F1>(fa1, plan1);
+      Inverse<F2>(fa2, plan2);
+      Inverse<F3>(fa3, plan3);
+
+      // CRT reconstruct + propagate carries into output limbs.
+      const InvTable &inv = GarnerInverses();
+      std::vector<DataT> result;
+      result.reserve(a.size() + b.size() + 2);
+
+      if (b64)
+      {
+        // 2 coefficients per output limb, each 32 bits → 64-bit limb. Carry
+        // propagation needs more than the per-coeff width; use ULong128.
+        ULong128 carry = 0;
+        ULong limb_acc = 0;
+        int slot = 0;
+        auto flush = [&result, &limb_acc, &slot](bool force) {
+          if (slot == 2 || (force && slot != 0))
+          {
+            result.push_back((DataT)limb_acc);
+            limb_acc = 0;
+            slot = 0;
+          }
+        };
+        for (SizeT i = 0; i < (SizeT)coeffCount; ++i)
+        {
+          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
+          ULong digit = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+          limb_acc |= digit << (slot * 32);
+          ++slot;
+          flush(false);
+        }
+        while (carry > 0)
+        {
+          ULong digit = (ULong)(carry & 0xFFFFFFFFULL);
+          carry >>= 32;
+          limb_acc |= digit << (slot * 32);
+          ++slot;
+          flush(false);
+        }
+        flush(true);
+      }
+      else
+      {
+        // Base2_32: 1 coefficient per output limb (already 32-bit).
+        ULong128 carry = 0;
+        for (SizeT i = 0; i < (SizeT)coeffCount; ++i)
+        {
+          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
+          result.push_back((DataT)(total & 0xFFFFFFFFULL));
+          carry = total >> 32;
+        }
+        while (carry > 0)
+        {
+          result.push_back((DataT)(carry & 0xFFFFFFFFULL));
+          carry >>= 32;
+        }
+      }
+
+      TrimZeros(result);
+      return result;
+    }
+  } // namespace NttCrt
+} // namespace BigMath
+
+#endif


### PR DESCRIPTION
## Summary

Adds an alternate NTT multiplication path using 3-prime CRT with 32-bit coefficient splitting. Gated on \`BIGMATH_NTT_CRT=1\`; default off, Goldilocks NTT remains the default.

Implements the design from [\`DIVISION.md §Improving skewed division beyond the current floor\`](docs/DIVISION.md#improving-skewed-division-beyond-the-current-floor) §"Faster NTT kernel — multi-prime CRT with 32-bit coefficients".

## Primes (all 30-bit, NTT-friendly)

| prime | factorization | generator |
|---:|---|---:|
| 998 244 353 | 119·2²³ + 1 | 3 |
| 985 661 441 | 235·2²² + 1 | 3 |
| 754 974 721 | 45·2²⁴ + 1 | 11 |

Combined modulus p1·p2·p3 ≈ 2⁹⁰ — comfortably holds 32×32 product summed over up to 2²⁶ ≈ 67M coefficients.

## Trade-offs

- **Coefficient packing**: Goldilocks does 4× 16-bit per 64-bit limb; CRT does 2× 32-bit per limb. NTT length halved.
- **Per-op cost**: 30-bit modular ops are much cheaper than ULong128 Goldilocks reduce. Cheaper enough that 3× transform count is net win.
- **CRT reconstruction**: per-coefficient Garner reconstruction with precomputed modular inverses, output as `ULong128` (≤ 90 bits).

## Bench vs Goldilocks (LIMB_64=1 default, M1 Max, -O3 -march=native)

| op | Goldilocks | CRT | delta |
|---|---:|---:|---:|
| mul 100k×100k | 3.48 ms | 3.44 ms | −1% |
| mul 500k×500k | 17.69 ms | **15.90 ms** | **−10%** |
| **mul 1M×1M** | **36.51 ms** | **33.53 ms** | **−8%** |
| mul 100k/10k skewed | 1.67 ms | 1.41 ms | **−15%** |
| mul 500k/50k skewed | 7.60 ms | 6.71 ms | −12% |
| mul 1M/100k skewed | 16.06 ms | 14.41 ms | −10% |
| **div 200k/50k skewed** | **20.93 ms** | **18.33 ms** | **−12%** |
| **div 500k/100k skewed** | **53.69 ms** | **47.61 ms** | **−11%** |
| parse 100k | 4.41 ms | 4.11 ms | −7% |
| parse 1M | 88.20 ms | 81.73 ms | −7% |
| tostr 100k | 30.24 ms | 28.95 ms | −4% |

The skewed-div floor cases (the original target) win 11–12%, matching the doc's predicted 1.10–1.18× end-to-end speedup (the 1.3–1.5× was for the NTT kernel itself; end-to-end is diluted by non-NTT overhead in Newton's outer loops).

## CRT + threads (combined)

Tested but **regresses** on division: 3× more thread dispatches per multiplication compound the per-call overhead at the small-to-mid NTT sizes Newton iterates through.

| op | Goldilocks | CRT | threads | CRT+threads |
|---|---:|---:|---:|---:|
| mul 1M×1M | 36.5 | 33.5 | **27.9** | 31.1 |
| div 200k/50k | 20.9 | **18.3** | 23.2 | 30.1 |
| div 500k/100k | 53.7 | **47.6** | 52.6 | 66.6 |

Pick **one** flag based on workload: CRT for div/parse heavy, threads for large-mult-dominant.

## Verification

- **Default (\`BIGMATH_NTT_CRT=0\`)**: 242 unit_tests pass, mult_correctness clean. Bench unchanged vs prior master.
- **\`BIGMATH_NTT_CRT=1\`**: 242 unit_tests pass, mult_correctness clean (including max-carry 257×257 and unbalanced 513×17 stress cases). Wins above.

## Implementation

Single new header \`include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h\` (~400 lines):
- Templated \`ModField<P>\` with `Add/Sub/Mul/Power/Inv`
- Generic templated \`Forward<F>\` / \`Inverse<F>\` mirroring \`NTTCore\` structure (also parallelism-aware)
- Garner CRT reconstruction with cached modular inverses
- Top-level \`NttCrt::Multiply\` handling pack/transform/pointwise/inverse/CRT/finalize

Dispatch in \`NTTMultiplication::Multiply\` short-circuits to \`NttCrt::Multiply\` when the macro is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)