### PR TITLE
perf: Möller-Granlund 3/2 qhat reciprocal in FastDivision Base2_64 (~1.27× small-n)

### DIFF
--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -412,7 +412,25 @@ Measured win on `FastDivision` band (Base2_32, M1 Max, `divperf_simple`):
 | 8192×512 | 9.64 ms | 7.78 ms | −19% |
 | 16384×512 | 15.92 ms | 14.15 ms | −11% |
 
-The M-G qhat is currently gated on `base == Base2_32 && n >= 2` in the j-loop. Under `BIGMATH_LIMB_64=1` it's skipped (the 3-by-2 reciprocal precompute would need a 192/128 software division), and Knuth qhat with a 128/64 hardware divide is used instead. Re-enabling M-G for Base2_64 is a [future opportunity](#future-opportunities).
+### Möller–Granlund 3/2 reciprocal in `FastDivision` qhat, Base2_64 path (2026-05-26)
+
+Extended M-G to the `Base2_64` path. The 192/128 reciprocal precompute is avoided by using paper Algorithm 6 (`Reciprocal3by2_Base64`): derive the 3-by-2 reciprocal from a 2-by-1 reciprocal of the divisor's top word — only one `ULong128 / ULong` operation, no 192-bit software division. The 3/2 division itself (`MGQhat_Base64`) mirrors `MGQhat_Base32` with `ULong128` intermediates.
+
+Measured win on M1 Max, `Base2_64` default, FastDivision called directly (skewed sizes where qhat dominates):
+
+| m × n (limbs) | Knuth qhat | M-G qhat | speedup |
+|---|---:|---:|---:|
+| 256 × 16    | 9.41 μs    | 7.42 μs    | **1.27×** |
+| 1024 × 32   | 61.3 μs    | 50.2 μs    | **1.22×** |
+| 4096 × 64   | 414 μs     | 369 μs     | **1.12×** |
+| 16384 × 128 | 3089 μs    | 2860 μs    | 1.08×    |
+| 65536 × 256 | 23046 μs   | 22152 μs   | 1.04×    |
+| 1024 × 512  | 349 μs     | 345 μs     | flat     |
+| 4096 × 2048 | 5464 μs    | 5494 μs    | flat     |
+
+Strong wins are concentrated at high skew with small `n`. As `n` grows the per-iteration `SubtractMul` (n `ULong128` mul-adds) eclipses the qhat cost and the proportional win shrinks. Newton/BZ dispatch bands cover the larger-`n` cases anyway, so the band where M-G actually matters is exactly `b.size() ∈ (1, ~256)` 64-bit limbs.
+
+Gated by the same `BIGMATH_FASTDIV_USE_MG_QHAT` flag (default on); now activates for both `Base2_32` and `Base2_64` when `n >= 2`.
 
 ### 64-bit limb refactor (2026-05, PRs #18–#30)
 
@@ -530,11 +548,7 @@ The CRT + threading combination compounds: 4-5× cumulative win on the floor cas
 
 Ranked by expected ROI per unit of effort.
 
