### PR TITLE
perf: parallelize NTT root-table build (7-17% faster mul ≥5M digits)

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTCore.h
+++ b/include/biginteger/algorithms/multiplication/NTTCore.h
@@ -97,10 +97,30 @@ namespace BigMath
             if (invert)
                 root = ModularField::Inv(root);
 
-            std::vector<ULong> roots(n / 2);
-            roots[0] = 1;
-            for (Int k = 1; k < n / 2; ++k)
-                roots[k] = ModularField::Mul(roots[k - 1], root);
+            Int half = n / 2;
+            std::vector<ULong> roots(half);
+            ULong *rPtr = roots.data();
+            // Parallel chunk fill mirroring NttCrt::BuildRoots — each thread
+            // jumps ahead via Power then sequential Mul within its range.
+            if ((SizeT)half >= ParallelMinSize())
+            {
+                ParallelFor(half, [rPtr, root](Int start, Int end) {
+                    if (end <= start) return;
+                    ULong cur = (start == 0) ? (ULong)1 : ModularField::Power(root, (ULong)start);
+                    rPtr[start] = cur;
+                    for (Int k = start + 1; k < end; ++k)
+                    {
+                        cur = ModularField::Mul(cur, root);
+                        rPtr[k] = cur;
+                    }
+                });
+            }
+            else
+            {
+                rPtr[0] = 1;
+                for (Int k = 1; k < half; ++k)
+                    rPtr[k] = ModularField::Mul(rPtr[k - 1], root);
+            }
             return roots;
         }
 

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -118,9 +118,30 @@ namespace BigMath
     {
       UInt root = F::Power(G, (F::Prime - 1) / (UInt)n);
       if (invert) root = F::Inv(root);
-      std::vector<UInt> r(n / 2);
-      r[0] = 1;
-      for (Int k = 1; k < n / 2; ++k) r[k] = F::Mul(r[k - 1], root);
+      Int half = n / 2;
+      std::vector<UInt> r(half);
+      // Parallel chunk fill: each thread does one Power(root, chunk_start)
+      // then sequential Mul within its chunk. Eliminates the 16.5M-Mul
+      // serial dependency at N=33M (≈5-13% of 20M-100M mul time per row).
+      UInt *rPtr = r.data();
+      if ((SizeT)half >= ParallelMinSize())
+      {
+        ParallelFor(half, [rPtr, root](Int start, Int end) {
+          if (end <= start) return;
+          UInt cur = (start == 0) ? (UInt)1 : F::Power(root, (UInt)start);
+          rPtr[start] = cur;
+          for (Int k = start + 1; k < end; ++k)
+          {
+            cur = F::Mul(cur, root);
+            rPtr[k] = cur;
+          }
+        });
+      }
+      else
+      {
+        rPtr[0] = 1;
+        for (Int k = 1; k < half; ++k) rPtr[k] = F::Mul(rPtr[k - 1], root);
+      }
       return r;
     }
 


### PR DESCRIPTION
## Summary

Profile of 100M × 100M mul (via `sample`) showed `BuildRoots` was 5-15% of total mul time per row at large sizes — a sequential dependency chain of N/2 modular multiplies (16.5M at N = 33M) that ran on a single thread.

This PR replaces the sequential fill with a chunk-parallel one: each worker computes its chunk-start root via `Power(root, chunk_start)` (jump-ahead), then sequential `Mul` within the chunk.

Mirrors the change across both NTT cores: `NTTCore.h` (Goldilocks) and `NTTMultiplicationCrt.h` (3-prime CRT). At N = 33M with 8 threads, theoretical speedup is ~8×; measured per-row wins below.

## Benchmark (paired `bench_vs_gmp`, M1 Max)

Balanced multiplication:

| size | baseline ms | post-fix ms | speedup | vs GMP before | vs GMP after |
|---|---:|---:|---|---|---|
| 2M × 2M | 26.32 | 23.25 | -11.7% | 1.25× | 1.06× |
| 5M × 5M | 58.27 | 49.66 | **-14.8%** | 0.92× | **0.78×** |
| 10M × 10M | 144.48 | 120.60 | **-16.5%** | 0.71× | **0.59×** ← 41% faster than GMP |
| 20M × 20M | 432.35 | 403.07 | -6.8% | 1.61× | 1.48× |
| 50M × 50M | 2 423.37 | 2 152.66 | -11.2% | 3.58× | 3.21× |
| 100M × 100M | 5 313.01 | 4 829.25 | -9.1% | 3.71× | 3.33× |

Skewed mul: 100M × 10M improved -7.7% (2 224 → 2 054 ms). Other skewed sizes within noise envelope.

Div / parse / tostring: flat — fix is NTT-internal and doesn't touch dispatch.

## Why this works

For an N-point NTT, all N/2 forward roots are powers of one primitive root. Naive build: `r[k] = r[k-1] · root`, a serial dependency. Parallel build: each chunk `[start, end)` jumps ahead to `r[start] = root^start` via `Power` (log₂(N) mods), then resumes the sequential chain within its own chunk. Wall time drops from `N/2` mods to roughly `N / (2 · nThreads)` plus per-chunk `log₂(N)` Power overhead — the overhead is negligible at N ≥ 2²⁰.

## Test plan
- [x] `mult_correctness` passes (all NTT cross-checks against Classic)
- [x] `div_correctness` passes
- [x] `unit_tests` passes
- [x] `bench_vs_gmp` paired runs confirm wins + no regression on div/parse/tostring

🤖 Generated with [Claude Code](https://claude.com/claude-code)