### PR TITLE
Optimize ToString conversion

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -135,6 +135,20 @@ Skewed (`a.size() >> b.size()`) — Newton/BZ band, real algorithmic work:
 
 **Observation:** narrowest gap at 1k (the linear leaf, where GM div2by1 already runs); peaks at 50k (D&C overhead + Newton recip setup not yet amortized); narrows again from 100k onward as D&C asymptotic + NTT inheriting from multiplication's overtake compound.
 
+### ToString focused warm benchmark
+
+After the table above, `tests/performance/tostring_bench.cpp` was added to isolate BigMath conversion cost without GMP and to measure warm-cache optimization deltas. The 2026-05-26 ToString pass added bit-length digit estimation, thread-local cached D&C divider chains, 10¹⁹ linear formatting chunks, digit-pair ASCII emission, and a boundary `NewtonDivision::Divider::DivideAndRemainderInto` API.
+
+| size (digits) | pre-pass ms | post-pass ms | speedup |
+|---|---:|---:|---:|
+| 1 000 | 0.0079 | 0.0063-0.0066 | 1.2-1.3× |
+| 10 000 | 1.1224 | 0.2793-0.2924 | 3.8-4.0× |
+| 50 000 | 9.4674 | 3.95-4.05 | 2.3-2.4× |
+| 100 000 | 19.8435 | 8.94-9.05 | 2.2× |
+| 200 000 | 41.1607 | 20.28-20.65 | 2.0× |
+
+The dominant win is cached divider-chain reuse. The `DivideAndRemainderInto` API is currently neutral because it delegates to existing Newton internals; deeper scratch-buffer reuse would need to be pushed into `DivideChunk`, multiplication, and subtraction temporaries.
+
 ---
 
 ## Headline summary