-### Möller–Granlund 3/2 reciprocal for `FastDivision` under Base2_64 (medium, ~10% on FastDivision band)
-
-PR #17 landed M-G for Base2_32 with strong wins. Base2_64 currently uses Knuth qhat because the M-G 3-by-2 reciprocal precompute requires `floor((2^192 - 1) / d)` where `d` is a 128-bit divisor — a 192/128 software division that doesn't exist in the standard library. Implementing it (~40–80 lines of long division, runs once per `FastDivision::DivideAndRemainder` call) would unlock the same proportional wins seen for Base2_32 in the dispatcher band `b.size() ∈ (1, NEWTON_MEDIUM_B / 2)` ≈ `(1, 512)` for 64-bit limbs.
-
-Effort: ~150 lines. Risk: low (M-G algorithm already validated at Base2_32; the new piece is just the 192/128 divide).
+_(M-G 3/2 for Base2_64 FastDivision was landed 2026-05-26 — see [Optimizations already implemented §Möller–Granlund 3/2 reciprocal in `FastDivision` qhat, Base2_64 path](#möllergranlund-32-reciprocal-in-fastdivision-qhat-base2_64-path-2026-05-26).)_
 
 ---
 

--- a/include/biginteger/algorithms/division/FastDivision.h
+++ b/include/biginteger/algorithms/division/FastDivision.h
@@ -143,6 +143,73 @@ namespace BigMath
       return (DataT)((ULong)(num / d) - ((ULong)1 << 32));
     }
 
+    // Möller-Granlund 3-by-2 reciprocal for B = 2^64. Uses Algorithm 6 of
+    // M-G 2010 to derive the 3/2 reciprocal from a 2/1 reciprocal of d1 —
+    // avoiding the otherwise-needed 192/128 software division.
+    // Precondition: d1's top bit set (divisor already normalized).
+    static inline ULong Reciprocal3by2_Base64(ULong d1, ULong d0)
+    {
+      // 2-by-1 reciprocal of d1: v = floor((2^128 - 1) / d1) - 2^64.
+      ULong v = (ULong)((~(ULong128)0) / d1);
+
+      // Algorithm 6 (M-G 2010): refine v to 3-by-2 reciprocal of (d1, d0).
+      ULong p = d1 * v + d0;
+      if (p < d0)
+      {
+        --v;
+        if (p >= d1)
+        {
+          --v;
+          p -= d1;
+        }
+        p -= d1;
+      }
+      ULong128 t = (ULong128)v * d0;
+      ULong t1 = (ULong)(t >> 64);
+      ULong t0 = (ULong)t;
+      p += t1;
+      if (p < t1)
+      {
+        --v;
+        if (p > d1 || (p == d1 && t0 >= d0))
+          --v;
+      }
+      return v;
+    }
+
+    // M-G Algorithm 4 (3/2 division) for B = 2^64. Mirrors the Base32 path
+    // at 128-bit widths via ULong128.
+    static inline ULong MGQhat_Base64(ULong u2, ULong u1, ULong u0,
+                                       ULong d1, ULong d0, ULong v)
+    {
+      // (q1, q0) = v * u2 + (u2, u1), discarding any 129th-bit carry-out.
+      ULong128 q = (ULong128)v * u2 + (((ULong128)u2 << 64) | u1);
+      ULong q1 = (ULong)(q >> 64);
+      ULong q0 = (ULong)q;
+
+      // 2-word remainder via 128-bit modular subtraction:
+      //   r = (u1:u0) - q1*(d1:d0) - (d1:d0) mod 2^128.
+      ULong r1_tmp = u1 - q1 * d1;
+      ULong128 r = ((ULong128)r1_tmp << 64) | u0;
+      ULong128 d_pair = ((ULong128)d1 << 64) | d0;
+      r -= d_pair;
+      r -= (ULong128)q1 * d0;
+      ++q1;
+
+      // First correction: if r-high >= saved q0, q1 was over-bumped; undo.
+      if ((ULong)(r >> 64) >= q0)
+      {
+        --q1;
+        r += d_pair; // 128-bit add; discard carry-out
+      }
+
+      // Second correction: residual r >= d.
+      if (r >= d_pair)
+        ++q1;
+
+      return q1;
+    }
+
     // M-G Algorithm 4 (3/2 division) for B = 2^32.
     // Returns qhat = quotient digit, exact or +1 vs true digit. The caller's
     // SubtractMul+AddBack handles the +1 case unchanged.
@@ -326,24 +393,40 @@ namespace BigMath
 
       vector<DataT> q(m + 1, 0);
 
-      bool useMG = false;
-      DataT mg_v = 0;
+      bool useMG32 = false;
+      bool useMG64 = false;
+      DataT mg_v32 = 0;
+      ULong mg_v64 = 0;
 #if BIGMATH_FASTDIV_USE_MG_QHAT
-      if (base == Base2_32 && n >= 2)
+      if (n >= 2)
       {
-        useMG = true;
-        mg_v = Reciprocal3by2_Base32((DataT)v[n - 1], (DataT)v[n - 2]);
+        if (base == Base2_32)
+        {
+          useMG32 = true;
+          mg_v32 = Reciprocal3by2_Base32((DataT)v[n - 1], (DataT)v[n - 2]);
+        }
+        else if (base == Base2_64)
+        {
+          useMG64 = true;
+          mg_v64 = Reciprocal3by2_Base64((ULong)v[n - 1], (ULong)v[n - 2]);
+        }
       }
 #endif
 
       for (Int j = (Int)m; j >= 0; --j)
       {
         ULong qhat;
-        if (useMG)
+        if (useMG32)
         {
           qhat = (ULong)MGQhat_Base32(
               (DataT)u[j + n], (DataT)u[j + n - 1], (DataT)u[j + n - 2],
-              (DataT)v[n - 1], (DataT)v[n - 2], mg_v);
+              (DataT)v[n - 1], (DataT)v[n - 2], mg_v32);
+        }
+        else if (useMG64)
+        {
+          qhat = MGQhat_Base64(
+              (ULong)u[j + n], (ULong)u[j + n - 1], (ULong)u[j + n - 2],
+              (ULong)v[n - 1], (ULong)v[n - 2], mg_v64);
         }
         else if (base == Base2_64)
         {


### PR DESCRIPTION
## Summary

Extend the existing M-G 3/2 qhat (Base2_32 path, PR #17) to Base2_64. The blocker has always been the 192/128 reciprocal precompute — sidestepped here via paper Algorithm 6 (\`Reciprocal3by2_Base64\`): derive the 3-by-2 reciprocal from a 2-by-1 reciprocal of the divisor's top word using only one \`ULong128 / ULong\` and 64-bit arithmetic. \`MGQhat_Base64\` mirrors the existing \`MGQhat_Base32\` at 128-bit widths.

## Measured wins (M1 Max, Base2_64 default, FastDivision direct call)

| m × n (limbs) | Knuth qhat | M-G qhat | speedup |
|---|---:|---:|---:|
| 256 × 16    | 9.41 μs    | 7.42 μs    | **1.27×** |
| 1024 × 32   | 61.3 μs    | 50.2 μs    | **1.22×** |
| 4096 × 64   | 414 μs     | 369 μs     | **1.12×** |
| 16384 × 128 | 3089 μs    | 2860 μs    | 1.08×    |
| 65536 × 256 | 23046 μs   | 22152 μs   | 1.04×    |
| 1024 × 512  | 349 μs     | 345 μs     | flat     |
| 4096 × 2048 | 5464 μs    | 5494 μs    | flat     |

Wins concentrate at high skew with small \`n\` (qhat dominates the j-loop). As \`n\` grows the per-iteration \`SubtractMul\` (n × \`ULong128\` mul-adds) eclipses qhat savings. Newton/BZ cover larger-\`n\` cases via dispatch — so the effective MG band is \`b.size() ∈ (1, ~256)\` 64-bit limbs.

## Dispatch / gating

Same flag as before: \`BIGMATH_FASTDIV_USE_MG_QHAT\` (default on). Now activates for both Base2_32 and Base2_64 when \`n >= 2\`.

## Test plan

- [x] 242 \`unit_tests\` pass (incl. \`test_base64_div\`, \`test_algorithms_crosscheck\`)
- [x] \`divperf_simple\` match=1 vs BurnikelZiegler at 1024×512, 4096×2048, 8192×512, 16384×512
- [x] Baseline (no-MG) build cross-compared on the bench table above

## Notes

Independent of PR #43 (GM 2/1 in ClassicDivision) — different file, different code path, different operand-shape regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)