### PR TITLE
docs: refresh README + STRING_CONVERSION for 2026-05 default stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # BigMath
 
-Arbitrary-precision integer library in C++20. Header-light with a thin static-library shell. Goldilocks-prime NTT multiplication, Newton–Raphson division, divide-and-conquer base conversion. Includes a REPL calculator built on top.
+Arbitrary-precision integer library in C++20. Header-light with a thin static-library shell. 64-bit limbs, 3-prime CRT NTT multiplication (multithreaded by default), Newton–Raphson division with cached reciprocals, divide-and-conquer base conversion. Includes a REPL calculator built on top.
 
-Target: pure C++ that gets within 2–6× of GMP across the typical workload, without dropping to platform-specific assembly.
+Target: pure C++ that matches GMP on skewed multiplication and gets within 1.4-5× on the rest, without dropping to platform-specific assembly.
 
 ---
 
 ## Features
 
-- **Multiplication:** Classic schoolbook → Karatsuba (64-bit hybrid leaf) → NTT with the Goldilocks prime `2⁶⁴ − 2³² + 1`. Single dispatcher in `algorithms/Multiplication.h` picks by operand size.
-- **Division:** Classic short division → Knuth Algorithm D (`FastDivision`) → Burnikel–Ziegler (balanced large) → Newton–Raphson with reciprocal caching (skewed large). Identity `q·b + r == a` is cross-checked in `tests/div_correctness.cpp`.
+- **64-bit limb representation** (`BIGMATH_LIMB_64=1`, default). `DataT` stores true 64-bit values; every carry/borrow chain uses `__uint128_t` accumulators. Halves loop iteration counts in scalar paths vs the legacy 32-bit-in-64-bit layout. Opt out via `-DBIGMATH_LIMB_64=0`.
+- **Multiplication:** Classic schoolbook → Karatsuba (64-bit-hybrid leaf) → 3-prime CRT NTT (998244353 / 985661441 / 754974721, 30-bit primes, 32-bit coefficient splitting) gated above 5000 limbs sum; Goldilocks NTT for smaller cases. Single dispatcher in `algorithms/Multiplication.h` picks by operand size.
+- **Multithreaded NTT** (`BIGMATH_USE_THREADS=1`, default). Small thread pool (size `min(hw_concurrency, BIGMATH_MAX_THREADS=8)`) parallelizes the CRT path: 6 forwards + 3 inverses as batched work units, one `ParallelDo` dispatch per phase. 2.3-3.4× speedup on large mul / skewed div / parse. Opt out via `-DBIGMATH_USE_THREADS=0` to drop pthread linkage.
+- **Division:** Classic short division → Knuth Algorithm D (`FastDivision` with Möller-Granlund 3-by-2 qhat for Base2_32) → Burnikel–Ziegler (balanced large) → Newton–Raphson with reciprocal caching (skewed large). Identity `q·b + r == a` is cross-checked in `tests/div_correctness.cpp`.
 - **Squaring:** Specialized Classic / Karatsuba / NTT squarers (1.4–1.6× over `Multiply(a,a)`).
 - **String I/O:** Linear chunked parser/formatter for small inputs, divide-and-conquer with cached Newton reciprocals at scale. Asymptotic `O(M(L) · log L)` both directions.
 - **BigDecimal:** Java-style fixed-point decimal (unscaled BigInteger + int scale) with exact +, −, \*; rounded division taking 8 rounding modes; parse/format covering plain and scientific notation.
 - **Calculator REPL:** Variables, hex/bin/dec output, multi-line continuation, comments, `:help :quit :vars :reset :base :digits :time :load :save` directives. Built as a separate executable.
+- **Thread-safe by construction** for concurrent use of distinct objects from distinct threads. See [docs/THREAD_SAFETY.md](docs/THREAD_SAFETY.md).
 
 ## Layout
 