@@ -142,7 +156,7 @@ Skewed (`a.size() >> b.size()`) — Newton/BZ band, real algorithmic work:
 - **Multiplication ≥5M digits:** BigMath faster than GMP (0.89× at 5M, 0.65× at 10M balanced).
 - **Multiplication skewed 2M×200k:** parity (0.98×).
 - **Division skewed:** ~3-6× behind GMP, narrowing slowly with size (NTT-bound — multiplication win flows through Newton's reciprocal iteration).
-- **ToString:** 4.5× at 2M, narrows from 11× peak at 50k. Still the widest residual gap; concentrated in Newton's per-chunk divmod and the linear leaf's `__udivmodti4` (already mitigated by M-G div2by1, PR #43).
+- **ToString:** 4.5× at 2M in the GMP comparison table, with focused warm BigMath-only results now showing a 2-4× improvement from cached divider chains and leaf formatting changes. The remaining gap is still concentrated in Newton's per-chunk divmod and NTT-backed multiplication inside division.
 - **Parse:** 1.7× at 10M, monotonically narrowing.
 
 For optimizations considered and rejected with measurement evidence, see the **Explored but rejected** sections of each subsystem doc. The 2026-05 optimization stack (LIMB_64 + CRT NTT + threading + M-G reciprocals + BZ Knuth fix) closed the GMP gap by 3-5× across every band; the remaining gap concentrates in the basecase NTT butterfly inner loop where GMP's hand-tuned ARM64 assembly maintains an edge.

--- a/docs/STRING_CONVERSION.md
+++ b/docs/STRING_CONVERSION.md
@@ -459,7 +459,7 @@ Profile of `ToString 100 000 digits` under default stack (sample(1), M1 Max):
 |---|---:|
 | `NewtonDivision::Divider::DivideAndRemainder` (D&C chain divmod calls) | ~55% |
 | `NttCrt::Multiply` (internal mults inside Newton's `ApproxReciprocal` + `DivideChunk`) | ~25% |
-| `ToStringLinearAppend` (linear leaf, divmod-10¹⁸ loop) + `__udivmodti4` | ~10% |
+| `ToStringLinearAppend` (linear leaf, divmod-10¹⁹ loop) | ~10% |
 | `ToStringDivConquer` orchestration + Compare/Shift/TrimZeros | ~7% |
 | Allocation + misc | ~3% |
 
@@ -488,9 +488,9 @@ A loosely chronological summary of optimizations that landed and stuck.
 
 The base case for all parsing. Reads 18 ASCII digits at a time, multiplies the partial result by 10¹⁸ via `ClassicMultiplication::MultiplyTo`, adds the chunk via `AddTo`. 18× fewer multi-precision multiplications than a per-digit parser. Has always existed.
 
-### Linear formatter with divmod-10¹⁸
+### Linear formatter with divmod-10¹⁹
 
-The base case for all formatting. Divides by 10¹⁸ in place via `ClassicDivision::DivModTo`, emits 18 ASCII digits per division. Symmetric to the parser. Has always existed.
+The base case for all formatting. Divides by 10¹⁹ in place via `ClassicDivision::DivModTo`, emits 19 ASCII digits per division. Parsing still uses 10¹⁸ so scalar chunk multiplication keeps broad carry headroom; formatting can use the larger divisor safely because it only performs scalar division and the divisor fits in `uint64_t`.
 
 ### `Pow10` memoization
 
@@ -506,23 +506,39 @@ The 2026-05 optimization that produced the largest single ToString win. Chain of
 
 Critical detail: the chain must be constructed top-down with `chain[i] = 10^(L / 2^(i+1))`. An earlier power-of-2-tower construction (`chain[i] = 10^(18 · 2^i)`) gave catastrophically unbalanced splits and made the D&C formatter slower than the linear formatter at 500k digits.
 
+### Cached ToString divider chains
+
+The D&C formatter now keeps a thread-local cache of full decimal divider chains keyed by the top split digit count. `Pow10` values were already cached, but warm `ToString` calls still rebuilt every `NewtonDivision::Divider` reciprocal. Reusing the chain targets the previous chain-construction cost directly and benefits repeated conversions of similarly sized values.
+
+Focused warm benchmark on this repository's `tests/performance/tostring_bench.cpp`:
+
+| size | baseline ms | cached-chain stack ms | speedup |
+|---|---:|---:|---:|
+| 1 000 | 0.0079 | 0.0063-0.0066 | 1.2-1.3× |
+| 10 000 | 1.1224 | 0.2793-0.2924 | 3.8-4.0× |
+| 50 000 | 9.4674 | 3.95-4.05 | 2.3-2.4× |
+| 100 000 | 19.8435 | 8.94-9.05 | 2.2× |
+| 200 000 | 41.1607 | 20.28-20.65 | 2.0× |
+
+The cache is `thread_local` like `Pow10`; entries grow monotonically for the lifetime of the thread.
+
 ### Squaring in `Pow10` even-`d` branch
 
 For even `d`, `Pow10(d) = Pow10(d/2)²`. Using [`Square`](MULTIPLICATION.md#squaring) instead of `Multiply(p, p)` saves one FFT in the NTT case (1.4×) and half the partial products in the Karatsuba/schoolbook case (1.5×). Real-world impact: ~3% on cold-start parse and ToString (caught by the `Pow10` cache after the first invocation).
 
 ### `ToStringLinearAppend` direct ASCII formatting
 
-The linear formatter formats each chunk's digits directly into a `char` buffer using straightforward modular reduction, then `out.append`s the buffer. No intermediate `std::string` allocations per chunk. The top chunk is special-cased to skip leading zeros; lower chunks always emit full 18 digits.
+The linear formatter formats each chunk's digits directly into a `char` buffer, then `out.append`s the buffer. No intermediate `std::string` allocations per chunk. The top chunk is special-cased to skip leading zeros; lower chunks always emit full 19 digits. The current code uses a 100-entry digit-pair table to halve the number of scalar decimal divisions in the ASCII emission loop.
 
 ### Approximate decimal length estimation
 
-`ToString` estimates the output decimal length as `(SizeT)((double)r.size() * 9.633) + 1` (each 32-bit limb is roughly `log10(2³²) ≈ 9.633` decimal digits). The estimate is used to:
+`ToString` estimates the output decimal length from the actual bit length of the most significant limb, using `floor(bits * log10(2)) + 1`. The estimate is used to:
 
 1. Pre-reserve the output string buffer (avoids re-allocation during append).
 2. Decide whether to take the linear or D&C path.
 3. Choose the top `Pow10` for the chain.
 
-The estimate is always an overestimate (rounds up). The overestimate is harmless: pre-reserved buffer holds slightly more than needed; chain construction handles the top split robustly.
+This is still a safe upper bound, but it is tighter than multiplying by total limb count because the most significant limb is often only partially full. That avoids some oversized top-level divider chains near D&C boundaries.
 
 ### 64-bit hybrid Karatsuba leaf (indirect)
 

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -432,6 +432,17 @@ namespace BigMath
             computeRemainder);
       }
 
+      void DivideAndRemainderInto(
+          vector<DataT> const &a,
+          vector<DataT> &q,
+          vector<DataT> &r,
+          bool computeRemainder = true) const
+      {
+        auto qr = DivideAndRemainder(a, computeRemainder);
+        q = std::move(qr.first);
+        r = std::move(qr.second);
+      }
+
       vector<DataT> Divide(vector<DataT> const &a) const
       {
         return DivideAndRemainder(a, false).first;

--- a/include/biginteger/common/Parser.h
+++ b/include/biginteger/common/Parser.h
@@ -35,6 +35,10 @@ namespace BigMath
   // Base 10^18 grouping. 10^18 < 2^60, fits in uint64 with room for 32-bit limb multiply.
   inline constexpr ULong Base10_18 = 1000000000000000000ULL;
   inline constexpr SizeT Base10_18_Zeroes = 18;
+  // Formatting can divide by 10^19 directly. Parsing keeps 10^18 so chunk*limb
+  // multiplication has broad carry headroom across both limb modes.
+  inline constexpr ULong Base10_19 = 10000000000000000000ULL;
+  inline constexpr SizeT Base10_19_Zeroes = 19;
   inline constexpr SizeT DecimalDcThreshold = 8192;
 
 #ifndef BIGMATH_TOSTR_DC_THRESHOLD

--- a/src/common/Parser.cpp
+++ b/src/common/Parser.cpp
@@ -16,6 +16,7 @@
 #include "biginteger/algorithms/division/NewtonDivision.h"
 
 #include <memory>
+#include <cmath>
 #include <unordered_map>
 #include <utility>
 
@@ -195,7 +196,66 @@ namespace BigMath
     return Parse(num, 0, char_processed);
   }
 
-  // Linear divmod-10^18 formatter. Appends to `out`. padTo > 0 pads to exactly
+  namespace
+  {
+    constexpr char DigitPairs[] =
+        "00010203040506070809"
+        "10111213141516171819"
+        "20212223242526272829"
+        "30313233343536373839"
+        "40414243444546474849"
+        "50515253545556575859"
+        "60616263646566676869"
+        "70717273747576777879"
+        "80818283848586878889"
+        "90919293949596979899";
+
+    void AppendUnsignedDecimal(ULong v, std::string &out)
+    {
+      char buf[20];
+      char *p = buf + sizeof(buf);
+      while (v >= 100)
+      {
+        ULong q = v / 100;
+        unsigned rem = (unsigned)(v - q * 100);
+        p -= 2;
+        p[0] = DigitPairs[2 * rem];
+        p[1] = DigitPairs[2 * rem + 1];
+        v = q;
+      }
+      if (v >= 10)
+      {
+        p -= 2;
+        p[0] = DigitPairs[2 * v];
+        p[1] = DigitPairs[2 * v + 1];
+      }
+      else
+      {
+        *--p = (char)('0' + v);
+      }
+      out.append(p, (buf + sizeof(buf)) - p);
+    }
+
+    void AppendPaddedUnsignedDecimal(ULong v, SizeT width, std::string &out)
+    {
+      char buf[20];
+      SizeT pos = width;
+      while (pos >= 2)
+      {
+        ULong q = v / 100;
+        unsigned rem = (unsigned)(v - q * 100);
+        pos -= 2;
+        buf[pos] = DigitPairs[2 * rem];
+        buf[pos + 1] = DigitPairs[2 * rem + 1];
+        v = q;
+      }
+      if (pos == 1)
+        buf[0] = (char)('0' + v);
+      out.append(buf, width);
+    }
+  }
+
+  // Linear divmod-10^19 formatter. Appends to `out`. padTo > 0 pads to exactly
   // padTo decimal digits with leading zeros (used by D&C lower halves).
   void ToStringLinearAppend(std::vector<DataT> r, SizeT padTo, std::string &out)
   {
@@ -214,44 +274,44 @@ namespace BigMath
     std::vector<ULong> chunks;
     chunks.reserve(r.size() + 1);
     while (!(r.size() == 1 && r[0] == 0))
-      chunks.push_back((ULong)ClassicDivision::DivModTo(r, Base10_18, CurrentBase));
+      chunks.push_back((ULong)ClassicDivision::DivModTo(r, Base10_19, CurrentBase));
 
     int topDigits = 0;
     {
       ULong v = chunks.back();
       do { ++topDigits; v /= 10; } while (v);
     }
-    SizeT natural = (chunks.size() - 1) * Base10_18_Zeroes + (SizeT)topDigits;
+    SizeT natural = (chunks.size() - 1) * Base10_19_Zeroes + (SizeT)topDigits;
 
     if (padTo > natural)
       out.append(padTo - natural, '0');
 
-    char buf[20];
-    char *bufEnd = buf + 20;
-
     auto it = chunks.rbegin();
     {
       ULong v = *it++;
-      char *p = bufEnd;
-      do { *--p = (char)('0' + (v % 10)); v /= 10; } while (v);
-      out.append(p, bufEnd - p);
+      AppendUnsignedDecimal(v, out);
     }
     for (; it != chunks.rend(); ++it)
-    {
-      ULong v = *it;
-      for (Int i = (Int)Base10_18_Zeroes - 1; i >= 0; --i)
-      {
-        buf[i] = (char)('0' + (v % 10));
-        v /= 10;
-      }
-      out.append(buf, Base10_18_Zeroes);
-    }
+      AppendPaddedUnsignedDecimal(*it, Base10_19_Zeroes, out);
   }
 
   // Chain entry: 10^digits + its precomputed Newton-reciprocal divider.
   // Built top-down so each level splits its parent in half — balanced T(N) = 2T(N/2) + M(N).
   namespace
   {
+    SizeT EstimateDecimalDigits(std::vector<DataT> const &r)
+    {
+#if BIGMATH_LIMB_64
+      constexpr SizeT limbBits = 64;
+      SizeT highBits = limbBits - (SizeT)__builtin_clzll((ULong)r.back());
+#else
+      constexpr SizeT limbBits = 32;
+      SizeT highBits = limbBits - (SizeT)__builtin_clz((unsigned)r.back());
+#endif
+      long double bits = (long double)(r.size() - 1) * (long double)limbBits + (long double)highBits;
+      return (SizeT)std::floor(bits * 0.3010299956639811952137388947244930267682L) + 1;
+    }
+
     struct DecimalDcEntry
     {
       SizeT digits;
@@ -271,6 +331,17 @@ namespace BigMath
         chain.push_back(std::move(e));
       }
       return chain;
+    }
+
+    std::vector<DecimalDcEntry> const &GetDecimalDcChain(SizeT topDigits)
+    {
+      static thread_local std::unordered_map<SizeT, std::vector<DecimalDcEntry>> cache;
+      auto it = cache.find(topDigits);
+      if (it != cache.end())
+        return it->second;
+
+      auto inserted = cache.emplace(topDigits, BuildDecimalDcChain(topDigits));
+      return inserted.first->second;
     }
 
     void ToStringDivConquer(
@@ -302,11 +373,13 @@ namespace BigMath
         return;
       }
 
-      auto qr = chain[level].divider->DivideAndRemainder(n);
+      std::vector<DataT> q;
+      std::vector<DataT> r;
+      chain[level].divider->DivideAndRemainderInto(n, q, r);
       SizeT half = chain[level].digits;
       SizeT topPad = (padTo > half) ? padTo - half : 0;
-      ToStringDivConquer(std::move(qr.first), chain, level + 1, topPad, out);
-      ToStringDivConquer(std::move(qr.second), chain, level + 1, half, out);
+      ToStringDivConquer(std::move(q), chain, level + 1, topPad, out);
+      ToStringDivConquer(std::move(r), chain, level + 1, half, out);
     }
   } // namespace
 
