### PR TITLE
Tune multiplication dispatch for skewed shapes

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -64,6 +64,17 @@ Skewed (`a.size() >> b.size()`):
 - Below 1M, GMP's hand-tuned basecase keeps a 1.4-2.6× lead.
 - Skewed mults stay within a 1.0-1.6× band across the size range. The 2M×200k case is at parity; larger skewed sizes drag the smaller operand into BigMath's NTT-bound regime asymmetrically while GMP keeps the small operand in its well-tuned mid-band.
 
+### Shape-focused multiplication dispatch
+
+`tests/performance/multiplication_shape_bench.cpp` was added to measure direct Classic, Karatsuba, NTT, dispatcher, and an experimental blockwise-skew prototype by limb shape. It found one production dispatch miss: tiny high-skew operands should not enter Karatsuba.
+
+| limb shape | previous dispatch | retuned dispatch | impact |
+|---|---:|---:|---|
+| `1280x64` (`20n/n`) | 0.1522 ms | 0.0848 ms | 1.8× faster |
+| `3200x64` (`50n/n`) | 0.4469 ms | ~0.21-0.25 ms | ~1.8-2.1× faster |
+
+The blockwise-skew prototype wins some `min=64` microbenchmarks but loses at larger smaller-operand sizes, so it remains benchmark-only. A Barrett modular multiply experiment for CRT NTT primes was slower than the existing `% P` lowering and was rejected.
+
 ---
 
 ## Division

--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -519,6 +519,19 @@ The largest case is unchanged because the Goldilocks NTT coefficient capacity is
 
 Opt-out: `-DBIGMATH_LIMB_64=0` reverts to 32-bit limbs.
 
+### Shape-aware skew dispatch and NTT finalization pass (2026-05)
+
+`tests/performance/multiplication_shape_bench.cpp` measures balanced and skewed limb shapes directly against Classic, Karatsuba, NTT, dispatcher, and an experimental blockwise-skew prototype. This exposed one real dispatch miss: very small high-skew operands were entering Karatsuba even when Classic was faster.
+
+The production dispatcher now keeps `minSize <= 64` and `maxSize >= 10 * minSize` on Classic. Representative M1 Max timings:
+
+| shape | before dispatch | after dispatch | reason |
+|---|---:|---:|---|
+| `1280x64` limbs (`20n/n`) | 0.1522 ms | 0.0848 ms | avoid Karatsuba skew overhead |
+| `3200x64` limbs (`50n/n`) | 0.4469 ms | ~0.21-0.25 ms | avoid Karatsuba skew overhead |
+
+The same pass simplified Base2_64 finalization in `NTTMultiplication` and CRT NTT by packing fixed groups of coefficients directly into output limbs. End-to-end gains are small and noisy, but the implementation removes slot/flush lambda overhead from a hot path and passed the multiplication correctness suite.
+
 ---
 
 ## Future opportunities