@@ -96,28 +99,36 @@ Operators: `+ - * / % ^` (with `^` right-associative). Literals: decimal, `0x…
 
 ## Documentation
 
-- [docs/BASE.md](docs/BASE.md) — number representation, base-2³² limbs, why little-endian
-- [docs/MULTIPLICATION.md](docs/MULTIPLICATION.md) — Classic / Karatsuba / Toom-3 / NTT and their tradeoffs
-- [docs/DIVISION.md](docs/DIVISION.md) — Classic / Fast (Knuth D) / Burnikel–Ziegler / Newton / Reciprocal-cached
+- [docs/BASE.md](docs/BASE.md) — number representation, 64-bit limbs, why little-endian
+- [docs/MULTIPLICATION.md](docs/MULTIPLICATION.md) — Classic / Karatsuba / Toom-3 / NTT (Goldilocks + multi-prime CRT) and their tradeoffs
+- [docs/DIVISION.md](docs/DIVISION.md) — Classic / Fast (Knuth D + Möller-Granlund qhat) / Burnikel–Ziegler / Newton / Reciprocal-cached
 - [docs/STRING_CONVERSION.md](docs/STRING_CONVERSION.md) — chunked decimal I/O, D&C parse/format, Newton-divider chain
 - [docs/BIGDECIMAL.md](docs/BIGDECIMAL.md) — fixed-point decimal model, rounding modes, performance
-- [BUILDING.md](BUILDING.md) — CMake build, install, threshold tuning
+- [docs/THREAD_SAFETY.md](docs/THREAD_SAFETY.md) — concurrency model, opt-in internal parallelism
+- [BUILDING.md](BUILDING.md) — CMake build, install, build flags, threshold tuning
 
 Each doc covers algorithms, dispatch, benchmark numbers vs GMP, optimizations that landed, and approaches that were tried and rejected with reasons.
 
 ## Performance
 
-Apple M1 Max, vs GMP 6.3.0, `-O3 -march=native`:
+Apple M1 Max, vs GMP 6.3.0, `-O3 -march=native`, full default stack (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool). Min of 5 runs:
 
 | operation | size | BigMath | GMP | ratio |
 |---|---|---:|---:|---:|
-| mul | 5 000 × 5 000 digits | 0.043 ms | 0.012 ms | 3.5× |
-| mul | 1 000 000 × 1 000 000 | 37.5 ms | 8.9 ms | 4.2× |
-| div | 500 000 / 100 000 | 55 ms | 4.6 ms | 12× |
-| parse | 100 000 digits | 7.4 ms | 1.1 ms | 7.1× |
-| ToString | 100 000 digits | 41 ms | 2.3 ms | 18× |
+| mul | 5 000 × 5 000 digits | 0.030 ms | 0.011 ms | 2.73× |
+| mul | 100 000 × 100 000 | 1.06 ms | 0.61 ms | **1.74×** |
+| mul | 1 000 000 × 1 000 000 | 12.5 ms | 8.9 ms | **1.41×** |
+| mul (skewed) | 500 000 / 50 000 | 2.17 ms | 2.09 ms | **1.04× (parity)** |
+| mul (skewed) | 1 000 000 / 100 000 | 4.62 ms | 4.52 ms | **1.02× (parity)** |
+| div (skewed) | 200 000 / 50 000 | 8.91 ms | 1.71 ms | 5.21× |
+| div (skewed) | 500 000 / 100 000 | 18.6 ms | 4.56 ms | 4.09× |
+| parse | 100 000 digits | 3.24 ms | 1.04 ms | 3.10× |
+| parse | 1 000 000 digits | 48.0 ms | 20.6 ms | 2.33× |
+| ToString | 100 000 digits | 22.5 ms | 2.35 ms | 9.57× |
 
-The residual gap is the structural cost of pure C++ vs GMP's hand-tuned ARM64 assembly, plus the 32-bit-limb representation that keeps every inner-loop accumulator in a single register. NTT-bound operations hit the Goldilocks 16-bit coefficient floor regardless of representation. See the docs for full ratio tables and per-algorithm tuning notes.
+**Skewed multiplications at the 1M scale match GMP within 2-4%.** Balanced large mults (1.41-1.74× GMP) still trail because the threaded CRT NTT can't hide the symmetric work overlap. Division and base conversion close most of the original 12-20× gap via the same threaded CRT path. Residual gap concentrated in ToString divmod chains and the basecase NTT butterfly inner loop (where GMP's hand-tuned ARM64 assembly maintains an edge). See the per-doc ratio tables for the full breakdown.
+
+Opt-out flags (`-DBIGMATH_USE_THREADS=0` / `-DBIGMATH_NTT_CRT=0` / `-DBIGMATH_LIMB_64=0`) revert any subset of the defaults — useful for embedded targets, header-only-strict consumers, or A/B comparison.
 
 ## License
 

--- a/docs/STRING_CONVERSION.md
+++ b/docs/STRING_CONVERSION.md
@@ -397,59 +397,64 @@ c++ -std=c++20 -O3 -march=native -I/opt/homebrew/include -L/opt/homebrew/lib \
     tests/performance/bench_vs_gmp.cpp -o bench_vs_gmp -lgmp
 ```
 
