### PR TITLE
tune: lower BIGMATH_NTT_CRT_THRESHOLD default 10000 → 5000

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -133,12 +133,16 @@ namespace BigMath
                 return ClassicMultiplication::Multiply(b, a[0], base);
 
 #if BIGMATH_NTT_CRT
-            // Size-gated hybrid: CRT wins on large NTT-bound ops where its
-            // per-op savings outweigh the 3× transform overhead. Below the
-            // threshold, Goldilocks wins (notably mul 50k×50k +18% with CRT).
-            // Tuned 2026-05 on M1 Max; override via -DBIGMATH_NTT_CRT_THRESHOLD=N.
+            // Size-gated hybrid. Crossover measured via direct NTT-vs-CRT
+            // sweep (min of 7 iters per case, M1 Max, -O3 -march=native):
+            //   sum=4000   Goldilocks wins big (0.76 vs 1.24 ms = 1.6× faster)
+            //   sum=6000   CRT wins (2.12 vs 1.70 ms = 1.24×)
+            //   sum=8000   CRT wins (1.73 vs 1.49 ms = 1.16×)
+            //   sum≥10000  tie within 1-2%
+            // Threshold 5000 catches the 6000-8000 wins without admitting
+            // the sum=4000 regression. Override via -DBIGMATH_NTT_CRT_THRESHOLD=N.
 #ifndef BIGMATH_NTT_CRT_THRESHOLD
-#define BIGMATH_NTT_CRT_THRESHOLD 10000
+#define BIGMATH_NTT_CRT_THRESHOLD 5000
 #endif
             if (a.size() + b.size() >= BIGMATH_NTT_CRT_THRESHOLD)
                 return NttCrt::Multiply(a, b, base);


### PR DESCRIPTION
## Summary

Tunes the CRT vs Goldilocks crossover from a noisy choice (10000 from \`bench_vs_gmp\`) to a measured one (5000 from a direct min-of-7 sweep).

## Sweep result

Direct \`NTTMultiplication::Multiply\` vs \`NttCrt::Multiply\` at each size, min of 7 iters, warmed caches:

| a+b limbs | Goldilocks | CRT | speedup | winner |
|---:|---:|---:|---:|---|
| **4000** | 0.76 ms | 1.24 ms | 0.61× | **Goldilocks** (CRT −39%) |
| **6000** | 2.12 ms | 1.70 ms | 1.24× | **CRT** |
| **8000** | 1.73 ms | 1.49 ms | 1.16× | **CRT** |
| ≥10000 | tied within 1–2% | | | tie |

Threshold 5000 admits the 6000–8000 CRT wins without dragging in the sum=4000 regression.

## bench_vs_gmp deltas vs threshold=10000

| op | @10k | @5k | delta |
|---|---:|---:|---:|
| mul 100k/10k skewed | 1.59 ms | **1.42 ms** | **−11%** (matches always-CRT) |
| div 200k/50k | 20.31 ms | **18.78 ms** | **−8%** |
| div 500k/100k | 48.71 ms | **47.83 ms** | −2% |
| parse 1M | 83.95 ms | **81.46 ms** | −3% |
| tostr 100k | 29.83 ms | **28.70 ms** | −4% |

## Verification
- Default \`BIGMATH_NTT_CRT=0\` unchanged: 242 unit_tests pass, mult_correctness clean
- \`BIGMATH_NTT_CRT=1\` with new default 5000: 242 unit_tests pass, mult_correctness clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)