### PR TITLE
refactor(ntt): flip BIGMATH_NTT_CRT default 0 → 1

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -20,8 +20,12 @@
  * S. M. Mahbub Murshed (murshed@gmail.com)
  */
 
+// Default: CRT NTT enabled via size-gated dispatch (threshold 5000 limbs
+// sum). Wins 5-15% on large mul / skewed div / parse / ToString when the
+// combined operand size crosses the gate. Below the gate, Goldilocks NTT
+// runs as before — zero-cost fall-through. Opt out via -DBIGMATH_NTT_CRT=0.
 #ifndef BIGMATH_NTT_CRT
-#define BIGMATH_NTT_CRT 0
+#define BIGMATH_NTT_CRT 1
 #endif
 
 #ifndef NTT_MULTIPLICATION_CRT


### PR DESCRIPTION
## Summary

CRT NTT becomes the default. Goldilocks remains available for the sub-threshold band (sum < 5000 limbs) via the size-gated dispatch, so this is a strict superset of the prior behavior — no measured case is worse than what users got at the old default.

## Bench vs prior Goldilocks-default (LIMB_64=1, M1 Max, -O3 -march=native)

| op | Goldilocks | CRT default | delta | vs GMP |
|---|---:|---:|---:|---:|
| mul 500k×500k | 17.69 ms | 16.25 ms | **−8%** | 3.57× |
| mul 1M×1M | 36.51 ms | **34.36 ms** | **−6%** | 3.77× |
| mul 100k/10k skewed | 1.67 ms | **1.42 ms** | **−15%** | 4.75× |
| mul 500k/50k skewed | 7.60 ms | 6.69 ms | **−12%** | 2.96× |
| mul 1M/100k skewed | 16.06 ms | 14.61 ms | **−9%** | 2.96× |
| div 200k/50k skewed | 20.93 ms | **18.78 ms** | **−10%** | 11.00× |
| div 500k/100k skewed | 53.69 ms | **47.83 ms** | **−11%** | 10.54× |
| parse 100k | 4.41 ms | 4.11 ms | −7% | 3.93× |
| parse 1M | 88.20 ms | **81.46 ms** | **−8%** | 3.99× |
| tostr 100k | 30.24 ms | **28.70 ms** | **−5%** | 12.20× |

Best ratios vs GMP this codebase has seen.

## Opt-out

\`-DBIGMATH_NTT_CRT=0\` reverts to single-prime Goldilocks for all NTT calls.

## Verification
- **Default (\`BIGMATH_NTT_CRT=1\`)**: 242 unit_tests, mult_correctness clean, divperf_simple match=1 across all 4 cases
- **Opt-out (\`BIGMATH_NTT_CRT=0\`)**: 242 unit_tests, mult_correctness clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)