-Hardware: Apple M1 Max. Reference: GMP 6.3.0 (Homebrew). `min` over a small iteration count.
+Hardware: Apple M1 Max. Reference: GMP 6.3.0 (Homebrew). Full default stack (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool). Min over 5 runs.
 
 ### Parse
 
 | size | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| 1 000 digits | 0.005 | 0.002 | 3.1 × |
-| 10 000 digits | 0.24 | 0.038 | 6.2 × |
-| 50 000 digits | 2.9 | 0.41 | 7.2 × |
-| 100 000 digits | 7.4 | 1.1 | 7.1 × |
-| 500 000 digits | 54 | 8.9 | 6.0 × |
-| 1 000 000 digits | 124 | 20.5 | 6.0 × |
+| 1 000 digits | 0.002 | 0.002 | **1.00 ×** |
+| 10 000 digits | 0.112 | 0.038 | 2.95 × |
+| 50 000 digits | 1.34 | 0.39 | 3.47 × |
+| 100 000 digits | 3.24 | 1.04 | **3.10 ×** |
+| 500 000 digits | 21.4 | 8.88 | **2.41 ×** |
+| 1 000 000 digits | 48.0 | 20.6 | **2.33 ×** |
 
 ### ToString
 
 | size | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| 1 000 digits | 0.037 | 0.003 | 11 × |
-| 10 000 digits | 1.7 | 0.077 | 22 × |
-| 50 000 digits | 17 | 0.86 | 20 × |
-| 100 000 digits | 41 | 2.3 | 18 × |
+| 1 000 digits | 0.017 | 0.003 | 5.67 × |
+| 10 000 digits | 0.863 | 0.077 | 11.2 × |
+| 50 000 digits | 10.1 | 0.85 | 12.0 × |
+| 100 000 digits | 22.5 | 2.35 | **9.57 ×** |
 
-(GMP doesn't have a directly comparable 500k+ ToString benchmark in this harness; `mpz_get_str` is O(n²) by default in mainline GMP, similar to BigMath's linear formatter — both libraries would need D&C ToString to scale, and the relative ratio at very large sizes depends on which D&C path each uses.)
+(GMP doesn't have a directly comparable 500k+ ToString benchmark in this harness; `mpz_get_str` is O(n²) by default in mainline GMP, similar to BigMath's linear formatter — both libraries would need D&C ToString to scale.)
 
-**Historical view** of ToString showing the impact of the 2026-05 optimization pass:
+**Historical view** showing the cumulative wins across the 2026-05 optimization pass:
 
-| size | early 2026 | current | improvement |
-|---|---|---|---|
-| ToString 10 000 digits | 47 × | 22 × | **2.1 ×** |
-| ToString 50 000 digits | 113 × | 20 × | **5.7 ×** |
-| ToString 100 000 digits | **160 ×** | **18 ×** | **9 ×** |
+| size | early 2026 | mid-session | now (CRT + threads default) | improvement |
+|---|---|---|---|---|
+| Parse 100 000 | 7.1 × | 7.1 × | **3.10 ×** | **2.3 ×** |
+| Parse 1 000 000 | 6.0 × | 6.0 × | **2.33 ×** | **2.6 ×** |
+| ToString 10 000 | 47 × | 22 × | **11.2 ×** | **4.2 ×** |
+| ToString 50 000 | 113 × | 20 × | **12.0 ×** | **9.4 ×** |
+| ToString 100 000 | **160 ×** | 18 × | **9.57 ×** | **16.7 ×** |
 
-The 100k case went from 160× to 18× over the session. The cumulative wins came from:
+The 100k ToString case went from 160× to 9.6× over the session — **16.7× cumulative improvement**. Wins came from:
 
 1. D&C ToString with Newton-Divider chain (8.4× at 100k).
 2. 64-bit hybrid Karatsuba leaf (improved every `Multiply` and `Divide` call in the chain).
 3. Squaring specialization in `Pow10` cache build.
 4. Reduced Karatsuba recursive overhead.