@@ -319,18 +392,7 @@ namespace BigMath
     while (r.size() > 1 && r.back() == 0)
       r.pop_back();
 
-    // Each LimbBits-wide limb ≈ LimbBits * log10(2) decimal digits.
-    // Base2_32 = 9.633, Base2_64 = 19.266. Used for buffer reserve AND D&C
-    // chain depth — underestimating leaves the linear-leaf chunk way too big
-    // (e.g. Base2_64 with 9.633 underestimates 2×, halves chain depth, and
-    // pushes a 60k-digit value through ToStringLinearAppend, dominating
-    // runtime with __udivmodti4 libcalls).
-#if BIGMATH_LIMB_64
-    constexpr double digitsPerLimb = 19.266;
-#else
-    constexpr double digitsPerLimb = 9.633;
-#endif
-    SizeT approxDigits = (SizeT)((double)r.size() * digitsPerLimb) + 1;
+    SizeT approxDigits = EstimateDecimalDigits(r);
 
     std::string s;
     s.reserve(approxDigits + (isNeg ? 2 : 1));
@@ -343,7 +405,7 @@ namespace BigMath
       return s;
     }
 
-    auto chain = BuildDecimalDcChain(approxDigits / 2);
+    auto const &chain = GetDecimalDcChain(approxDigits / 2);
     ToStringDivConquer(std::move(r), chain, 0, 0, s);
     return s;
   }

