### PR TITLE
feat(threads): fix dispatch regression + cross-prime CRT parallelism (2-3× wins)

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -143,34 +143,33 @@ namespace BigMath
       return cache.emplace(n, BuildPlan<F, G>(n)).first->second;
     }
 
+    // Always-serial Forward/Inverse. Parallelism in the CRT path is coarse-
+    // grained: NttCrt::Multiply dispatches the 6 transforms (3 forward of a,
+    // 3 forward of b) and 3 inverses as batched ParallelFor work units, one
+    // per prime. Layer-level parallelism inside a single NTT was tried (see
+    // git history) but the per-layer dispatch overhead (~30µs × log2(n)) at
+    // sub-megabyte NTT sizes exceeded the parallel win. Coarse-grained
+    // parallelism amortizes ~3 dispatches per Multiply across 3-6 work units.
     template <typename F>
     inline void Forward(std::vector<UInt> &a, const Plan<F> &plan)
     {
       Int n = (Int)a.size();
       const UInt *roots = plan.forwardRoots.data();
+      UInt *aPtr = a.data();
       for (Int len = n; len > 1; len >>= 1)
       {
         Int halflen = len >> 1;
         Int stride = n / len;
-        Int numBlocks = n / len;
-        UInt *aPtr = a.data();
-        auto body = [aPtr, halflen, len, stride, roots](Int bStart, Int bEnd) {
-          for (Int b = bStart; b < bEnd; ++b)
+        for (Int i = 0; i < n; i += len)
+        {
+          for (Int j = 0; j < halflen; ++j)
           {
-            Int i = b * len;
-            for (Int j = 0; j < halflen; ++j)
-            {
-              UInt u = aPtr[i + j];
-              UInt v = aPtr[i + j + halflen];
-              aPtr[i + j] = F::Add(u, v);
-              aPtr[i + j + halflen] = F::Mul(F::Sub(u, v), roots[j * stride]);
-            }
+            UInt u = aPtr[i + j];
+            UInt v = aPtr[i + j + halflen];
+            aPtr[i + j] = F::Add(u, v);
+            aPtr[i + j + halflen] = F::Mul(F::Sub(u, v), roots[j * stride]);
           }
-        };
-        if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
-          ParallelFor(numBlocks, body);
-        else
-          body(0, numBlocks);
+        }
       }
     }
 
@@ -179,40 +178,25 @@ namespace BigMath
     {
       Int n = (Int)a.size();
       const UInt *roots = plan.inverseRoots.data();
+      UInt *aPtr = a.data();
       for (Int len = 2; len <= n; len <<= 1)
       {
         Int halflen = len >> 1;
         Int stride = n / len;
-        Int numBlocks = n / len;
-        UInt *aPtr = a.data();
-        auto body = [aPtr, halflen, len, stride, roots](Int bStart, Int bEnd) {
-          for (Int b = bStart; b < bEnd; ++b)
+        for (Int i = 0; i < n; i += len)
+        {
+          for (Int j = 0; j < halflen; ++j)
           {
-            Int i = b * len;
-            for (Int j = 0; j < halflen; ++j)
-            {
-              UInt u = aPtr[i + j];
-              UInt v = F::Mul(aPtr[i + j + halflen], roots[j * stride]);
-              aPtr[i + j] = F::Add(u, v);
-              aPtr[i + j + halflen] = F::Sub(u, v);
-            }
+            UInt u = aPtr[i + j];
+            UInt v = F::Mul(aPtr[i + j + halflen], roots[j * stride]);
+            aPtr[i + j] = F::Add(u, v);
+            aPtr[i + j + halflen] = F::Sub(u, v);
           }
-        };
-        if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
-          ParallelFor(numBlocks, body);
-        else
-          body(0, numBlocks);
+        }
       }
 
-      UInt *aPtr = a.data();
       UInt invSize = plan.invSize;
-      auto scale = [aPtr, invSize](Int s, Int e) {
-        for (Int i = s; i < e; ++i) aPtr[i] = F::Mul(aPtr[i], invSize);
-      };
-      if ((SizeT)n >= ParallelMinSize())
-        ParallelFor(n, scale);
-      else
-        scale(0, n);
+      for (Int i = 0; i < n; ++i) aPtr[i] = F::Mul(aPtr[i], invSize);
     }
 
     // ─── Garner CRT reconstruction ───────────────────────────────────────────

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -307,9 +307,34 @@ namespace BigMath
       const auto &plan2 = GetPlan<F2, G2>(n);
       const auto &plan3 = GetPlan<F3, G3>(n);
 