+5. **64-bit limb refactor** halved Newton's internal limb counts (PRs #18-#30).
+6. **`digitsPerLimb` fix** correctly sized D&C leaf chunks under LIMB_64 (PR #29 — caught a 2× regression that the limb refactor had introduced).
+7. **Multi-prime CRT NTT** dropped per-coefficient modular cost (PRs #34-#37).
+8. **Multithreaded NTT** parallelizes the 3 CRT primes' transforms across the pool (PRs #32, #38-#39).
 
 ### Where the ToString time goes (post-optimization)
 
-Profile of `ToString 100 000 digits`:
+Profile of `ToString 100 000 digits` under default stack (sample(1), M1 Max):
 
-| function | % of ToString time |
+| function group | % of ToString time |
 |---|---:|
-| `KaratsubaMultiplication::MultiplyRecursive` dispatch (in `BuildDecimalDcChain` and Newton inner mults) | ~11% |
-| `ToStringDivConquer` orchestration (std::move, Compare, recurse) | ~7.5% |
-| `NewtonDivision::*` chain (divmod operations) | ~5.2% |
-| `KaratsubaMultiplication::MultiplyClassicPtr` (the leaf, after the 64-bit hybrid) | ~2.7% |
-| `ToStringLinearAppend` (linear leaf, divmod-10¹⁸ loop) | ~2.5% |
-| `__udivmodti4` (128/64 divmod inside linear leaf) | ~2.2% |
+| `NewtonDivision::Divider::DivideAndRemainder` (D&C chain divmod calls) | ~55% |
+| `NttCrt::Multiply` (internal mults inside Newton's `ApproxReciprocal` + `DivideChunk`) | ~25% |
+| `ToStringLinearAppend` (linear leaf, divmod-10¹⁸ loop) + `__udivmodti4` | ~10% |
+| `ToStringDivConquer` orchestration + Compare/Shift/TrimZeros | ~7% |
+| Allocation + misc | ~3% |
 
-**The distribution is flat** post-optimization. The first big rounds of optimization concentrated 39% of time at the schoolbook leaf, which was crushed by the 64-bit hybrid. What remains is spread across multiplication dispatch, divmod orchestration, and Newton iteration internals — no single dominant target.
+The distribution is now dominated by Newton's divmod chain calling NTT mults. The earlier hot spots (39% in `MultiplyClassicPtr` schoolbook leaf, 5-10% in `__udivmodti4`) were eliminated by the 64-bit hybrid leaf + `digitsPerLimb` fix. Remaining headroom would come from Mulders' short-mult inside Newton — see [DIVISION.md §Improving skewed division](DIVISION.md#improving-skewed-division-beyond-the-current-floor).
 
 ### Parse: where the time goes
 


### PR DESCRIPTION
## Summary

Doc-only PR updating README.md and STRING_CONVERSION.md to reflect the final default stack: \`BIGMATH_LIMB_64=1\` + \`BIGMATH_NTT_CRT=1\` + \`BIGMATH_USE_THREADS=1\` (8-thread pool on M1 Max).

## README.md
- Features section adds 64-bit limbs, multithreaded NTT, multi-prime CRT NTT, Möller-Granlund qhat, thread-safety pointer.
- Performance table refreshed with min-of-5-runs numbers. Headline:

  | op | before | now |
  |---|---:|---:|
  | mul 1M×1M | 4.2× | **1.41×** |
  | mul 1M/100k skewed | 3.5× | **1.02× (parity)** |
  | div 500k/100k | 12× | **4.09×** |
  | parse 1M | 6.0× | **2.33×** |
  | tostr 100k | 18× | **9.57×** |

- Documentation list adds docs/THREAD_SAFETY.md.
- Opt-out flag summary at end of Performance section.

## STRING_CONVERSION.md
- Parse + ToString bench tables refreshed (min over 5 runs).
- Historical-view table extended: ToString 100k cumulative improvement **160× → 9.57× = 16.7× over the session**.
- Profile section updated for the post-optimization distribution (Newton divmod chain now dominates; earlier 39%-at-schoolbook-leaf hot spot eliminated by 64-bit hybrid + digitsPerLimb fix).

## Test plan
- [x] No code changes; doc-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)