### PR TITLE
Fix BZ regression on near-balanced division (PR #54 follow-up)

### DIFF
--- a/src/algorithms/Division.cpp
+++ b/src/algorithms/Division.cpp
@@ -53,10 +53,15 @@ namespace BigMath
       return NewtonDivision::DivideAndRemainder(a, b, base, computeRemainder);
 
     // BZ for large near-balanced divisors and for big-and-skewed cases.
+    // The +32-limb quotient-bulk guard in the near-balanced clause excludes
+    // degenerate cases where a ≈ b and the quotient is 0-2 limbs — BZ would
+    // split a into m = n/2 blocks and run wasted m×m multiplies on mostly-zero
+    // high blocks, while FastDivision short-circuits via a single qhat
+    // iteration. Regressed 5M×5M balanced 1.45 → 4.48 ms before this guard.
     bool bz_eligible =
         (base == Base2_32 || base == Base2_64) &&
         b.size() > BZ_DIVISOR_THRESHOLD &&
-        ((b.size() >= 1024 && a.size() <= 3 * b.size()) ||
+        ((b.size() >= 1024 && a.size() >= b.size() + 32 && a.size() <= 3 * b.size()) ||
          (a.size() > 2048 && a.size() > 3 * b.size()));
     if (bz_eligible)
       return BurnikelZieglerDivision::DivideAndRemainder(a, b, base, computeRemainder);


### PR DESCRIPTION
## Summary

PR #54 extended BZ eligibility to Base2_64. The near-balanced clause `(b.size() >= 1024 && a.size() <= 3 * b.size())` admits the degenerate case where `a ≈ b` and the quotient is 0-2 limbs. BZ has no early-exit for tiny quotients — `Divide2nByN` splits `a` into `m = n/2` blocks and runs `m × m` multiplies on mostly-zero high blocks, while FastDivision short-circuits via a single qhat iteration.

**Regression caught:** `5M × 5M balanced div` went from **1.45 ms** (pre-PR #54, FastDivision short-circuit) to **4.48 ms** (post-PR #54, BZ) — 27× vs GMP's 0.166 ms.

**Fix:** add a quotient-bulk guard `a.size() >= b.size() + 32` to the near-balanced clause. Degenerate-quotient cases now fall to FastDivision short-circuit. The big-and-skewed clause (`a > 3b`) is untouched.

## Benchmark deltas

Paired runs of `bench_vs_gmp`, full extended harness, M1 Max, same session.

| div size | pre-fix ms | post-fix ms | speedup |
|---|---:|---:|---|
| **5M × 5M balanced** | **4.479** | **1.202** | **3.7×** |
| 1M × 1M balanced | 0.002 | 0.001 | flat |
| 500k × 500k balanced | 0.003 | 0.001 | flat |
| 40k × 10k skewed | 0.730 | 0.729 | flat |
| 200k × 50k skewed | 11.319 | 11.261 | flat |
| 1M × 200k skewed | 38.382 | 35.914 | noise |
| 10M × 2M skewed | 467.255 | 466.584 | flat |

vs GMP: 5M × 5M balanced moves from 27.03× → **7.16×**. Skewed division unchanged. Multiplication / parse / ToString unaffected (predicate change touches dispatch only).

## Test plan
- [x] `div_correctness` passes
- [x] `unit_tests` passes
- [x] `bench_vs_gmp` paired runs confirm fix + no regression elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)