+#if BIGMATH_USE_THREADS
+      // Cross-prime parallelism: 6 forwards as one batch.
+      {
+        std::vector<UInt> *bufs[6] = {&fa1, &fb1, &fa2, &fb2, &fa3, &fb3};
+        const Plan<F1> *p1 = &plan1;
+        const Plan<F2> *p2 = &plan2;
+        const Plan<F3> *p3 = &plan3;
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Forward<F1>(*bufs[0], *p1); break;
+              case 1: Forward<F1>(*bufs[1], *p1); break;
+              case 2: Forward<F2>(*bufs[2], *p2); break;
+              case 3: Forward<F2>(*bufs[3], *p2); break;
+              case 4: Forward<F3>(*bufs[4], *p3); break;
+              case 5: Forward<F3>(*bufs[5], *p3); break;
+            }
+          }
+        };
+        ParallelDo(6, body);
+      }
+#else
       Forward<F1>(fa1, plan1); Forward<F1>(fb1, plan1);
       Forward<F2>(fa2, plan2); Forward<F2>(fb2, plan2);
       Forward<F3>(fa3, plan3); Forward<F3>(fb3, plan3);
+#endif
 
       {
         UInt *p1a = fa1.data(), *p1b = fb1.data();
@@ -327,9 +352,30 @@ namespace BigMath
         else body(0, n);
       }
 
+#if BIGMATH_USE_THREADS
+      {
+        std::vector<UInt> *bufs[3] = {&fa1, &fa2, &fa3};
+        const Plan<F1> *p1 = &plan1;
+        const Plan<F2> *p2 = &plan2;
+        const Plan<F3> *p3 = &plan3;
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Inverse<F1>(*bufs[0], *p1); break;
+              case 1: Inverse<F2>(*bufs[1], *p2); break;
+              case 2: Inverse<F3>(*bufs[2], *p3); break;
+            }
+          }
+        };
+        ParallelDo(3, body);
+      }
+#else
       Inverse<F1>(fa1, plan1);
       Inverse<F2>(fa2, plan2);
       Inverse<F3>(fa3, plan3);
+#endif
 
       // CRT reconstruct + propagate carries into output limbs.
       const InvTable &inv = GarnerInverses();

--- a/include/biginteger/common/Parallel.h
+++ b/include/biginteger/common/Parallel.h
@@ -57,6 +57,23 @@ namespace BigMath
   // the per-dispatch overhead (~5µs * N threads).
   SizeT ParallelMinSize();
 
+  // ParallelDo: dispatch numTasks chunks unconditionally (bypass MinSize).
+  // For coarse-grained parallelism where each task is large enough that
+  // dispatch overhead is irrelevant — e.g. running 3 independent NTTs in
+  // parallel, one per prime.
+  void ParallelDo(Int numTasks, void (*body)(Int start, Int end, void *ctx), void *ctx);
+
+  template <typename F>
+  inline void ParallelDo(Int numTasks, F &&body)
+  {
+    struct Ctx { F f; };
+    Ctx ctx{std::forward<F>(body)};
+    auto tramp = +[](Int s, Int e, void *p) {
+      static_cast<Ctx *>(p)->f(s, e);
+    };
+    ParallelDo(numTasks, tramp, &ctx);
+  }
+
 #else
 
   // Stubs for the single-threaded build. Always returns 1 / runs serially.
@@ -68,6 +85,13 @@ namespace BigMath
   {
     if (total > 0)
       body(Int{0}, total);
+  }
+
+  template <typename F>
+  inline void ParallelDo(Int numTasks, F &&body)
+  {
+    if (numTasks > 0)
+      body(Int{0}, numTasks);
   }
 
 #endif