@@ -540,9 +553,9 @@ Predicted end-to-end multiplication wins:
 
 Also covered in [DIVISION.md §Improving skewed division](DIVISION.md#improving-skewed-division-beyond-the-current-floor) under "Faster NTT kernel". The original rejection (see below) was about extending the operand-size range; the current motivation is fewer coefficients at the same range. Worth a fresh look if multithreading isn't enough.
 
-### NTT butterfly assembly
+### Prepared/reusable NTT operands
 
-The NTT butterfly is 95–97% of cost for large mults. Replacing the inner loop with hand-tuned ARM64 assembly using paired loads, optimal `MUL`/`UMULH` scheduling, and explicit `CSEL` for the branchless reduce could plausibly recover 30–50% of the ~1.5–2× gap to GMP at large sizes. Cost: significant — needs a per-platform asm file with care taken for register allocation, plus a fallback C++ path for non-ARM64 targets. Maintenance burden high.
+Repeated multiplication by the same large operand could cache coefficient splitting, transform size, and forward spectra. This does not help one-off `Multiply(a, b)` because the legal transform size depends on both operands. A useful implementation needs an explicit prepared-operand API and invalidation rules for Goldilocks vs CRT modes.
 
 ### NTT butterfly assembly
 
@@ -616,6 +629,14 @@ The apparent wins below 512 limbs are not real Toom-5 wins because `Toom5Multipl
 ### Lowering `NTT_MULTIPLICATION_THRESHOLD` below 4096
 
 Direct algorithm microbenchmarks can make NTT look attractive too early. End-to-end dispatcher sweeps tell a different story: NTT-via-dispatcher below total size ~4096 is slower than Karatsuba-via-dispatcher because the path has setup overhead (coefficient packing, twiddle cache lookup, and buffer preparation) that algorithm-direct benchmarks do not fully capture. The 2026-05 portable C++ NTT plan/cache/finalization pass retuned `NTT_THRESHOLD` to 4096 total limbs. Lesson: don't tune dispatch from microbenchmarks alone.
+
+### Blockwise skew multiplication in dispatch
+
+A prototype split the larger operand into chunks, multiplied each chunk by the smaller operand, and accumulated shifted partial products. It remains in `multiplication_shape_bench.cpp` for experiments. It can win in narrow `min=64`, high-ratio microbenchmarks, but it regressed when promoted into production dispatch and loses once the smaller operand reaches 512+ limbs because repeated setup and accumulation exceed one full NTT.
+
+### Barrett reduction for CRT NTT primes
+
+CRT NTT uses fixed 32-bit primes, so Barrett reduction looked like an obvious way to avoid `% P` in `ModField::Mul`. The prototype regressed all tested CRT-heavy rows, including the `512`, `1024`, `2048`, and `4096` limb shape sweeps. The compiler's division/modulo lowering for these constants is already better than the generic Barrett sequence in this loop.
 
 ### PGO (Profile-Guided Optimization)
 

--- a/include/biginteger/algorithms/Multiplication.h
+++ b/include/biginteger/algorithms/Multiplication.h
@@ -47,9 +47,19 @@ namespace BigMath
 #define BIGMATH_CLASSIC_MIN_LIMB_THRESHOLD 0
 #endif
 
+#ifndef BIGMATH_CLASSIC_SKEW_MIN_LIMB_THRESHOLD
+#define BIGMATH_CLASSIC_SKEW_MIN_LIMB_THRESHOLD 64
+#endif
+
+#ifndef BIGMATH_CLASSIC_SKEW_RATIO
+#define BIGMATH_CLASSIC_SKEW_RATIO 10
+#endif
+
   extern const SizeT CLASSIC_MULTIPLICATION_THRESHOLD;
   extern const SizeT NTT_MULTIPLICATION_THRESHOLD;
   extern const SizeT CLASSIC_MIN_LIMB_THRESHOLD;
+  extern const SizeT CLASSIC_SKEW_MIN_LIMB_THRESHOLD;
+  extern const SizeT CLASSIC_SKEW_RATIO;
 
   std::vector<DataT> Multiply(std::vector<DataT> const &a,
                               std::vector<DataT> const &b,

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -78,30 +78,38 @@ namespace BigMath
             result.reserve(coeffCount / 4 + 2);
 
             ULong carry = 0;
-            ULong limb_acc = 0;
-            int slot = 0; // 0..3 within the current limb
-
-            auto flush = [&result, &limb_acc, &slot](bool force)
+            SizeT i = 0;
+            for (; i + 3 < coeffCount; i += 4)
             {
-                if (slot == 4 || (force && slot != 0))
-                {
-                    result.push_back((DataT)limb_acc);
-                    limb_acc = 0;
-                    slot = 0;
-                }
-            };
+                ULong total0 = coeffs[i] + carry;
+                ULong d0 = total0 & 0xFFFFULL;
+                carry = total0 >> 16;
 
-            for (SizeT i = 0; i < coeffCount; ++i)
+                ULong total1 = coeffs[i + 1] + carry;
+                ULong d1 = total1 & 0xFFFFULL;
+                carry = total1 >> 16;
+
+                ULong total2 = coeffs[i + 2] + carry;
+                ULong d2 = total2 & 0xFFFFULL;
+                carry = total2 >> 16;
+
+                ULong total3 = coeffs[i + 3] + carry;
+                ULong d3 = total3 & 0xFFFFULL;
+                carry = total3 >> 16;
+
+                result.push_back((DataT)(d0 | (d1 << 16) | (d2 << 32) | (d3 << 48)));
+            }
+
+            ULong limb_acc = 0;
+            int slot = 0;
+            for (; i < coeffCount; ++i)
             {
                 ULong total = coeffs[i] + carry;
                 ULong digit = total & 0xFFFFULL;
                 carry = total >> 16;
-
                 limb_acc |= digit << (slot * 16);
                 ++slot;
-                flush(false);
             }
-
             while (carry > 0)
             {
                 ULong digit = carry & 0xFFFFULL;
@@ -109,10 +117,16 @@ namespace BigMath
 
                 limb_acc |= digit << (slot * 16);
                 ++slot;
-                flush(false);
+                if (slot == 4)
+                {
+                    result.push_back((DataT)limb_acc);
+                    limb_acc = 0;
+                    slot = 0;
+                }
             }
 
-            flush(true);
+            if (slot != 0)
+                result.push_back((DataT)limb_acc);
 
             TrimZeros(result);
             return result;

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -387,24 +387,28 @@ namespace BigMath
         // 2 coefficients per output limb, each 32 bits → 64-bit limb. Carry
         // propagation needs more than the per-coeff width; use ULong128.
         ULong128 carry = 0;
-        ULong limb_acc = 0;
-        int slot = 0;
-        auto flush = [&result, &limb_acc, &slot](bool force) {
-          if (slot == 2 || (force && slot != 0))
-          {
-            result.push_back((DataT)limb_acc);
-            limb_acc = 0;
-            slot = 0;
-          }
-        };
-        for (SizeT i = 0; i < (SizeT)coeffCount; ++i)
+        SizeT i = 0;
+        for (; i + 1 < (SizeT)coeffCount; i += 2)
         {
           ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
-          ULong digit = (ULong)(total & 0xFFFFFFFFULL);
+          ULong lo = (ULong)(total & 0xFFFFFFFFULL);
           carry = total >> 32;
-          limb_acc |= digit << (slot * 32);
-          ++slot;
-          flush(false);
+
+          total = Garner(fa1[i + 1], fa2[i + 1], fa3[i + 1], inv) + carry;
+          ULong hi = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+
+          result.push_back((DataT)(lo | (hi << 32)));
+        }
+
+        ULong limb_acc = 0;
+        int slot = 0;
+        if (i < (SizeT)coeffCount)
+        {
+          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
+          limb_acc = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+          slot = 1;
         }
         while (carry > 0)
         {
@@ -412,9 +416,15 @@ namespace BigMath
           carry >>= 32;
           limb_acc |= digit << (slot * 32);
           ++slot;
-          flush(false);
+          if (slot == 2)
+          {
+            result.push_back((DataT)limb_acc);
+            limb_acc = 0;
+            slot = 0;
+          }
         }
-        flush(true);
+        if (slot != 0)
+          result.push_back((DataT)limb_acc);
       }
       else
       {

--- a/multiplication_improvement_plan.md
+++ b/multiplication_improvement_plan.md
@@ -1,0 +1,156 @@
+# Multiplication Improvement Plan
+
+## Diagnosis
+
+BigMath multiplication is already strong at very large balanced sizes: `BENCHMARK.md` shows it beating GMP at 5M+ digits. The remaining gaps are concentrated in smaller scalar/Karatsuba bands, the NTT crossover band, and very large skewed multiplication where the full NTT path may do too much symmetric work.
+
+The next useful work should be benchmark-driven. Avoid adding asymptotically attractive algorithms without a measured production band.
+
+## 1. Add Shape-Focused Multiplication Benchmarks
+
+Add a focused benchmark that measures direct algorithms and dispatcher behavior across balanced and skewed limb shapes.
+
+Suggested cases:
+
+```text
+balanced: 64, 96, 128, 256, 512, 1024, 2048, 4096, 8192 limbs
+skewed:   1024x64, 2048x128, 4096x256, 8192x512, 16384x1024
+large:    10n/n, 20n/n, 50n/n
+```
+
+Measure:
+
+- Classic
+- Karatsuba
+- NTT Goldilocks
+- CRT NTT
+- dispatcher
+
+Use end-to-end `Multiply()` timings, not only direct microbenchmarks.
+
+## 2. Retune Dispatch by Shape
+
+Current dispatch is mostly threshold-based. Total limb count is not enough for skewed operands.
+
+Use the shape benchmark to tune:
+
+- Karatsuba vs NTT threshold
+- CRT NTT threshold
+- serial vs threaded threshold
+- skew-specific fallback bands
+
+Goal: keep NTT for balanced and moderate-skew cases, but avoid full-size NTT when a blockwise or Karatsuba path wins for high skew.
+
+## 3. Prototype Blockwise Skewed Multiplication
+
+For `A` much larger than `B`, split `A` into chunks near the size of `B`:
+
+```text
+A = A0 + A1 * B^k + A2 * B^(2k) + ...
+A * B = sum(Ai * B) shifted
+```
+
+Benchmark this against one full NTT. This may help large skewed cases such as `5M x 500k` and `10M x 1M`, where BigMath falls behind GMP again.
+
+Reject the prototype if repeated smaller multiplications lose to one large NTT.
+
+## 4. Optimize NTT Finalization
+
+`FinalizeBase2_64` shows up as a meaningful cost in NTT-heavy profiles. Improvements here affect multiplication, division, parse, and ToString.
+
+Investigate:
+
+- tighter carry-propagation loops
+- fewer cleanup/trimming passes
+- specialized paths for common coefficient counts
+- pointer-based finalization
+- separate microbenchmark for finalization
+
+Expected gain is likely single-digit percent, but broad.
+
+## 5. Tune CRT NTT and Thread Thresholds Separately
+
+The ideal thresholds may differ for:
+
+- Goldilocks vs CRT
+- serial vs threaded
+- balanced vs skewed operands
+
+Recheck `BIGMATH_NTT_CRT_THRESHOLD` and thread activation thresholds using shape-aware benchmarks. Avoid assuming the balanced optimum is also best for skewed multiplication.
+
+## 6. Investigate Faster NTT Kernel
+
+The butterfly and modular multiplication loops dominate large products.
+
+Potential work:
+
+- stronger loop unrolling
+- pointer-based butterfly loops
+- ARM64-specific assembly kernel
+- better scheduling around `MUL` / `UMULH`
+- reduced loads/stores in pointwise multiply
+
+This is high effort and platform-sensitive. Do it only after benchmarks confirm the NTT kernel remains the bottleneck.
+
+## 7. Consider Prepared NTT Operands
+
+For repeated multiplication by the same large operand, add an internal or public prepared-operand API that caches:
+
+- coefficient split
+- transform size
+- forward NTT spectra
+- CRT per-prime spectra
+
+This does not help one-off `a * b`, but can help exponentiation, repeated products, and some division/string-conversion internals.
+
+## 8. Audit Squaring Use
+
+Squaring already has specialized implementations. Ensure callers use `Square(x)` instead of `Multiply(x, x)` where applicable.
+
+Known good use:
+
+- `Pow10(d)` even branch
+
+Future audit targets:
+
+- exponentiation if added
+- benchmark/test helpers
+- internal algorithm code that computes self-products
+
+## Avoid For Now
+
+- Do not add Toom-3 or Toom-5 to dispatch; both were measured slower in the production band.
+- Do not lower the NTT threshold based only on direct microbenchmarks; dispatch overhead changes the result.
+- Do not reattempt Mulders-style high multiplication unless it reduces actual NTT work.
+- Do not implement Schonhage-Strassen or Furer-style multiplication for this input range.
+
+## Recommended Order
+
+1. Add shape-focused multiplication benchmark.
+2. Retune dispatch from measured balanced and skewed shapes.
+3. Prototype blockwise skewed multiplication.
+4. Optimize `FinalizeBase2_64`.
+5. Retune CRT/thread thresholds by shape.
+6. Investigate NTT kernel improvements.
+7. Consider prepared NTT operands for repeated-workload APIs.
+
+## 2026-05-26 Implementation Findings
+
+### Completed
+
+- Added `tests/performance/multiplication_shape_bench.cpp`, a shape-aware benchmark that measures Classic, Karatsuba, NTT, dispatcher, and an experimental blockwise skew prototype across balanced and skewed limb ratios.
+- Retuned default dispatch for very small high-skew shapes: when `minSize <= 64` and `maxSize >= 10 * minSize`, dispatch now uses Classic instead of Karatsuba.
+- Simplified Base2_64 NTT finalization loops in both Goldilocks and CRT NTT paths by packing coefficients directly into output limbs instead of using slot/flush lambdas.
+
+### Measured Wins
+
+The clearest win is the skew dispatch guard. Before the retune, `20n/n` at `1280x64` limbs dispatched through Karatsuba and took about `0.1522 ms`, while Classic took `0.0821 ms`. After the retune, dispatcher time is about `0.0848 ms`. The `50n/n` at `3200x64` case improved from about `0.4469 ms` to roughly `0.21-0.25 ms`, depending on run noise.
+
+The finalization-loop changes were correctness-neutral and small/mixed in end-to-end timings. They remain because they remove avoidable branch/lambda overhead in hot NTT output code without changing algorithm selection.
+
+### Prototyped But Not Promoted
+
+- Blockwise skew multiplication can beat one-shot Classic in narrow `min=64`, high-ratio cases inside the benchmark harness, but it regressed when promoted into production dispatch and loses badly once the smaller operand reaches 512+ limbs. It remains a benchmark prototype only.
+- Barrett-style modular reduction for CRT NTT prime multiplication was tested and rejected. It was consistently slower than the compiler's `% P` code for these fixed 32-bit NTT primes.
+- Prepared/reusable NTT operands were considered but not added. The benefit requires a repeated-same-operand API because transform size depends on both operands; one-off `Multiply(a, b)` cannot reuse a prepared spectrum safely without a larger API contract.
+- Assembly was not attempted. The portable work did not leave a newly isolated bottleneck that justifies platform-specific code in this pass.

--- a/src/algorithms/Multiplication.cpp
+++ b/src/algorithms/Multiplication.cpp
@@ -13,6 +13,8 @@ namespace BigMath
   const SizeT CLASSIC_MULTIPLICATION_THRESHOLD = BIGMATH_CLASSIC_MULTIPLICATION_THRESHOLD;
   const SizeT NTT_MULTIPLICATION_THRESHOLD = BIGMATH_NTT_MULTIPLICATION_THRESHOLD;
   const SizeT CLASSIC_MIN_LIMB_THRESHOLD = BIGMATH_CLASSIC_MIN_LIMB_THRESHOLD;
+  const SizeT CLASSIC_SKEW_MIN_LIMB_THRESHOLD = BIGMATH_CLASSIC_SKEW_MIN_LIMB_THRESHOLD;
+  const SizeT CLASSIC_SKEW_RATIO = BIGMATH_CLASSIC_SKEW_RATIO;
 
   std::vector<DataT> Multiply(std::vector<DataT> const &a,
                               std::vector<DataT> const &b,
@@ -28,8 +30,12 @@ namespace BigMath
 
     SizeT size = a.size() + b.size();
     SizeT minSize = std::min(a.size(), b.size());
+    SizeT maxSize = std::max(a.size(), b.size());
 
     if (size <= CLASSIC_MULTIPLICATION_THRESHOLD || minSize <= CLASSIC_MIN_LIMB_THRESHOLD)
+      return ClassicMultiplication::Multiply(a, b, base);
+
+    if (minSize <= CLASSIC_SKEW_MIN_LIMB_THRESHOLD && maxSize >= CLASSIC_SKEW_RATIO * minSize)
       return ClassicMultiplication::Multiply(a, b, base);
 
     if (size < NTT_MULTIPLICATION_THRESHOLD)

--- a/tests/performance/multiplication_shape_bench.cpp
+++ b/tests/performance/multiplication_shape_bench.cpp
@@ -1,0 +1,305 @@
+// Shape-focused multiplication benchmark for dispatcher tuning.
+
+#include "biginteger/BigInteger.h"
+#include "biginteger/algorithms/Multiplication.h"
+#include "biginteger/algorithms/multiplication/ClassicMultiplication.h"
+#include "biginteger/algorithms/multiplication/KaratsubaMultiplication.h"
+#include "biginteger/algorithms/multiplication/NTTMultiplication.h"
+#include "biginteger/common/Comparator.h"
+#include "biginteger/common/Util.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace BigMath;
+
+namespace
+{
+  volatile SizeT sink = 0;
+
+  std::vector<DataT> RandomNumber(SizeT limbs, std::mt19937_64 &gen)
+  {
+    std::vector<DataT> value(limbs);
+    for (SizeT i = 0; i < limbs; ++i)
+    {
+#if BIGMATH_LIMB_64
+      value[i] = (DataT)gen();
+#else
+      value[i] = (DataT)(gen() & 0xFFFFFFFFULL);
+#endif
+    }
+    if (!value.empty())
+    {
+#if BIGMATH_LIMB_64
+      value.back() |= 0x8000000000000000ULL;
+#else
+      value.back() |= 0x80000000ULL;
+#endif
+    }
+    TrimZerosToOne(value);
+    return value;
+  }
+
+  template <class F>
+  double BestMs(F &&fn, int reps)
+  {
+    double best = std::numeric_limits<double>::max();
+    for (int i = 0; i < reps; ++i)
+    {
+      auto start = std::chrono::steady_clock::now();
+      SizeT check = fn();
+      auto end = std::chrono::steady_clock::now();
+      sink += check;
+      best = std::min(best, std::chrono::duration<double, std::milli>(end - start).count());
+    }
+    return best;
+  }
+
+  int RepsFor(SizeT totalLimbs)
+  {
+    if (totalLimbs <= 256) return 9;
+    if (totalLimbs <= 2048) return 7;
+    if (totalLimbs <= 8192) return 5;
+    if (totalLimbs <= 32768) return 3;
+    return 1;
+  }
+
+  std::string Winner(
+      double classic,
+      double karatsuba,
+      double ntt,
+      double blockwise,
+      double dispatch)
+  {
+    std::string name = "dispatch";
+    double best = dispatch;
+    if (!std::isnan(classic) && classic < best)
+    {
+      best = classic;
+      name = "classic";
+    }
+    if (!std::isnan(karatsuba) && karatsuba < best)
+    {
+      best = karatsuba;
+      name = "karatsuba";
+    }
+    if (!std::isnan(ntt) && ntt < best)
+    {
+      best = ntt;
+      name = "ntt";
+    }
+    if (!std::isnan(blockwise) && blockwise < best)
+    {
+      best = blockwise;
+      name = "blockwise";
+    }
+    return name;
+  }
+
+  struct Case
+  {
+    std::string shape;
+    SizeT lhsLimbs;
+    SizeT rhsLimbs;
+  };
+
+  void AddProductAt(
+      std::vector<DataT> &out,
+      std::vector<DataT> const &product,
+      SizeT offset)
+  {
+    if (product.empty() || IsZero(product))
+      return;
+    if (out.size() < offset + product.size() + 1)
+      out.resize(offset + product.size() + 1, 0);
+
+    SizeT i = 0;
+#if BIGMATH_LIMB_64
+    ULong128 carry = 0;
+    for (; i < product.size(); ++i)
+    {
+      ULong128 sum = (ULong128)out[offset + i] + product[i] + carry;
+      out[offset + i] = (DataT)sum;
+      carry = sum >> 64;
+    }
+    SizeT pos = offset + i;
+    while (carry)
+    {
+      ULong128 sum = (ULong128)out[pos] + carry;
+      out[pos] = (DataT)sum;
+      carry = sum >> 64;
+      ++pos;
+      if (pos >= out.size() && carry)
+        out.push_back(0);
+    }
+#else
+    ULong carry = 0;
+    for (; i < product.size(); ++i)
+    {
+      ULong sum = (ULong)out[offset + i] + product[i] + carry;
+      out[offset + i] = (DataT)(sum & 0xFFFFFFFFULL);
+      carry = sum >> 32;
+    }
+    SizeT pos = offset + i;
+    while (carry)
+    {
+      ULong sum = (ULong)out[pos] + carry;
+      out[pos] = (DataT)(sum & 0xFFFFFFFFULL);
+      carry = sum >> 32;
+      ++pos;
+      if (pos >= out.size() && carry)
+        out.push_back(0);
+    }
+#endif
+  }
+
+  std::vector<DataT> BlockwiseSkewMultiply(
+      std::vector<DataT> const &a,
+      std::vector<DataT> const &b,
+      BaseT base)
+  {
+    std::vector<DataT> const *large = &a;
+    std::vector<DataT> const *small = &b;
+    if (a.size() < b.size())
+      std::swap(large, small);
+
+    SizeT blockLimbs = std::max((SizeT)256, (SizeT)small->size() * 4);
+    std::vector<DataT> out(large->size() + small->size() + 2, 0);
+    for (SizeT start = 0; start < large->size(); start += blockLimbs)
+    {
+      SizeT end = std::min((SizeT)large->size(), start + blockLimbs);
+      std::vector<DataT> chunk(large->begin() + start, large->begin() + end);
+      TrimZerosToOne(chunk);
+      if (IsZero(chunk))
+        continue;
+      std::vector<DataT> product = Multiply(chunk, *small, base);
+      AddProductAt(out, product, start);
+    }
+    TrimZerosToOne(out);
+    return out;
+  }
+
+  void CheckEqual(
+      std::vector<DataT> const &actual,
+      std::vector<DataT> const &expected,
+      std::string const &label)
+  {
+    if (Compare(actual, expected) != 0)
+    {
+      std::cerr << "multiplication result mismatch: " << label
+                << " actual_limbs=" << actual.size()
+                << " expected_limbs=" << expected.size() << '\n';
+      std::abort();
+    }
+  }
+}
+
+int main(int argc, char **argv)
+{
+  std::vector<Case> cases;
+  if (argc > 1)
+  {
+    for (int i = 1; i < argc; ++i)
+    {
+      SizeT n = (SizeT)std::strtoull(argv[i], nullptr, 10);
+      cases.push_back({"n/n", n, n});
+      cases.push_back({"2n/n", 2 * n, n});
+      cases.push_back({"5n/n", 5 * n, n});
+      cases.push_back({"10n/n", 10 * n, n});
+      cases.push_back({"20n/n", 20 * n, n});
+      cases.push_back({"50n/n", 50 * n, n});
+    }
+  }
+  else
+  {
+    for (SizeT n : {64u, 96u, 128u, 256u, 512u, 1024u, 2048u, 4096u, 8192u})
+      cases.push_back({"n/n", n, n});
+    for (SizeT n : {64u, 128u, 256u, 512u, 1024u, 2048u})
+    {
+      cases.push_back({"5n/n", 5 * n, n});
+      cases.push_back({"10n/n", 10 * n, n});
+      cases.push_back({"20n/n", 20 * n, n});
+    }
+  }
+
+  std::cout << "base=" << BigInteger::Base() << "\n";
+  std::cout << "shape,lhs_limbs,rhs_limbs,total_limbs,classic_ms,karatsuba_ms,ntt_ms,blockwise_ms,dispatch_ms,winner\n";
+
+  std::mt19937_64 gen(0xA11CEB16B00B5ULL);
+  for (auto const &c : cases)
+  {
+    std::vector<DataT> a = RandomNumber(c.lhsLimbs, gen);
+    std::vector<DataT> b = RandomNumber(c.rhsLimbs, gen);
+    SizeT total = c.lhsLimbs + c.rhsLimbs;
+    int reps = RepsFor(total);
+
+    std::vector<DataT> expected = Multiply(a, b, BigInteger::Base());
+
+    double classic = std::numeric_limits<double>::quiet_NaN();
+    if (total <= 4096 || std::min(c.lhsLimbs, c.rhsLimbs) <= 128)
+    {
+      classic = BestMs([&]() {
+        auto r = ClassicMultiplication::Multiply(a, b, BigInteger::Base());
+        CheckEqual(r, expected, c.shape + " classic");
+        return (SizeT)r.size();
+      }, reps);
+    }
+
+    double karatsuba = std::numeric_limits<double>::quiet_NaN();
+    if (total <= 8192 || std::min(c.lhsLimbs, c.rhsLimbs) <= 128)
+    {
+      karatsuba = BestMs([&]() {
+        auto r = KaratsubaMultiplication::Multiply(a, b, BigInteger::Base());
+        CheckEqual(r, expected, c.shape + " karatsuba");
+        return (SizeT)r.size();
+      }, reps);
+    }
+
+    double ntt = BestMs([&]() {
+      auto r = NTTMultiplication::Multiply(a, b, BigInteger::Base());
+      CheckEqual(r, expected, c.shape + " ntt");
+      return (SizeT)r.size();
+    }, std::max(1, reps / 2));
+
+    double blockwise = std::numeric_limits<double>::quiet_NaN();
+    if (std::max(c.lhsLimbs, c.rhsLimbs) >= 8 * std::min(c.lhsLimbs, c.rhsLimbs))
+    {
+      blockwise = BestMs([&]() {
+        auto r = BlockwiseSkewMultiply(a, b, BigInteger::Base());
+        CheckEqual(r, expected, c.shape + " blockwise");
+        return (SizeT)r.size();
+      }, std::max(1, reps / 2));
+    }
+
+    double dispatch = BestMs([&]() {
+      auto r = Multiply(a, b, BigInteger::Base());
+      CheckEqual(r, expected, c.shape + " dispatch");
+      return (SizeT)r.size();
+    }, reps);
+
+    std::cout << c.shape << ','
+              << c.lhsLimbs << ','
+              << c.rhsLimbs << ','
+              << total << ','
+              << std::fixed << std::setprecision(4)
+              << classic << ','
+              << karatsuba << ','
+              << ntt << ','
+              << blockwise << ','
+              << dispatch << ','
+              << Winner(classic, karatsuba, ntt, blockwise, dispatch)
+              << '\n';
+  }
+
+  std::cerr << "checksum=" << sink << '\n';
+  return 0;
+}


### PR DESCRIPTION
## Summary

- add a shape-focused multiplication benchmark covering balanced and skewed limb ratios
- retune multiplication dispatch so tiny high-skew operands stay on Classic instead of Karatsuba
- simplify Base2_64 NTT finalization loops in Goldilocks and CRT paths
- document measured wins, rejected blockwise-skew production dispatch, and rejected CRT Barrett reduction

## Benchmarks

- c++ -std=c++20 -O3 -DNDEBUG -Iinclude tests/performance/multiplication_shape_bench.cpp ... -o /tmp/multiplication_shape_bench
- /tmp/multiplication_shape_bench 64

Key rows:

| shape | previous dispatch | retuned dispatch |
|---|---:|---:|
| 1280x64 limbs | 0.1522 ms | 0.0822 ms |
| 3200x64 limbs | 0.4469 ms | 0.2119 ms |

The blockwise skew prototype won some min=64 benchmark rows but regressed when promoted into production dispatch and lost for 512+ smaller operands, so it remains benchmark-only.

## Correctness

- c++ -std=c++20 -O2 -Iinclude tests/mult_correctness.cpp ... -o /tmp/mult_correctness
- /tmp/mult_correctness
