### PR TITLE
fix: Knuth-normalize divisor in BurnikelZieglerDivision (div_correctness hang since PR #30)

### DIFF
--- a/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
+++ b/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
@@ -365,23 +365,45 @@ namespace BigMath
       if (a.size() <= BZ_THRESHOLD || b.size() <= BZ_THRESHOLD)
         return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);
 
-      // BZ recursion needs an even-sized divisor at the top level so the 2n-by-n
-      // split is balanced. For odd nb, bit-shift both a and b left so b's MSB is
-      // pushed into a new high limb (nb → nb+1, even). Quotient is shift-invariant;
-      // remainder is shifted right by the same amount to undo.
-      if (b.size() % 2 != 0)
+      // Knuth-normalize the divisor (top bit of b.back() set). Required for BZ's
+      // 3n/2n correction-loop bound of 2 iterations; without it the loop runs O(B)
+      // times when the recursive q-estimate is wildly off (PR #30 LIMB_64 sparse-input
+      // hang was here — divisor.back() = 1 forced ~2^64 correction iters).
+      DataT b_top = b[b.size() - 1];
+      Int shift = 0;
+#if BIGMATH_LIMB_64
+      const DataT topBitMask = 0x8000000000000000ULL;
+#else
+      const DataT topBitMask = 0x80000000U;
+#endif
+      while ((b_top & topBitMask) == 0)
       {
-        vector<DataT> bv(b.begin(), b.end());
-        Int shift = BitsToBumpLimbCount(bv);
-        vector<DataT> aShifted = ShiftLeftBits(vector<DataT>(a.begin(), a.end()), shift);
-        vector<DataT> bShifted = ShiftLeftBits(bv, shift);
-        auto qr = DivideRecursive(aShifted, bShifted, base, computeRemainder);
-        if (computeRemainder)
+        b_top <<= 1;
+        ++shift;
+      }
+
+      vector<DataT> aNorm = (shift > 0)
+                                ? ShiftLeftBits(vector<DataT>(a.begin(), a.end()), shift)
+                                : vector<DataT>(a.begin(), a.end());
+      vector<DataT> bNorm = (shift > 0)
+                                ? ShiftLeftBits(vector<DataT>(b.begin(), b.end()), shift)
+                                : vector<DataT>(b.begin(), b.end());
+
+      // BZ recursion needs even divisor size for the 2n-by-n split. If post-normalize
+      // size is odd, fall to FastDivision — which has its own internal normalization
+      // and isn't sensitive to BZ's correction-loop bound.
+      if (bNorm.size() % 2 != 0)
+      {
+        auto qr = FastDivision::DivideAndRemainder(aNorm, bNorm, base, computeRemainder);
+        if (computeRemainder && shift > 0)
           qr.second = ShiftRightBits(qr.second, shift);
         return qr;
       }
 
-      return DivideRecursive(FromSpan(a), FromSpan(b), base, computeRemainder);
+      auto qr = DivideRecursive(aNorm, bNorm, base, computeRemainder);
+      if (computeRemainder && shift > 0)
+        qr.second = ShiftRightBits(qr.second, shift);
+      return qr;
     }
 
     static vector<DataT> Divide(span<const DataT> a, span<const DataT> b, BaseT base)


### PR DESCRIPTION
## Problem

\`div_correctness\` has been hanging at the \`random 1024×513\` cross-check ever since \`BIGMATH_LIMB_64=1\` became default in #30. Symptom: the BZ reference invocation inside \`CheckDivision\` never returns.

## Root cause

BZ's top-level normalization (\`BurnikelZieglerDivision::DivideAndRemainder\`) used \`BitsToBumpLimbCount\` to compute its shift. That helper returns just enough bits to bump \`b.size() → b.size()+1\` (for the even-divisor recursion split). It does **not** Knuth-normalize.

Under LIMB_64 with sparse-32 inputs (the random-data shape \`div_correctness\` generates — \`uniform_int_distribution<uint64_t>\` masked to \`0xFFFFFFFF\`), \`b.back()\` is at most 32 bits wide. \`BitsToBumpLimbCount\` returns \`65 - bitwidth\` ≥ 33. After \`ShiftLeftBits\`, \`bShifted.back() = 1\` — only bit 0 set, top bit of the top limb nowhere near bit 63.

BZ's 3n/2n recursion relies on Knuth's correction-loop bound of ≤2 iterations, **which requires a normalized divisor**. Without normalization the recursive \`Divide2nByN(top, b1)\` overestimates q wildly (because \`b1\` is unnormalized), so \`d = q·b0\` ends up much larger than \`r\`, and the correction loop \`while (Compare(r,d) < 0) { Decrement(q); r = r + divisor; }\` has to add \`divisor\` (small) to \`r\` ~2^32–2^64 times to catch up.

Probe data (m=257, n=514, base=Base2_64, iter=1 vs iter=6):
- \`r.back\` grew \`0x02 → 0x09\` (linear in iters, top limb of \`divisor\` = 1)
- \`d.back = 0x06b8b6abe518f592\` (~2^58)
- Need ~0x06b8b6ab iters ≈ 113M to close the gap. Hence \"hang.\"

## Fix

Replace the odd-size handler with proper Knuth normalize. Shift = clz(b.back()) so the divisor's top bit sits at bit 63. If post-normalize \`bNorm.size()\` is still odd, fall to \`FastDivision\` — which has its own internal normalization via the d-scaling factor and is not dependent on the BZ correction-loop bound.

## Why LIMB_32 didn't hang

Under LIMB_32 with the same random data, the limb \"value bits\" only occupy bits 0–31 of each \`uint64_t\` slot, so a freshly-generated random \`b.back()\` typically has its top *value* bit (bit 31) set. \`BitsToBumpLimbCount\` returns 1 or 2; after shift the new top limb spillover still contains high bits, and \`bShifted.back()\` ends up at most a few orders below the divisor's overall magnitude — not catastrophically unnormalized. Under LIMB_64 with the same data, the limb has 32 unused high bits and the shift amplifies them into a degenerate top limb.

## Test plan

- [x] \`div_correctness\` completes in <15s with all 21 cases passing (was hanging indefinitely on the 1024×513 case)
- [x] 242 \`unit_tests\` still pass
- [x] Independent of PR #43 / #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)