### PR TITLE
Retune division dispatch for Base2_64

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -100,6 +100,20 @@ Skewed (`a.size() >> b.size()`) — Newton/BZ band, real algorithmic work:
 - Residual ~3× gap is the structural cost of Newton's chunked iteration vs GMP's `mpn_dcpi1_div_q` (a single recursive divide rather than reciprocal-then-chunk).
 - Balanced cases route through trivial short-circuits and aren't algorithmically meaningful at this size profile.
 
+### Shape-focused division dispatch
+
+`tests/performance/division_shape_bench.cpp` was added after the table above to benchmark meaningful limb-shape division directly. The pass found that the default Base2_64 dispatcher was excluding BZ and sending many near-balanced cases through FastDivision. Dispatch now enables BZ for Base2_64, raises normal Newton entry to 4096-limb divisors, and keeps a high-skew Newton band from 2048-limb divisors at `a >= 8b`.
+
+Representative Base2_64 results:
+
+| shape (limbs) | old dispatch ms | new dispatch ms | main winner |
+|---|---:|---:|---|
+| `4096/2048` | 5.99 | 3.04 | BZ |
+| `6144/4096` | 11.15 | 3.61 | BZ |
+| `10240/4096` | 32.73 | 10.24 | BZ |
+| `12288/8192` | 44.41 | 7.94 | BZ |
+| `20480/2048` (`10n/n`) | 19.15 | 19.19 | Newton |
+
 ---
 
 ## Decimal parse (string → BigInteger)

--- a/division_improvement_plan.md
+++ b/division_improvement_plan.md
@@ -1,0 +1,111 @@
+# Division Improvement Plan
+
+## Diagnosis
+
+BigMath skewed division remains roughly 3-6x behind GMP in `BENCHMARK.md`, narrowing to about 3x at the largest tested sizes. The dominant path is Newton division. `docs/DIVISION.md` profiles the cost as mostly `NewtonDivision::DivideNormalizedWithReciprocal` plus `ApproxReciprocal`, both driven by NTT multiplication.
+
+Small allocation-only changes are unlikely to move the result. The next useful work should focus on dispatch, recursive division shape, and reducing Newton's multiplication cost.
+
+## 1. Audit Burnikel-Ziegler Dispatch Under Base2_64
+
+Status: completed.
+
+`src/algorithms/Division.cpp` currently gates BZ with `base == Base2_32`, while the default build uses `BIGMATH_LIMB_64=1` and `CurrentBase == Base2_64`. Verify whether this is intentional or a stale guard.
+
+Benchmark direct calls to `FastDivision`, `BurnikelZieglerDivision`, `NewtonDivision`, and dispatcher for:
+
+```text
+1024/512, 2048/1024, 4096/2048, 8192/4096,
+16384/8192, 32768/16384
+```
+
+If BZ is correct and faster for Base2_64, enable it in dispatch and update docs.
+
+Finding: BZ is correct under Base2_64 and is much faster than FastDivision on near-balanced shapes. Dispatch now allows BZ for `Base2_64`.
+
+## 2. Add Shape-Focused Division Benchmarks
+
+Status: completed.
+
+Current benchmark coverage emphasizes equal-size short-circuit cases and skewed Newton cases. Add a benchmark focused on meaningful division shapes:
+
+```text
+2n/n, 3n/2n, 5n/2n, 3n/n, 5n/n, 10n/n
+```
+
+Record direct algorithm timings and dispatcher choice. Use this before retuning thresholds.
+
+Added `tests/performance/division_shape_bench.cpp`.
+
+## 3. Retune Dispatch Thresholds
+
+Status: completed.
+
+After benchmark coverage exists, regenerate thresholds for:
+
+- Newton divisor lower bound
+- Newton skew ratio
+- BZ divisor threshold
+- BZ recursion threshold
+- Base2_64-specific BZ eligibility
+
+Avoid tightening Newton back to `4*b`; prior docs show that caused severe boundary regressions.
+
+Finding: Newton was entering too early for 1024-2048 limb divisors. The retune uses:
+
+- medium-skew Newton: `b >= 4096` and `a >= 3b`
+- high-skew Newton: `b >= 2048` and `a >= 8b`
+- BZ: enabled for both `Base2_32` and `Base2_64`
+
+## 4. Prototype GMP-Style Pre-Inverted D&C Division
+
+Status: prototyped and rejected for now.
+
+The largest structural gap is Newton chunked division versus GMP's recursive pre-inverted division. Prototype a new recursive path for large `2n/n` and near-balanced inputs, similar in spirit to GMP's `mpn_dcpi1_div_q`.
+
+Target:
+
+- precompute inverse once
+- compute quotient blocks recursively
+- avoid Newton's repeated full reciprocal chunk multiplications where possible
+- benchmark against BZ and Newton
+
+This is the highest-ceiling improvement, but also the highest-risk change.
+
+Experiment: implemented a precomputed BZ divisor tree that cached divisor splits and high-half recursive dividers across BZ blocks. It measured mixed/flat against the existing BZ implementation, so it was reverted. A true GMP-style `mpn_dcpi1_div_q` equivalent still requires a deeper algorithmic implementation, not just cached BZ structure.
+
+## 5. Investigate True Truncated Products
+
+Status: investigated, not implemented.
+
+Newton often only needs the high half of products such as `chunk * reciprocal`. The previous Mulders-style high product was rejected because it decomposed one NTT into two NTTs and measured flat.
+
+Only revisit this if the implementation reduces actual NTT work, for example with a true high-window convolution or truncated NTT API.
+
+Finding: the current multiplication API always computes full products, and the prior exact `MulHigh` experiment decomposed one NTT into two NTTs and measured flat. No production change was made.
+
+## 6. Improve Medium-Band FastDivision
+
+FastDivision still matters below Newton/BZ thresholds and for small divisors. Benchmark and consider:
+
+- quotient-only path when remainder is not needed
+- tighter Base2_64 subtract-multiply pointer loops
+- small divisor bands: `m/2`, `m/4`, `m/8`, `m/16`, `m/32`, `m/64`
+- avoiding temporary resizing in hot loops
+
+This will not close the large Newton gap, but can reduce medium-size regressions.
+
+## Avoid For Now
+
+- Reattempting the previous Mulders `MulHigh`; it measured flat.
+- Division-layer scratch buffers without output-buffer multiplication/subtraction; a ToString/Newton scratch experiment regressed.
+- Lowering BZ recursion threshold blindly below 512 limbs.
+- Removing `NewtonDivision::Divider`; cached reciprocal division is critical for repeated-divisor workloads and ToString.
+
+## Recommended Order
+
+1. Audit and benchmark BZ with Base2_64.
+2. Add shape-focused division benchmarks.
+3. Retune dispatch thresholds from measurements.
+4. Prototype pre-inverted recursive division for `2n/n`.
+5. Investigate true truncated NTT/high-product support only after the above.