--- a/tests/performance/tostring_bench.cpp
+++ b/tests/performance/tostring_bench.cpp
@@ -1,0 +1,90 @@
+// Focused ToString benchmark for decimal conversion experiments.
+
+#include "biginteger/BigInteger.h"
+#include "biginteger/common/Parser.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace BigMath;
+
+static std::string GenerateDigits(int digits, std::uint64_t seed)
+{
+  std::mt19937_64 rng(seed);
+  std::uniform_int_distribution<int> dist(0, 9);
+
+  std::string s;
+  s.reserve((std::size_t)digits);
+  s.push_back((char)('1' + (rng() % 9)));
+  for (int i = 1; i < digits; ++i)
+    s.push_back((char)('0' + dist(rng)));
+  return s;
+}
+
+template <class F>
+static double TimeMs(F &&fn, int iters)
+{
+  auto start = std::chrono::steady_clock::now();
+  for (int i = 0; i < iters; ++i)
+    fn();
+  auto end = std::chrono::steady_clock::now();
+  return std::chrono::duration<double, std::milli>(end - start).count() / iters;
+}
+
+static int Iterations(int digits)
+{
+  if (digits <= 1000) return 80;
+  if (digits <= 10000) return 20;
+  if (digits <= 50000) return 6;
+  if (digits <= 100000) return 3;
+  return 1;
+}
+
+int main(int argc, char **argv)
+{
+  std::vector<int> sizes;
+  if (argc > 1)
+  {
+    for (int i = 1; i < argc; ++i)
+      sizes.push_back(std::atoi(argv[i]));
+  }
+  else
+  {
+    sizes = {1000, 10000, 50000, 100000, 200000};
+  }
+
+  std::cout << "digits,iters,parse_ms,tostring_ms\n";
+  for (int digits : sizes)
+  {
+    std::string input = GenerateDigits(digits, 0xB16B00B5ULL ^ (std::uint64_t)digits);
+    BigInteger value = Parse(input.c_str());
+    std::string warm = ToString(value);
+    if (warm != input)
+    {
+      std::cerr << "round trip failed at " << digits << " digits\n";
+      return 1;
+    }
+
+    int iters = Iterations(digits);
+    double parseMs = TimeMs([&]() {
+      BigInteger parsed = Parse(input.c_str());
+      if (parsed.size() == 0) std::abort();
+    }, iters);
+
+    double toStringMs = TimeMs([&]() {
+      std::string out = ToString(value);
+      if (out.size() != input.size()) std::abort();
+    }, iters);
+
+    std::cout << digits << ',' << iters << ','
+              << std::fixed << std::setprecision(4)
+              << parseMs << ',' << toStringMs << '\n';
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- cache ToString decimal D&C divider chains per thread to reuse Newton reciprocal setup
- estimate decimal digits from actual bit length and use 10^19 formatting chunks with digit-pair ASCII emission
- add a focused ToString benchmark harness and document measured results
- expose NewtonDivision::Divider::DivideAndRemainderInto as a boundary API for future scratch-buffer work

## Benchmarks
Focused warm benchmark: \digits,iters,parse_ms,tostring_ms
1000,80,0.0028,0.0066
10000,20,0.1200,0.2866
50000,6,1.3781,3.9500
100000,3,3.2431,8.8552
200000,1,7.8797,20.1654

Baseline -> final ToString ms:
- 1k: 0.0079 -> 0.0063-0.0066
- 10k: 1.1224 -> 0.2793-0.2924
- 50k: 9.4674 -> 3.95-4.05
- 100k: 19.8435 -> 8.94-9.05
- 200k: 41.1607 -> 20.28-20.65
- 500k final sample: 64.187 ms

## Tests
- \  [PASS] Parse.EmptyAndNullSafe  (0.09 ms)
  [PASS] Parse.JustZero  (0.00 ms)
  [PASS] Parse.LeadingPlus  (0.09 ms)
  [PASS] Parse.LeadingMinus  (0.00 ms)
  [PASS] Parse.LeadingZeros  (0.00 ms)
  [PASS] Parse.AllZeros  (0.00 ms)
  [PASS] Parse.NegativeZeroNormalized  (0.00 ms)
  [PASS] Parse.StopsAtNonDigit  (0.00 ms)
  [PASS] Parse.StopsAtNonDigitWithSign  (0.00 ms)
  [PASS] Parse.EighteenDigitChunkBoundary  (0.00 ms)
  [PASS] ToString.ZeroIsZero  (0.00 ms)
  [PASS] ToString.PadDoesNotApplyOnPublicApi  (0.00 ms)
  [PASS] ToString.NegativeFormatted  (0.00 ms)
  [PASS] RoundTrip.Small_1  (0.00 ms)
  [PASS] RoundTrip.Small_18  (0.00 ms)
  [PASS] RoundTrip.Small_100  (0.00 ms)
  [PASS] RoundTrip.Mid_1000  (0.03 ms)
  [PASS] RoundTrip.AboveFormatDc_3000  (0.23 ms)
  [PASS] RoundTrip.NearParseDc_8000  (0.68 ms)
  [PASS] RoundTrip.AboveParseDc_12000  (1.28 ms)
  [PASS] RoundTrip.Large_25000  (4.05 ms)
  [PASS] IO.OstreamMatchesToString  (0.00 ms)
  [PASS] IO.IstreamRoundTrip  (0.00 ms)
  [PASS] Pow10.SmallPowers  (0.00 ms)
  [PASS] Pow10.LargePowerMatchesString  (0.01 ms)

===========================================================
 Tests: 25 passed, 0 failed   (6.5 ms total)
=========================================================== : 25 passed
- \  [PASS] Add.ZeroIdentity  (0.07 ms)
  [PASS] Add.BothZero  (0.00 ms)
  [PASS] Add.SmallPositive  (0.01 ms)
  [PASS] Add.MultiLimbCarry  (0.00 ms)
  [PASS] Add.CarryChain  (0.00 ms)
  [PASS] Add.Commutative  (0.21 ms)
  [PASS] Add.Associative  (0.11 ms)
  [PASS] Add.NegativePlusPositiveSmaller  (0.00 ms)
  [PASS] Add.NegativePlusPositiveLarger  (0.00 ms)
  [PASS] Add.NegativePlusNegative  (0.00 ms)
  [PASS] Add.CancellationToZero  (0.00 ms)
  [PASS] Sub.ZeroMinusZero  (0.00 ms)
  [PASS] Sub.AnyMinusZero  (0.00 ms)
  [PASS] Sub.ZeroMinusPositive  (0.00 ms)
  [PASS] Sub.ZeroMinusNegative  (0.00 ms)
  [PASS] Sub.EqualToZero  (0.00 ms)
  [PASS] Sub.PositiveMinusSmallerPositive  (0.00 ms)
  [PASS] Sub.PositiveMinusLargerPositive  (0.00 ms)
  [PASS] Sub.BorrowChain  (0.00 ms)
  [PASS] Sub.OppositeSigns  (0.00 ms)
  [PASS] Sub.BothNegative  (0.00 ms)
  [PASS] AddSub.AddThenSubtractRecoversOriginal  (0.24 ms)
  [PASS] MulCross.Tiny_2x2  (0.03 ms)
  [PASS] MulCross.Small_16  (0.01 ms)
  [PASS] MulCross.Mid_64  (0.04 ms)
  [PASS] MulCross.Mid_256  (0.28 ms)
  [PASS] MulCross.Toom3Region_512  (0.86 ms)
  [PASS] MulCross.NTTRegion_1024  (2.55 ms)
  [PASS] MulCross.Skewed_512x16  (0.28 ms)
  [PASS] MulCross.Skewed_1024x32  (0.69 ms)
  [PASS] MulCross.OneByMany  (0.00 ms)
  [PASS] MulCross.ManyByOne  (0.00 ms)
  [PASS] MulCross.MaxCarry257  (0.35 ms)
  [PASS] SquareCross.Small_4  (0.02 ms)
  [PASS] SquareCross.Mid_64  (0.02 ms)
  [PASS] SquareCross.Mid_256  (0.20 ms)
  [PASS] SquareCross.Large_1024  (2.30 ms)
  [PASS] DivCross.Tiny_8x4  (0.03 ms)
  [PASS] DivCross.Mid_64x32  (0.04 ms)
  [PASS] DivCross.Balanced_256  (0.23 ms)
  [PASS] DivCross.AlmostBalanced_257  (0.42 ms)
  [PASS] DivCross.Balanced_1024  (2.03 ms)
  [PASS] DivCross.Skewed_4096_x_1100  (26.31 ms)
  [PASS] DivCross.Skewed_8192_x_512  (26.02 ms)
  [PASS] DivCross.ScalarDivisor  (0.03 ms)
  [PASS] DivCross.ReciprocalReuseAcrossNumerators  (0.60 ms)
  [PASS] Base64Add.ScalarNoCarry  (0.00 ms)
  [PASS] Base64Add.ScalarWithCarryPropagate  (0.00 ms)
  [PASS] Base64Add.MultiLimbCarryChain  (0.00 ms)
  [PASS] Base64Add.ScalarIntoEmptyVector  (0.00 ms)
  [PASS] Base64Sub.ScalarNoBorrow  (0.00 ms)
  [PASS] Base64Sub.ScalarBorrowPropagate  (0.00 ms)
  [PASS] Base64Sub.MultiLimbBorrowChain  (0.00 ms)
  [PASS] Base64Sub.EqualOperandsZero  (0.00 ms)
  [PASS] Base64AddSub.RoundTripRandom  (0.00 ms)
  [PASS] Base64Div.ClassicScalarSmall  (0.00 ms)
  [PASS] Base64Div.ClassicScalarMaxDivisor  (0.00 ms)
  [PASS] Base64Div.FastDivisionSmall2x1  (0.00 ms)
  [PASS] Base64Div.FastDivisionMidBalanced  (0.00 ms)
  [PASS] Base64Div.FastDivisionLargerBalanced  (0.01 ms)
  [PASS] Base64Div.FastDivisionSkewed  (0.03 ms)
  [PASS] Base64Div.FastDivisionMaxFillDivisor  (0.00 ms)
  [PASS] Base64Div.FastDivisionLeadingFFDivisor  (0.01 ms)
  [PASS] Base64Div.FastDivisionAlessB  (0.00 ms)
  [PASS] Base64Kara.AgainstClassicSmall  (0.01 ms)
  [PASS] Base64Kara.AgainstClassicMidUnbalanced  (0.03 ms)
  [PASS] Base64Kara.AgainstClassicMaxFill  (0.01 ms)
  [PASS] Base64Ntt.AgainstClassicSmall  (0.02 ms)
  [PASS] Base64Ntt.AgainstClassicMidUnbalanced  (0.11 ms)
  [PASS] Base64Ntt.AgainstClassicMaxFill  (0.06 ms)
  [PASS] Base64Ntt.KaratsubaVsNttAgree  (0.09 ms)
  [PASS] Base64Mult.ScalarSmall  (0.00 ms)
  [PASS] Base64Mult.ScalarCarryToNewLimb  (0.00 ms)
  [PASS] Base64Mult.ScalarMaxByMax  (0.00 ms)
  [PASS] Base64Mult.VectorScalarRangeForm  (0.00 ms)
  [PASS] Base64Mult.FullProductSmall  (0.00 ms)
  [PASS] Base64Mult.FullProductCarryChain  (0.00 ms)
  [PASS] Base64Mult.FullProductMaxByMax2Limb  (0.00 ms)
  [PASS] Base64Mult.ScalarZeroIsZero  (0.00 ms)
  [PASS] Compare.EqualPositive  (0.00 ms)
  [PASS] Compare.EqualNegative  (0.00 ms)
  [PASS] Compare.PositiveGreaterThanNegative  (0.00 ms)
  [PASS] Compare.NegativeOrderReversed  (0.00 ms)
  [PASS] Compare.ZeroVsNegativeZero  (0.00 ms)
  [PASS] Compare.MultiLimbBoundary  (0.00 ms)
  [PASS] Compare.RawVectorCompare  (0.00 ms)
  [PASS] Construction.DefaultIsZero  (0.00 ms)
  [PASS] Construction.SizedDefaultZero  (0.00 ms)
  [PASS] Construction.NegativeZeroNormalized  (0.15 ms)
  [PASS] Construction.FromVectorTrimmed  (0.00 ms)
  [PASS] Construction.SizedFill  (0.00 ms)
  [PASS] Construction.CopyAndAssign  (0.00 ms)
  [PASS] Construction.UnaryNegationFlipsSign  (0.00 ms)
  [PASS] Construction.UnaryNegationZeroStaysPositive  (0.00 ms)
  [PASS] Construction.SetSignZeroIgnored  (0.00 ms)
  [PASS] Construction.SetSignNonZero  (0.00 ms)
  [PASS] Builder.FromULongZero  (0.00 ms)
  [PASS] Builder.FromULongMax  (0.00 ms)
  [PASS] Builder.FromLongNegative  (0.00 ms)
  [PASS] Builder.FromString  (0.00 ms)
  [PASS] Builder.FromCStrLeadingPlus  (0.00 ms)
  [PASS] Builder.FromCStrLeadingZeros  (0.00 ms)
  [PASS] Builder.FromLongDoubleZero  (0.00 ms)
  [PASS] Builder.FromLongDoublePositive  (0.00 ms)
  [PASS] Builder.FromLongDoubleNegative  (0.00 ms)
  [PASS] DivScalar.ByOne  (0.00 ms)
  [PASS] DivScalar.ZeroOverAny  (0.00 ms)
  [PASS] DivScalar.KnownValue  (0.00 ms)
  [PASS] DivScalar.ByZeroThrows  (0.23 ms)
  [PASS] DivScalar.NegativeNumerator  (0.00 ms)
  [PASS] Div.ByOne  (0.00 ms)
  [PASS] Div.BySelfIsOne  (0.00 ms)
  [PASS] Div.SmallerOverLarger  (0.00 ms)
  [PASS] Div.KnownValue  (0.00 ms)
  [PASS] Div.SignRulesQuotient  (0.00 ms)
  [PASS] Div.ByZeroThrows  (0.01 ms)
  [PASS] DivDispatch.FastBand_Small  (0.00 ms)
  [PASS] DivDispatch.FastBand_Balanced_100  (0.01 ms)
  [PASS] DivDispatch.BZBand_Balanced_1024  (0.02 ms)
  [PASS] DivDispatch.NewtonBand_Skewed  (7.60 ms)
  [PASS] DivDispatch.NewtonBand_VeryLarge  (12.60 ms)
  [PASS] DivDispatch.BZBand_AlmostBalanced  (0.38 ms)
  [PASS] Div.MulThenDivRecovers  (0.16 ms)
  [PASS] Div.IdentityHolds  (0.09 ms)
  [PASS] Eval.Basic  (0.03 ms)
  [PASS] Eval.UnaryMinus  (0.00 ms)
  [PASS] Eval.Power  (0.00 ms)
  [PASS] Eval.Modulo  (0.00 ms)
  [PASS] Eval.DigitSeparator  (0.00 ms)
  [PASS] Eval.HexLiteral  (0.01 ms)
  [PASS] Eval.BinaryLiteral  (0.00 ms)
  [PASS] Eval.Whitespace  (0.00 ms)
  [PASS] Eval.CommentToEndOfLine  (0.00 ms)
  [PASS] Eval.LargePower  (0.00 ms)
  [PASS] Eval.Variables  (0.00 ms)
  [PASS] Eval.ErrorUnknownIdentifier  (0.02 ms)
  [PASS] Eval.ErrorDivByZero  (0.01 ms)
  [PASS] Eval.ErrorNegativeExponent  (0.01 ms)
  [PASS] Eval.ErrorTrailingJunk  (0.01 ms)
  [PASS] Eval.ErrorParenMismatch  (0.02 ms)
  [PASS] MulScalar.ZeroTimesAny  (0.00 ms)
  [PASS] MulScalar.OneTimesAny  (0.00 ms)
  [PASS] MulScalar.NineByNine  (0.00 ms)
  [PASS] MulScalar.KeepsSign  (0.00 ms)
  [PASS] Mul.ZeroTimesBig  (0.00 ms)
  [PASS] Mul.OneTimesBig  (0.00 ms)
  [PASS] Mul.NegativeOneFlipsSign  (0.00 ms)
  [PASS] Mul.SignRules  (0.00 ms)
  [PASS] Mul.ProductSquare  (0.00 ms)
  [PASS] Mul.Commutative  (0.11 ms)
  [PASS] Mul.DistributesOverAdd  (0.08 ms)
  [PASS] MulDispatch.Small32Digits  (0.00 ms)
  [PASS] MulDispatch.ClassicBand_100  (0.01 ms)
  [PASS] MulDispatch.KaratsubaBand_2000  (0.10 ms)
  [PASS] MulDispatch.KaratsubaBand_5000  (0.34 ms)
  [PASS] MulDispatch.NTTBand_20000  (2.65 ms)
  [PASS] MulDispatch.AsymmetricSizes  (0.22 ms)
  [PASS] MulDispatch.ScalarFastPath  (0.00 ms)
  [PASS] Shift.LeftByZeroIsIdentity  (0.00 ms)
  [PASS] Shift.RightByZeroIsIdentity  (0.00 ms)
  [PASS] Shift.ZeroShiftedIsZero  (0.00 ms)
  [PASS] Shift.LeftOneLimbEquals2Pow64  (0.00 ms)
  [PASS] Shift.LeftTwoLimbsEquals2Pow128  (0.00 ms)
  [PASS] Shift.LeftMatchesMultiplyByPowOfTwo64  (0.00 ms)
  [PASS] Shift.RightInvertsLeftWhenMultipleOfLimb  (0.00 ms)
  [PASS] Shift.RightOverflowProducesZero  (0.00 ms)
  [PASS] Shift.RightTruncatesLowLimbs  (0.00 ms)
  [PASS] Shift.SignPreserved  (0.00 ms)
  [PASS] Parse.EmptyAndNullSafe  (0.00 ms)
  [PASS] Parse.JustZero  (0.00 ms)
  [PASS] Parse.LeadingPlus  (0.00 ms)
  [PASS] Parse.LeadingMinus  (0.00 ms)
  [PASS] Parse.LeadingZeros  (0.00 ms)
  [PASS] Parse.AllZeros  (0.00 ms)
  [PASS] Parse.NegativeZeroNormalized  (0.00 ms)
  [PASS] Parse.StopsAtNonDigit  (0.00 ms)
  [PASS] Parse.StopsAtNonDigitWithSign  (0.00 ms)
  [PASS] Parse.EighteenDigitChunkBoundary  (0.00 ms)
  [PASS] ToString.ZeroIsZero  (0.00 ms)
  [PASS] ToString.PadDoesNotApplyOnPublicApi  (0.00 ms)
  [PASS] ToString.NegativeFormatted  (0.00 ms)
  [PASS] RoundTrip.Small_1  (0.00 ms)
  [PASS] RoundTrip.Small_18  (0.00 ms)
  [PASS] RoundTrip.Small_100  (0.01 ms)
  [PASS] RoundTrip.Mid_1000  (0.03 ms)
  [PASS] RoundTrip.AboveFormatDc_3000  (0.15 ms)
  [PASS] RoundTrip.NearParseDc_8000  (0.64 ms)
  [PASS] RoundTrip.AboveParseDc_12000  (1.25 ms)
  [PASS] RoundTrip.Large_25000  (3.94 ms)
  [PASS] IO.OstreamMatchesToString  (0.00 ms)
  [PASS] IO.IstreamRoundTrip  (0.00 ms)
  [PASS] Pow10.SmallPowers  (0.00 ms)
  [PASS] Pow10.LargePowerMatchesString  (0.01 ms)
  [PASS] Util.GcdBasic  (0.00 ms)
  [PASS] Util.TrimZerosStripsTrailing  (0.00 ms)
  [PASS] Util.TrimZerosToOneNeverEmpties  (0.00 ms)
  [PASS] Util.CanonicalZeroIsOneLimbZero  (0.00 ms)
  [PASS] Util.IsZeroEmpty  (0.00 ms)
  [PASS] Util.IsZeroSingleLimb  (0.00 ms)
  [PASS] Util.IsZeroAllZerosManyLimbs  (0.00 ms)
  [PASS] Util.IsZeroAnyNonZero  (0.00 ms)
  [PASS] Util.CompareEqual  (0.00 ms)
  [PASS] Util.CompareIgnoresTrailingZeros  (0.00 ms)
  [PASS] Util.CompareHighLimbWins  (0.00 ms)
  [PASS] Util.ResizeGrowsWithZeros  (0.00 ms)
  [PASS] Util.ResizeNeverShrinks  (0.00 ms)
  [PASS] Util.MakeSameSizePadsBoth  (0.01 ms)
  [PASS] Util.CopyRangeMemcpy  (0.00 ms)
  [PASS] Util.CopyFullVector  (0.00 ms)
  [PASS] Builder.LongDoubleLargeRoundTrip  (0.00 ms)
  [PASS] Builder.ULongRoundTrip  (0.00 ms)
  [PASS] Builder.LongRoundTrip  (0.00 ms)

===========================================================
 Tests: 212 passed, 0 failed   (95.4 ms total)
=========================================================== excluding BigDecimal test TU: 212 passed
- Full unit link including BigDecimal TU was not run because BigDecimal definitions are not linked by the current direct compile command.