### PR TITLE
perf: Möller-Granlund div2by1 reciprocal in ClassicDivision (~2.1× small-N ToString, ~1.08× at 100k)

### DIFF
--- a/docs/BASE.md
+++ b/docs/BASE.md
@@ -365,7 +365,7 @@ while (pos <= end) {
 
 `ClassicMultiplication::MultiplyTo(r, Base10_18, Base2_32)` multiplies each 32-bit limb by `10¹⁸` (a 60-bit constant). The result of one partial product is `(2³² − 1) · 10¹⁸ ≈ 2⁹² + small`, which fits in `ULong128`. The `Base2_32` parameter governs the storage base for `r`: low 32 bits become new limb, high bits become carry into the next position.
 
-Decimal output is the inverse: `ClassicDivision::DivModTo(r, Base10_18, Base2_32)` divides `r` by `10¹⁸` in place and returns the remainder (the next 18 decimal digits to format). This uses `ULong128 / ULong` per limb step (one ARM64 `UDIV` instruction sequence).
+Decimal output is the inverse: `ClassicDivision::DivModTo(r, Base10_18, Base2_32)` divides `r` by `10¹⁸` in place and returns the remainder (the next 18 decimal digits to format). The per-limb step uses a Möller-Granlund "div2by1" reciprocal divide (`UMULH` + 128-bit add + ≤2 fixups), with the reciprocal precomputed once per call from the invariant `10¹⁸` divisor.
 
 Both directions exploit the fact that `10¹⁸` fits in a 64-bit register while leaving the 32-bit limb storage representation untouched. The base 2³² storage and the base 10¹⁸ I/O chunking are independent design choices that happen to compose cleanly.
 

--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -118,7 +118,7 @@ The ordering matters: Newton wins on **skewed** problems (large dividend over me
    remainder = acc
 ```
 
-For `Base2_32`, the inner `(acc << 32 | a[i])` fits in a `ULong128`, and `__uint128_t / uint64_t` is one instruction on x86 (`DIV`) and a hardware-supported sequence on ARM64 (`UDIV` + multiply-subtract).
+For `Base2_32`, the inner `(acc << 32 | a[i])` fits in a `ULong128`. As of 2026-05-26 the per-limb divide is a Möller-Granlund "div2by1" reciprocal step (`ClassicDivision::GranlundMollerDivider`, paper Algorithm 4), not a hardware `UDIV`/`DIV` — the reciprocal is precomputed once per call from the invariant divisor, then each limb costs `UMULH` + 128-bit add + 1–2 fixup branches. Base2_64 takes the same path. See [STRING_CONVERSION.md §Granlund–Möller](STRING_CONVERSION.md#granlundmöller-magic-number-divmod-in-classicdivision) for measurement.
 
 The `DivModTo` variant performs the division **in place** on the dividend vector (overwriting it with the quotient) and returns the remainder. This is the hot operation inside `ToStringLinearAppend`, where the dividend is repeatedly divided by `10¹⁸` to peel off 18 decimal digits at a time.
 

--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -515,14 +515,6 @@ Opt-out: `-DBIGMATH_LIMB_64=0` reverts to 32-bit limbs.
 
 Ranked by expected ROI per unit of effort.
 
-### Granlund–Möller magic-number division by 10¹⁸ (cheap, marginal)
-
-`ToStringLinearAppend` calls `ClassicDivision::DivModTo(r, Base10_18, base)` in a tight loop, each invocation ultimately routing through the compiler-provided `__udivmodti4` (a 128/64 long division). For a fixed divisor (`10¹⁸`), [Granlund–Möller "Improved division by invariant integers"](https://gmplib.org/~tege/divcnst-pldi94.pdf) reduces this to a multiply-by-reciprocal-high plus a small correction — one or two `UMULH`s replacing a `UDIV`-loop.
-
-Under `BIGMATH_LIMB_64=0` (legacy 32-bit limbs): profile shows `__udivmodti4` at 1.5–2.2% of `ToString 100k`, so the upper bound on the win is small (~1–2% on ToString).
-
-Under `BIGMATH_LIMB_64=1` (default since 2026-05): `__udivmodti4` rose to 5–10% of `ToString 100k` after the limb refactor (twice as many libcalls per leaf at half the limb count, with leaf chunks now correctly sized after the `digitsPerLimb` fix in PR #29). Estimated win: 3–6% on ToString. ~80 lines, low risk.
-
 ### Multithreaded NTT (architectural, 1.5–3× on large NTT-bound ops)
 
 Detailed in [DIVISION.md §Improving skewed division](DIVISION.md#improving-skewed-division-beyond-the-current-floor). Applies symmetrically to multiplication — `Multiply` at ≥ 100k digits is NTT-bound and would benefit identically. The architectural lift is the same (header-only library + thread pool design), so the cost amortizes across both subsystems.

--- a/docs/STRING_CONVERSION.md
+++ b/docs/STRING_CONVERSION.md
@@ -266,18 +266,18 @@ while (!(r.size() == 1 && r[0] == 0))
 
 Each `DivModTo` is O(|r|) limb operations. The number of iterations is O(L / 18) where L is the digit count. Total O(L · |r|) = O(L · L/9.6) = O(L²). Same quadratic complexity as the linear parser; same threshold for switching to D&C.
 
-The inner loop of `DivModTo(vec, Base10_18, Base2_32)` walks `vec` from high limb to low, maintaining a `ULong128` accumulator:
+The inner loop of `DivModTo(vec, Base10_18, Base2_32)` walks `vec` from high limb to low, maintaining a `ULong128` accumulator. Each limb step is a Möller-Granlund "div2by1" reciprocal divide (`GranlundMollerDivider`, built once per call from the invariant divisor):
 
 ```
+   gm  = GranlundMollerDivider(d=Base10_18)   ← precompute shift, dn, v once
    acc = 0
    for i = n-1 down to 0:
-       acc      = (acc << 32) | vec[i]   ← ULong128 by construction
-       vec[i]   = (acc / Base10_18)       ← ULong128 / ULong64 → __udivmodti4
-       acc      = (acc % Base10_18)
-   return (ULong)acc                      ← the remainder (a base-10¹⁸ digit)
+       acc          = (acc << 32) | vec[i]
+       (vec[i], r)  = gm.DivMod(acc.hi, acc.lo)  ← UMULH + add + ≤2 fixups
+   return r                                  ← the remainder (a base-10¹⁸ digit)
 ```
 
-The `__udivmodti4` is the single hottest instruction in linear formatting. On M1 it lowers to a `UDIV` plus a multiply-subtract; on x86 to a `DIV`. Both are slow compared to the surrounding bit operations — Granlund–Möller's "magic-number" division by an invariant constant could replace it with a few `UMULH`s, but the gain caps at ~1–2% on `ToString 100 000` (see [Future opportunities](#future-opportunities)).
+Replacing the prior `__udivmodti4` libcall (one `UDIV` + multiply-subtract on ARM64, one `DIV` on x86) with `UMULH` + adds yields a measured 1.08–2.13× speedup on `ToString` depending on input size — small inputs that stay in the linear leaf gain the most, large inputs gain less because the D&C path dominates. See [Optimizations already implemented §Granlund–Möller](#granlundmöller-magic-number-divmod-in-classicdivision).
 
 ### Divide-and-conquer formatter (`ToStringDivConquer`)
 
@@ -519,17 +519,28 @@ The estimate is always an overestimate (rounds up). The overestimate is harmless
 
 Discussed in detail in [MULTIPLICATION.md §Classic schoolbook](MULTIPLICATION.md#classic-schoolbook). Every `Multiply` and `Square` call inside the parser's D&C combine and the ToString's `Pow10` build hits Karatsuba (for the mid-sized intermediate products) and benefits from the 64-bit hybrid leaf. The ToString 10k case went from 31× to 22× vs GMP largely thanks to this multiplication-level change, even though no string-conversion code was modified.
 
+### Granlund–Möller magic-number divmod in `ClassicDivision`
+
+Landed 2026-05-26. `ClassicDivision::DivideTo`, `DivModTo`, and `DivideAndRemainder` all replaced their `ULong128 / d` inner loops with Möller-Granlund "div2by1" reciprocal arithmetic (paper Algorithm 4). Reciprocal is built once per call (`(2^128 - 1) / dn` precompute) and amortized across the per-limb loop; each limb step then costs one 64×64→128 `UMULH` plus a 128-bit add and 1–2 fixup branches, vs the prior `__udivmodti4` libcall.
+
+`ToString` benefits directly — every `DivModTo(r, Base10_18, ...)` call in `ToStringLinearAppend` runs through the new path, and the D&C formatter routes hundreds of <2 048-digit leaf subproblems through the same loop. Measured wins (M1 Max, default stack):
+
+| size | pre-GM BM ms | post-GM BM ms | speedup | pre-GM × GMP | post-GM × GMP |
+|---|---:|---:|---:|---:|---:|
+| ToString 1 000 | 0.017 | 0.008 | **2.13×** | 5.67 × | 2.34 × |
+| ToString 10 000 | 0.863 | 0.724 | **1.19×** | 11.2 × | 8.78 × |
+| ToString 50 000 | 10.1 | 9.07 | **1.11×** | 12.0 × | 10.4 × |
+| ToString 100 000 | 22.5 | 20.85 | **1.08×** | 9.57 × | 8.62 × |
+
+Pre-implementation estimate in this doc was "1–2% on ToString 100k" (capped by `__udivmodti4` being only 2.2% of profile). Realized win at 100k is ~8%, larger than predicted because the D&C path's leaves all hit the linear formatter, not just the top-level dispatch. Small-N wins are large (2.13× at 1k) because that range stays entirely in the linear leaf — exactly the regime where the prior `__udivmodti4` libcall dominated.
+
+`Parse` is unaffected (parser uses `MultiplyTo`, not `DivModTo`). `FastDivision` and friends call `ClassicDivision::DivModTo` for their single-limb-divisor fallback, so any caller passing a single-limb divisor now benefits.
+
 ---
 
 ## Future opportunities
 
 Ranked by expected ROI per unit of effort.
-
-### Granlund–Möller magic-number divmod by 10¹⁸ (cheap, marginal)
-
-`ToStringLinearAppend` calls `ClassicDivision::DivModTo(r, Base10_18, Base2_32)` in a tight loop. Each call ultimately invokes `__udivmodti4` (128/64 long division) per limb step. For the invariant divisor `10¹⁸`, [Granlund–Möller "Improved Division by Invariant Integers"](https://gmplib.org/~tege/division-paper.pdf) reduces divmod to a multiply-by-precomputed-reciprocal-high plus a small correction — one or two `UMULH`s replacing a `UDIV` sequence.
-
-Estimated win: 1–2% on ToString 100k (capped because `__udivmodti4` is only 2.2% of profile). Effort: ~80 lines, low risk (the invariant divisor makes the reciprocal computation a constant). Probably worth doing if/when the linear leaf gets attention.
 
 ### 64-bit hybrid in `ClassicMultiplication::MultiplyTo` (cheap, marginal)
 

--- a/include/biginteger/algorithms/division/ClassicDivision.h
+++ b/include/biginteger/algorithms/division/ClassicDivision.h
@@ -25,6 +25,46 @@ namespace BigMath
     class ClassicDivision
     {
     public:
+        // Möller-Granlund "div2by1" reciprocal for an invariant single-limb divisor.
+        // Replaces compiler __udivmodti4 (128/64 → 64) with UMULH + adds + 1-2 fixups.
+        // Reference: Möller, Granlund 2010, "Improved Division by Invariant Integers", Algorithm 4.
+        struct GranlundMollerDivider
+        {
+            ULong d;     // original divisor
+            ULong dn;    // d << shift (normalized, top bit set)
+            ULong v;     // floor((2^128 - 1) / dn) - 2^64
+            int shift;   // clz(d)
+
+            explicit GranlundMollerDivider(ULong divisor)
+                : d(divisor), shift(__builtin_clzll(divisor))
+            {
+                dn = divisor << shift;
+                ULong128 num = ~(ULong128)0; // 2^128 - 1
+                ULong128 q = num / dn;       // q ∈ [2^64, 2^65)
+                v = (ULong)q;                // low 64 bits = q - 2^64
+            }
+
+            // Divide (h*2^64 + l) by d. Quotient returned; remainder via rem.
+            // Precondition: h < d (so shifted h_n < dn).
+            inline ULong DivMod(ULong h, ULong l, ULong &rem) const
+            {
+                ULong128 combined = ((ULong128)h << 64) | l;
+                ULong128 shifted = combined << shift;
+                ULong u1 = (ULong)(shifted >> 64);
+                ULong u0 = (ULong)shifted;
+
+                ULong128 q = (ULong128)v * u1;
+                q += ((ULong128)u1 << 64) | u0;
+                ULong q1 = (ULong)(q >> 64) + 1;
+                ULong q0 = (ULong)q;
+                ULong r = u0 - q1 * dn;
+                if (r > q0) { q1--; r += dn; }
+                if (r >= dn) { q1++; r -= dn; }
+                rem = r >> shift;
+                return q1;
+            }
+        };
+
         static void DivideTo(vector<DataT> &u, DataT d, BaseT base)
         {
             Divide(u, 0, u.size() - 1, d, u, 0, u.size() - 1, base);
@@ -75,15 +115,18 @@ namespace BigMath
             if (w.size() < neededSize)
                 w.resize(neededSize, 0);
 
-            // Base-2^32 fast path: ULong128 keeps r*base from overflowing when d > 2^32.
+            // Base-2^32 fast path. Möller-Granlund invariant-divisor reciprocal:
+            // precompute once, then each limb step is UMULH + adds (no UDIV).
             if (base == Base2_32)
             {
-                ULong128 r = 0;
+                GranlundMollerDivider gm(d);
+                ULong r = 0;
                 for (Int i = (Int)uEnd; i >= (Int)uStart; i--)
                 {
-                    r = (r << 32) | (ULong128)u[i];
-                    DataT q = (DataT)(r / d);
-                    r %= d;
+                    ULong128 acc = ((ULong128)r << 32) | u[i];
+                    ULong h = (ULong)(acc >> 64);
+                    ULong l = (ULong)acc;
+                    DataT q = (DataT)gm.DivMod(h, l, r);
                     SizeT wPos = wStart + (i - uStart);
                     if (wPos <= wEnd)
                         w[wPos] = q;
@@ -94,16 +137,14 @@ namespace BigMath
                 return;
             }
 
-            // Base-2^64 fast path: shift-by-64 instead of -32. Compiler lowers
-            // the ULong128 / ULong64 divide via a libcall on ARM64.
+            // Base-2^64 fast path. Same GM trick: dividend = (r * 2^64 + u[i]).
             if (base == Base2_64)
             {
-                ULong128 r = 0;
+                GranlundMollerDivider gm(d);
+                ULong r = 0;
                 for (Int i = (Int)uEnd; i >= (Int)uStart; i--)
                 {
-                    r = (r << 64) | (ULong128)u[i];
-                    DataT q = (DataT)(r / d);
-                    r %= d;
+                    DataT q = (DataT)gm.DivMod(r, u[i], r);
                     SizeT wPos = wStart + (i - uStart);
                     if (wPos <= wEnd)
                         w[wPos] = q;
@@ -146,12 +187,14 @@ namespace BigMath
 
             if (base == Base2_32)
             {
-                ULong128 r = 0;
+                GranlundMollerDivider gm(d);
+                ULong r = 0;
                 for (Int i = (Int)u.size() - 1; i >= 0; --i)
                 {
-                    r = (r << 32) | (ULong128)u[i];
-                    u[i] = (DataT)(r / d);
-                    r %= d;
+                    ULong128 acc = ((ULong128)r << 32) | u[i];
+                    ULong h = (ULong)(acc >> 64);
+                    ULong l = (ULong)acc;
+                    u[i] = (DataT)gm.DivMod(h, l, r);
                 }
                 while (u.size() > 1 && u.back() == 0)
                     u.pop_back();
@@ -160,12 +203,11 @@ namespace BigMath
 
             if (base == Base2_64)
             {
-                ULong128 r = 0;
+                GranlundMollerDivider gm(d);
+                ULong r = 0;
                 for (Int i = (Int)u.size() - 1; i >= 0; --i)
                 {
-                    r = (r << 64) | (ULong128)u[i];
-                    u[i] = (DataT)(r / d);
-                    r %= d;
+                    u[i] = (DataT)gm.DivMod(r, u[i], r);
                 }
                 while (u.size() > 1 && u.back() == 0)
                     u.pop_back();
@@ -196,23 +238,24 @@ namespace BigMath
 
             if (base == Base2_32)
             {
-                ULong128 r = 0;
+                GranlundMollerDivider gm(d);
+                ULong r = 0;
                 for (Int i = (Int)u.size() - 1; i >= 0; i--)
                 {
-                    r = (r << 32) | (ULong128)u[i];
-                    w[i] = (DataT)(r / d);
-                    r %= d;
+                    ULong128 acc = ((ULong128)r << 32) | u[i];
+                    ULong h = (ULong)(acc >> 64);
+                    ULong l = (ULong)acc;
+                    w[i] = (DataT)gm.DivMod(h, l, r);
                 }
                 v[0] = (DataT)r;
             }
             else if (base == Base2_64)
             {
-                ULong128 r = 0;
+                GranlundMollerDivider gm(d);
+                ULong r = 0;
                 for (Int i = (Int)u.size() - 1; i >= 0; i--)
                 {
-                    r = (r << 64) | (ULong128)u[i];
-                    w[i] = (DataT)(r / d);
-                    r %= d;
+                    w[i] = (DataT)gm.DivMod(r, u[i], r);
                 }
                 v[0] = (DataT)r;
             }


### PR DESCRIPTION
## Summary

Replace `__udivmodti4` inner loop in `ClassicDivision` with Möller-Granlund "div2by1" reciprocal (paper Algorithm 4). Reciprocal built once per call from the invariant single-limb divisor; each per-limb step then costs one `UMULH` + 128-bit add + ≤2 fixup branches instead of a `__udivmodti4` libcall.

All six hot paths converted (`DivideTo` × {one-arg, range}, `DivModTo`, `DivideAndRemainder` × {single-vector, range} × {Base2_32, Base2_64}).

## Measured wins (M1 Max, default stack, vs GMP 6.3.0)

| size              | before BigMath | after BigMath | speedup | before × GMP | after × GMP |
|-------------------|---------------:|--------------:|--------:|-------------:|------------:|
| ToString 1 000    |        0.017ms |       0.008ms | **2.13×** | 5.67 × | 2.34 × |
| ToString 10 000   |        0.863ms |       0.724ms | **1.19×** | 11.2 × | 8.78 × |
| ToString 50 000   |        10.1ms  |       9.07ms  | **1.11×** | 12.0 × | 10.4 × |
| ToString 100 000  |        22.5ms  |       20.85ms | **1.08×** | 9.57 × | 8.62 × |

Small-N gains largest (range stays entirely in the linear leaf where `__udivmodti4` dominated). Large-N gains come from hundreds of <2048-digit D&C leaves all running through the same divmod loop.

`Parse` unaffected (uses `MultiplyTo`, not divmod). `FastDivision` single-limb fallback also benefits.

## Pre-implementation forecast vs reality

STRING_CONVERSION.md predicted "1-2% on ToString 100k" capped by `__udivmodti4` being only 2.2% of profile. Realized 100k win is ~8% — better than predicted because D&C path's hundreds of leaves all hit the linear formatter, not just top-level dispatch.

## Test plan

- [x] All 242 `unit_tests` pass (incl. `test_base64_div`, `test_algorithms_crosscheck`, `Pow10` parser round-trip)
- [x] `bench_vs_gmp` runs to completion with sane numbers
- [ ] `div_correctness` cross-check at 1024+ limbs (long-running; in progress on local machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)