--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -62,9 +62,9 @@ flowchart TD
     C -- no --> D{Compare&#40;a, b&#41;}
     D -- a == b --> Eq[return &#123;1, 0&#125;]
     D -- a &lt; b --> Less[return &#123;0, a&#125;]
-    D -- a &gt; b --> E{b.size &gt;= NEWTON_MEDIUM_B<br/>AND<br/>a.size·DEN &gt;= b.size·NUM?}
+    D -- a &gt; b --> E{Newton medium-skew<br/>or high-skew band?}
     E -- yes --> N[NewtonDivision]
-    E -- no --> F{Base2_32<br/>AND b.size &gt; BZ_THRESHOLD<br/>AND BZ band fits?}
+    E -- no --> F{Power-of-two base<br/>AND b.size &gt; BZ_THRESHOLD<br/>AND BZ band fits?}
     F -- yes --> BZ[BurnikelZieglerDivision]
     F -- no --> FD[FastDivision]
 ```
@@ -75,9 +75,12 @@ Default thresholds (overridable via `-D...`):
 
 | macro | default | unit | meaning |
 |---|---|---|---|
-| `BIGMATH_NEWTON_MEDIUM_B` | `1024` | limbs | Newton lower bound for divisor size |
-| `BIGMATH_NEWTON_SKEW_NUMERATOR` | `3` | — | Newton requires `a.size() ≥ 3·b.size() / 1` |
+| `BIGMATH_NEWTON_MEDIUM_B` | `4096` | limbs | Newton lower bound for medium-skew division |
+| `BIGMATH_NEWTON_SKEW_NUMERATOR` | `3` | — | medium-skew Newton requires `a.size() ≥ 3·b.size() / 1` |
 | `BIGMATH_NEWTON_SKEW_DENOMINATOR` | `1` | — | |
+| `BIGMATH_NEWTON_HIGH_SKEW_B` | `2048` | limbs | lower bound for very-high-skew Newton |
+| `BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR` | `8` | — | high-skew Newton requires `a.size() ≥ 8·b.size() / 1` |
+| `BIGMATH_NEWTON_HIGH_SKEW_DENOMINATOR` | `1` | — | |
 | `BIGMATH_NEWTON_LARGE_B` | `24576` | limbs | declared but **unused** in current dispatch — historical |
 | `BIGMATH_BZ_DIVISOR_THRESHOLD` | `512` | limbs | BZ entry guard |
 | `BIGMATH_BZ_RECURSION_THRESHOLD` | `512` | limbs | BZ base-case cutoff (inside `BurnikelZieglerDivision.h`) |
@@ -85,15 +88,16 @@ Default thresholds (overridable via `-D...`):
 The current dispatch logic, paraphrased:
 
 ```
-1. b.size ≥ 1024  AND  a.size ≥ 3·b.size                                  → Newton
-2. Base2_32  AND  b.size > 512  AND
+1. (b.size ≥ 4096 AND a.size ≥ 3·b.size)
+   OR (b.size ≥ 2048 AND a.size ≥ 8·b.size)                               → Newton
+2. (Base2_32 OR Base2_64)  AND  b.size > 512  AND
    ( (b.size ≥ 1024 AND a.size ≤ 3·b.size)
      OR (a.size > 2048 AND a.size > 3·b.size) )                           → Burnikel–Ziegler
 3. else                                                                   → FastDivision
 4. (b.size == 1 inside FastDivision)                                      → ClassicDivision
 ```
 
-The ordering matters: Newton wins on **skewed** problems (large dividend over medium divisor) because the per-divisor reciprocal setup amortizes over multiple chunks. BZ wins on **near-balanced** large problems where its 2n/n recursion structure shines. FastDivision is the default workhorse for everything else.
+The ordering matters: Newton wins on **large skewed** problems because the per-divisor reciprocal setup amortizes over multiple chunks. BZ wins on **near-balanced and mid-size skewed** problems where its 2n/n recursion structure beats both FastDivision and Newton's setup cost. FastDivision is the default workhorse for everything else.
 
 `KnuthDivision` and `ReciprocalDivision` exist as alternate implementations used by correctness tests for cross-checking. They are not in the production dispatch path.
 
@@ -400,6 +404,33 @@ One extra Newton refinement iteration at full precision when the dividend window
 ### Dispatcher band tuning (2026-05)
 
 The GMP bench surfaced a 72× regression on `200k / 50k` digits. Tracing showed the dispatcher predicate `a.size() ≥ 4·b.size()` was missing the case by 1–3 limbs at random sizes (`a = 20763, b = 5191` vs `4·5191 = 20764`). Lowering `NEWTON_SKEW_NUMERATOR` from 4 to 3 admitted these boundary cases to Newton. `NEWTON_MEDIUM_B` lowered from 8192 to 1024 after observing Newton beats FastDivision at much smaller divisors than the old guess. Result: that case dropped to 14×, a 5.3× improvement.
+
+### Base2_64 BZ dispatch and shape-focused retune (2026-05-26)
+
+`tests/performance/division_shape_bench.cpp` was added to benchmark meaningful division shapes directly: `2n/n`, `3n/2n`, `3n/n`, `5n/2n`, `5n/n`, and `10n/n`. This exposed a stale dispatcher guard: BZ itself supports Base2_64, but dispatch required `base == Base2_32`, so the default Base2_64 build routed many near-balanced cases to quadratic FastDivision.
+
+The dispatcher now allows BZ for both `Base2_32` and `Base2_64`, raises the medium-skew Newton floor to 4096 limbs, and adds a separate very-high-skew Newton band at 2048 limbs with ratio `a >= 8b`.
+
+Representative Base2_64 timings before the dispatch fix:
+
+| shape | fast ms | BZ ms | Newton ms | old dispatch ms | best |
+|---|---:|---:|---:|---:|---|
+| `4096/2048` | 5.25 | 3.04 | 7.51 | 5.99 | BZ |
+| `6144/4096` | 10.56 | 3.74 | 7.64 | 11.15 | BZ |
+| `10240/4096` | 31.61 | 10.37 | 11.94 | 32.73 | BZ |
+| `12288/8192` | 43.42 | 8.10 | 13.92 | 44.41 | BZ |
+
+After the retune, dispatch tracks the measured winner or near-winner:
+
+| shape | fast ms | BZ ms | Newton ms | new dispatch ms |
+|---|---:|---:|---:|---:|
+| `4096/2048` | 5.26 | 3.04 | 7.54 | 3.04 |
+| `6144/4096` | 10.51 | 3.69 | 7.61 | 3.61 |
+| `10240/4096` | 31.59 | 10.31 | 11.73 | 10.24 |
+| `12288/8192` | 43.38 | 8.00 | 13.84 | 7.94 |
+| `20480/2048` (`10n/n`) | 47.52 | 22.90 | 19.30 | 19.19 |
+
+The precomputed BZ divisor-tree prototype, a practical version of pre-inverted recursive D&C for this codebase, was also tried. It cached divisor splits and high-half recursive dividers across BZ blocks. It measured mixed/flat, so it was reverted: the current static BZ recursion remains simpler and just as fast.
 
 ### Newton reciprocal allocation cleanup
 

--- a/include/biginteger/algorithms/Division.h
+++ b/include/biginteger/algorithms/Division.h
@@ -4,7 +4,7 @@
  * Dispatch order:
  *   1. b ≥ NEWTON_MEDIUM_B  AND  a ≥ NEWTON_SKEW_NUMERATOR/DENOMINATOR · b
  *      → NewtonDivision      (blockwise handles arbitrary ratio via reciprocal cache)
- *   2. Base2_32  AND  b > BZ_DIVISOR_THRESHOLD  AND  BZ band fits
+ *   2. Power-of-two base  AND  b > BZ_DIVISOR_THRESHOLD  AND  BZ band fits
  *      → BurnikelZieglerDivision    (balanced 2n/n recursion)
  *   3. else
  *      → FastDivision        (Knuth Algorithm D, hybrid-64-bit basecase)
@@ -34,7 +34,7 @@ namespace BigMath
 #endif
 
 #ifndef BIGMATH_NEWTON_MEDIUM_B
-#define BIGMATH_NEWTON_MEDIUM_B 1024
+#define BIGMATH_NEWTON_MEDIUM_B 4096
 #endif
 
 #ifndef BIGMATH_BZ_DIVISOR_THRESHOLD
@@ -49,11 +49,26 @@ namespace BigMath
 #define BIGMATH_NEWTON_SKEW_DENOMINATOR 1
 #endif
 
+#ifndef BIGMATH_NEWTON_HIGH_SKEW_B
+#define BIGMATH_NEWTON_HIGH_SKEW_B 2048
+#endif
+
+#ifndef BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR
+#define BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR 8
+#endif
+
+#ifndef BIGMATH_NEWTON_HIGH_SKEW_DENOMINATOR
+#define BIGMATH_NEWTON_HIGH_SKEW_DENOMINATOR 1
+#endif
+
   extern const SizeT NEWTON_LARGE_B;
   extern const SizeT NEWTON_MEDIUM_B;
   extern const SizeT BZ_DIVISOR_THRESHOLD;
   extern const SizeT NEWTON_SKEW_NUMERATOR;
   extern const SizeT NEWTON_SKEW_DENOMINATOR;
+  extern const SizeT NEWTON_HIGH_SKEW_B;
+  extern const SizeT NEWTON_HIGH_SKEW_NUMERATOR;
+  extern const SizeT NEWTON_HIGH_SKEW_DENOMINATOR;
 
   std::pair<std::vector<DataT>, std::vector<DataT>> DivideAndRemainder(
       std::vector<DataT> const &a,

--- a/src/algorithms/Division.cpp
+++ b/src/algorithms/Division.cpp
@@ -15,6 +15,9 @@ namespace BigMath
   const SizeT BZ_DIVISOR_THRESHOLD = BIGMATH_BZ_DIVISOR_THRESHOLD;
   const SizeT NEWTON_SKEW_NUMERATOR = BIGMATH_NEWTON_SKEW_NUMERATOR;
   const SizeT NEWTON_SKEW_DENOMINATOR = BIGMATH_NEWTON_SKEW_DENOMINATOR;
+  const SizeT NEWTON_HIGH_SKEW_B = BIGMATH_NEWTON_HIGH_SKEW_B;
+  const SizeT NEWTON_HIGH_SKEW_NUMERATOR = BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR;
+  const SizeT NEWTON_HIGH_SKEW_DENOMINATOR = BIGMATH_NEWTON_HIGH_SKEW_DENOMINATOR;
 
   std::pair<std::vector<DataT>, std::vector<DataT>> DivideAndRemainder(
       std::vector<DataT> const &a,
@@ -39,15 +42,19 @@ namespace BigMath
 
     // Newton handles any ratio via blockwise mode; pick when divisor is large enough
     // for reciprocal-setup amortization and skew is in band.
-    bool newton_eligible =
+    bool newton_medium_skew =
         b.size() >= NEWTON_MEDIUM_B &&
         NEWTON_SKEW_DENOMINATOR * a.size() >= NEWTON_SKEW_NUMERATOR * b.size();
+    bool newton_high_skew =
+        b.size() >= NEWTON_HIGH_SKEW_B &&
+        NEWTON_HIGH_SKEW_DENOMINATOR * a.size() >= NEWTON_HIGH_SKEW_NUMERATOR * b.size();
+    bool newton_eligible = newton_medium_skew || newton_high_skew;
     if (newton_eligible)
       return NewtonDivision::DivideAndRemainder(a, b, base, computeRemainder);
 
     // BZ for large near-balanced divisors and for big-and-skewed cases.
     bool bz_eligible =
-        base == Base2_32 &&
+        (base == Base2_32 || base == Base2_64) &&
         b.size() > BZ_DIVISOR_THRESHOLD &&
         ((b.size() >= 1024 && a.size() <= 3 * b.size()) ||
          (a.size() > 2048 && a.size() > 3 * b.size()));

--- a/tests/performance/division_shape_bench.cpp
+++ b/tests/performance/division_shape_bench.cpp
@@ -1,0 +1,188 @@
+// Shape-focused division benchmark for dispatcher tuning.
+
+#include "biginteger/BigInteger.h"
+#include "biginteger/algorithms/Division.h"
+#include "biginteger/algorithms/Multiplication.h"
+#include "biginteger/algorithms/division/BurnikelZieglerDivision.h"
+#include "biginteger/algorithms/division/FastDivision.h"
+#include "biginteger/algorithms/division/NewtonDivision.h"
+#include "biginteger/common/Comparator.h"
+#include "biginteger/common/Util.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace BigMath;
+
+namespace
+{
+  volatile SizeT sink = 0;
+
+  std::vector<DataT> RandomNumber(SizeT limbs, std::mt19937_64 &gen)
+  {
+    std::vector<DataT> value(limbs);
+    for (SizeT i = 0; i < limbs; ++i)
+    {
+#if BIGMATH_LIMB_64
+      value[i] = (DataT)gen();
+#else
+      value[i] = (DataT)(gen() & 0xFFFFFFFFULL);
+#endif
+    }
+    if (!value.empty())
+    {
+#if BIGMATH_LIMB_64
+      value.back() |= 0x8000000000000000ULL;
+#else
+      value.back() |= 0x80000000ULL;
+#endif
+    }
+    TrimZerosToOne(value);
+    return value;
+  }
+
+  template <class F>
+  double BestMs(F &&fn, int reps)
+  {
+    double best = std::numeric_limits<double>::max();
+    for (int i = 0; i < reps; ++i)
+    {
+      auto start = std::chrono::steady_clock::now();
+      SizeT check = fn();
+      auto end = std::chrono::steady_clock::now();
+      sink += check;
+      best = std::min(best, std::chrono::duration<double, std::milli>(end - start).count());
+    }
+    return best;
+  }
+
+  int RepsFor(SizeT divisorLimbs)
+  {
+    if (divisorLimbs <= 256) return 7;
+    if (divisorLimbs <= 2048) return 5;
+    if (divisorLimbs <= 8192) return 3;
+    return 1;
+  }
+
+  std::string Winner(double fast, double bz, double newton, double dispatch)
+  {
+    std::string name = "fast";
+    double best = fast;
+    if (bz < best)
+    {
+      best = bz;
+      name = "bz";
+    }
+    if (newton < best)
+    {
+      best = newton;
+      name = "newton";
+    }
+    if (dispatch < best)
+      name = "dispatch";
+    return name;
+  }
+
+  void CheckResult(
+      std::vector<DataT> const &a,
+      std::vector<DataT> const &b,
+      std::pair<std::vector<DataT>, std::vector<DataT>> const &qr)
+  {
+    std::vector<DataT> qb = Multiply(qr.first, b, BigInteger::Base());
+    std::vector<DataT> recomposed = Add(qb, qr.second, BigInteger::Base());
+    TrimZerosToOne(recomposed);
+    if (Compare(recomposed, a) != 0 || Compare(qr.second, b) >= 0)
+    {
+      std::cerr << "division result mismatch\n";
+      std::abort();
+    }
+  }
+
+  struct Case
+  {
+    const char *shape;
+    SizeT dividendLimbs;
+    SizeT divisorLimbs;
+  };
+}
+
+int main(int argc, char **argv)
+{
+  std::vector<SizeT> divisors = {512, 1024, 2048, 4096, 8192};
+  if (argc > 1)
+  {
+    divisors.clear();
+    for (int i = 1; i < argc; ++i)
+      divisors.push_back((SizeT)std::strtoull(argv[i], nullptr, 10));
+  }
+
+  std::cout << "base=" << BigInteger::Base() << "\n";
+  std::cout << "shape,dividend_limbs,divisor_limbs,fast_ms,bz_ms,newton_ms,dispatch_ms,winner\n";
+
+  std::mt19937_64 gen(0xD1715100B16B00B5ULL);
+  for (SizeT n : divisors)
+  {
+    std::vector<Case> cases = {
+        {"2n/n", 2 * n, n},
+        {"3n/2n", 3 * n, 2 * n},
+        {"3n/n", 3 * n, n},
+        {"5n/2n", 5 * n, 2 * n},
+        {"5n/n", 5 * n, n},
+        {"10n/n", 10 * n, n},
+    };
+
+    for (auto const &c : cases)
+    {
+      std::vector<DataT> a = RandomNumber(c.dividendLimbs, gen);
+      std::vector<DataT> b = RandomNumber(c.divisorLimbs, gen);
+      if (Compare(a, b) <= 0)
+        a.push_back(1);
+
+      auto reference = FastDivision::DivideAndRemainder(a, b, BigInteger::Base(), true);
+      CheckResult(a, b, reference);
+
+      int reps = RepsFor(c.divisorLimbs);
+
+      double fast = BestMs([&]() {
+        auto qr = FastDivision::DivideAndRemainder(a, b, BigInteger::Base(), true);
+        return (SizeT)(qr.first.size() + qr.second.size());
+      }, reps);
+
+      double bz = BestMs([&]() {
+        auto qr = BurnikelZieglerDivision::DivideAndRemainder(a, b, BigInteger::Base(), true);
+        CheckResult(a, b, qr);
+        return (SizeT)(qr.first.size() + qr.second.size());
+      }, reps);
+
+      double newton = BestMs([&]() {
+        auto qr = NewtonDivision::DivideAndRemainder(a, b, BigInteger::Base(), true);
+        CheckResult(a, b, qr);
+        return (SizeT)(qr.first.size() + qr.second.size());
+      }, std::max(1, reps / 2));
+
+      double dispatch = BestMs([&]() {
+        auto qr = DivideAndRemainder(a, b, BigInteger::Base(), true);
+        CheckResult(a, b, qr);
+        return (SizeT)(qr.first.size() + qr.second.size());
+      }, reps);
+
+      std::cout << c.shape << ','
+                << c.dividendLimbs << ','
+                << c.divisorLimbs << ','
+                << std::fixed << std::setprecision(4)
+                << fast << ',' << bz << ',' << newton << ',' << dispatch << ','
+                << Winner(fast, bz, newton, dispatch) << '\n';
+    }
+  }
+
+  std::cerr << "checksum=" << sink << '\n';
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add a shape-focused division benchmark covering 2n/n, 3n/2n, 3n/n, and skewed bands
- enable Burnikel-Ziegler dispatch for Base2_64, where direct benchmarks show it is much faster than FastDivision for near-balanced cases
- retune Newton dispatch into medium-skew and high-skew bands so BZ covers 1024-2048 limb moderate-skew cases while Newton still handles very-high-skew cases
- document the findings in BENCHMARK.md, docs/DIVISION.md, and division_improvement_plan.md

## Benchmark highlights
Command: /tmp/division_shape_bench 512 1024 2048 4096 8192

Representative Base2_64 old dispatch -> new dispatch:
- 4096/2048: 5.99 ms -> 3.04 ms
- 6144/4096: 11.15 ms -> 3.61 ms
- 10240/4096: 32.73 ms -> 10.24 ms
- 12288/8192: 44.41 ms -> 7.94 ms
- 20480/2048 high-skew remains Newton: ~19.15 ms -> ~19.19 ms

Also prototyped a precomputed BZ divisor tree as a practical pre-inverted D&C experiment; it measured mixed/flat and was reverted. True truncated NTT/high-product support was reviewed but not implemented because the existing MulHigh attempt already measured flat unless actual NTT work is reduced.

## Tests
- /tmp/div_correctness passed
- /tmp/division_shape_bench 512 1024 2048 4096 8192 passed with cross-checks