--- a/src/common/Parallel.cpp
+++ b/src/common/Parallel.cpp
@@ -158,8 +158,18 @@ namespace BigMath
 
   SizeT ParallelMinSize()
   {
-    // Below ~4 KiB of work, dispatch overhead exceeds the parallel win.
-    return 4096;
+    // Tuned from sample(1) profile of div 200k/50k under threads (was 4096):
+    // psynch_cvwait dominated at 42K samples vs ~5K for actual NTT work.
+    // Root cause: NTT has log2(n) layers per transform; each layer does one
+    // ParallelFor dispatch costing ~30µs. CRT does 6 transforms × ~13 layers
+    // ≈ 78 dispatches per Multiply, totalling ~2.3ms overhead — exceeds the
+    // 1.5ms actual work at small NTT sizes.
+    //
+    // Raising to 65536 limits layer-parallelism to very large NTTs where the
+    // per-layer work amortizes the dispatch overhead. Preserves large-mul
+    // wins (1M×1M had layers ≥ 262144 ops) while eliminating regression on
+    // small-to-mid NTTs.
+    return 65536;
   }
 
   void ParallelFor(Int total, void (*body)(Int start, Int end, void *ctx), void *ctx)
@@ -172,6 +182,20 @@ namespace BigMath
       return;
     }
     Pool().RunChunks((Int)n, total, body, ctx);
+  }
+
+  void ParallelDo(Int numTasks, void (*body)(Int start, Int end, void *ctx), void *ctx)
+  {
+    if (numTasks <= 0) return;
+    SizeT n = Pool().NumThreads();
+    if (n <= 1)
+    {
+      body(0, numTasks, ctx);
+      return;
+    }
+    // Use min(numTasks, pool size) chunks so each thread gets ~1 task.
+    Int chunks = (Int)std::min((SizeT)numTasks, n);
+    Pool().RunChunks(chunks, numTasks, body, ctx);
   }
 }
 


### PR DESCRIPTION
## Summary

Two-step PR. First fixes the threading regression (added by PR #32) on division-heavy workloads. Then adds cross-prime parallelism for the CRT NTT path (default since PR #37), turning threading from a regression into a 2-3× win.

## Step 1: regression fix (commit 1)

\`sample(1)\` profile of div 200k/50k under threads showed \`__psynch_cvwait\` dominating (42K samples vs ~5K for actual NTT work). Per-NTT-layer ParallelFor dispatches × 6 transforms in CRT × ~13-18 layers = **100+ dispatches per Multiply**, ~2-3ms overhead exceeding the 1.5-2ms actual work.

Fix: \`ParallelMinSize\` 4096 → 65536 + remove in-layer ParallelFor from CRT NTT. Restored baseline (no regression).

## Step 2: cross-prime parallelism (commit 2)

The per-layer parallelism was the wrong granularity. Right approach: dispatch the 6 forwards + 3 inverses as **batched work units** — 1 dispatch per phase, 2 phases per Multiply.

Bug isolated during implementation: lambda \`[&]\` capture-by-reference broke when moved into the trampoline \`Ctx\` struct. Fix: explicit value capture \`[bufs, p1, p2, p3]\`.

## Bench vs serial baseline (\`BIGMATH_USE_THREADS=1\`, M1 Max)

| op | serial | threaded xp | speedup |
|---|---:|---:|---:|
| mul 100k×100k | 3.48 ms | **1.16 ms** | **3.0×** |
| mul 500k×500k | 17.69 ms | **6.60 ms** | **2.7×** |
| mul 1M×1M | 36.51 ms | **12.85 ms** | **2.8×** |
| mul 100k/10k skewed | 1.67 ms | **0.55 ms** | **3.0×** |
| mul 500k/50k skewed | 7.60 ms | **2.25 ms** | **3.4×** |
| mul 1M/100k skewed | 16.06 ms | **4.91 ms** | **3.3×** |
| **div 200k/50k** | 20.93 ms | **9.21 ms** | **2.3×** |
| **div 500k/100k** | 53.69 ms | **18.93 ms** | **2.8×** |
| parse 1M | 88.20 ms | 48.29 ms | 1.8× |
| tostr 100k | 30.24 ms | 23.06 ms | 1.3× |

vs GMP after fix:
- mul 1M×1M: **1.41×** (was 3.77×, session-start Goldilocks 4.2×)
- div 500k/100k: **4.19×** (was 10.54×, session-start 12×)
- div 200k/50k: **5.48×** (was 12.4×, session-start 14×)

**Best ratios this codebase has ever achieved against GMP.**

## Verification

- Default (no threads): 242 unit_tests, mult_correctness clean
- \`BIGMATH_USE_THREADS=1\`: 242 unit_tests, mult_correctness clean (incl. 100k digits stress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)