### PR TITLE
perf: radix-8 fused NTT butterflies (~15-25% on top of radix-4)

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTCore.h
+++ b/include/biginteger/algorithms/multiplication/NTTCore.h
@@ -286,6 +286,171 @@ namespace BigMath
                 body(0, numBlocks);
         }
 
+        // Radix-8 fused DIF butterfly. Combines three radix-2 layers (len, len/2,
+        // len/4) into a single load/store across 8 elements. Internally a pair of
+        // radix-4 fused butterflies (slots {0,2,4,6} and {1,3,5,7}) followed by
+        // four radix-2 butterflies on the resulting pairs.
+        static inline void ForwardRadix8Layer(ULong *a, Int n, Int outerLen, const ULong *roots)
+        {
+            Int halflen = outerLen >> 1;
+            Int qlen4 = outerLen >> 2;
+            Int qlen8 = outerLen >> 3;
+            Int stride = n / outerLen;
+            Int stride4 = stride << 2;
+            Int numBlocks = n / outerLen;
+            Int omega4_off = n / 4;
+            auto body = [a, halflen, qlen4, qlen8, outerLen, stride, stride4, omega4_off, roots](Int bStart, Int bEnd) {
+                for (Int b = bStart; b < bEnd; ++b)
+                {
+                    Int i = b * outerLen;
+                    for (Int j = 0; j < qlen8; ++j)
+                    {
+                        ULong x0 = a[i + j];
+                        ULong x1 = a[i + j + qlen8];
+                        ULong x2 = a[i + j + qlen4];
+                        ULong x3 = a[i + j + qlen4 + qlen8];
+                        ULong x4 = a[i + j + halflen];
+                        ULong x5 = a[i + j + halflen + qlen8];
+                        ULong x6 = a[i + j + halflen + qlen4];
+                        ULong x7 = a[i + j + halflen + qlen4 + qlen8];
+
+                        ULong g_a  = roots[j * stride];
+                        ULong gw_a = roots[j * stride + omega4_off];
+                        ULong g2_a = roots[2 * j * stride];
+                        ULong g_b  = roots[(j + qlen8) * stride];
+                        ULong gw_b = roots[(j + qlen8) * stride + omega4_off];
+                        ULong g2_b = roots[2 * (j + qlen8) * stride];
+                        ULong g3   = roots[j * stride4];
+
+                        ULong t0 = ModularField::Add(x0, x4);
+                        ULong t1 = ModularField::Add(x2, x6);
+                        ULong t2 = ModularField::Mul(ModularField::Sub(x0, x4), g_a);
+                        ULong t3 = ModularField::Mul(ModularField::Sub(x2, x6), gw_a);
+                        ULong y0 = ModularField::Add(t0, t1);
+                        ULong y2 = ModularField::Mul(ModularField::Sub(t0, t1), g2_a);
+                        ULong y4 = ModularField::Add(t2, t3);
+                        ULong y6 = ModularField::Mul(ModularField::Sub(t2, t3), g2_a);
+
+                        ULong u0 = ModularField::Add(x1, x5);
+                        ULong u1 = ModularField::Add(x3, x7);
+                        ULong u2 = ModularField::Mul(ModularField::Sub(x1, x5), g_b);
+                        ULong u3 = ModularField::Mul(ModularField::Sub(x3, x7), gw_b);
+                        ULong y1 = ModularField::Add(u0, u1);
+                        ULong y3 = ModularField::Mul(ModularField::Sub(u0, u1), g2_b);
+                        ULong y5 = ModularField::Add(u2, u3);
+                        ULong y7 = ModularField::Mul(ModularField::Sub(u2, u3), g2_b);
+
+                        ULong z0 = ModularField::Add(y0, y1);
+                        ULong z1 = ModularField::Mul(ModularField::Sub(y0, y1), g3);
+                        ULong z2 = ModularField::Add(y2, y3);
+                        ULong z3 = ModularField::Mul(ModularField::Sub(y2, y3), g3);
+                        ULong z4 = ModularField::Add(y4, y5);
+                        ULong z5 = ModularField::Mul(ModularField::Sub(y4, y5), g3);
+                        ULong z6 = ModularField::Add(y6, y7);
+                        ULong z7 = ModularField::Mul(ModularField::Sub(y6, y7), g3);
+
+                        a[i + j]                          = z0;
+                        a[i + j + qlen8]                  = z1;
+                        a[i + j + qlen4]                  = z2;
+                        a[i + j + qlen4 + qlen8]          = z3;
+                        a[i + j + halflen]                = z4;
+                        a[i + j + halflen + qlen8]        = z5;
+                        a[i + j + halflen + qlen4]        = z6;
+                        a[i + j + halflen + qlen4 + qlen8] = z7;
+                    }
+                }
+            };
+            if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
+                ParallelFor(numBlocks, body);
+            else
+                body(0, numBlocks);
+        }
+
+        // Radix-8 fused DIT butterfly. Inverse of ForwardRadix8Layer: applies
+        // three DIT radix-2 layers (len/4 → len/2 → len) over 8 elements in a
+        // single load/store.
+        static inline void InverseRadix8Layer(ULong *a, Int n, Int outerLen, const ULong *roots)
+        {
+            Int halflen = outerLen >> 1;
+            Int qlen4 = outerLen >> 2;
+            Int qlen8 = outerLen >> 3;
+            Int stride = n / outerLen;
+            Int stride4 = stride << 2;
+            Int numBlocks = n / outerLen;
+            Int omega4_off = n / 4;
+            auto body = [a, halflen, qlen4, qlen8, outerLen, stride, stride4, omega4_off, roots](Int bStart, Int bEnd) {
+                for (Int b = bStart; b < bEnd; ++b)
+                {
+                    Int i = b * outerLen;
+                    for (Int j = 0; j < qlen8; ++j)
+                    {
+                        ULong x0 = a[i + j];
+                        ULong x1 = a[i + j + qlen8];
+                        ULong x2 = a[i + j + qlen4];
+                        ULong x3 = a[i + j + qlen4 + qlen8];
+                        ULong x4 = a[i + j + halflen];
+                        ULong x5 = a[i + j + halflen + qlen8];
+                        ULong x6 = a[i + j + halflen + qlen4];
+                        ULong x7 = a[i + j + halflen + qlen4 + qlen8];
+
+                        // Layer A (innermost, len=L/4, twiddle = roots[j*stride4]).
+                        ULong g_a = roots[j * stride4];
+                        ULong v01 = ModularField::Mul(x1, g_a);
+                        ULong y0 = ModularField::Add(x0, v01);
+                        ULong y1 = ModularField::Sub(x0, v01);
+                        ULong v23 = ModularField::Mul(x3, g_a);
+                        ULong y2 = ModularField::Add(x2, v23);
+                        ULong y3 = ModularField::Sub(x2, v23);
+                        ULong v45 = ModularField::Mul(x5, g_a);
+                        ULong y4 = ModularField::Add(x4, v45);
+                        ULong y5 = ModularField::Sub(x4, v45);
+                        ULong v67 = ModularField::Mul(x7, g_a);
+                        ULong y6 = ModularField::Add(x6, v67);
+                        ULong y7 = ModularField::Sub(x6, v67);
+
+                        // Layer B (len=L/2). Pairs (0,2),(1,3),(4,6),(5,7).
+                        ULong g_b1 = roots[2 * j * stride];
+                        ULong g_b2 = roots[2 * (j + qlen8) * stride];
+                        ULong w02 = ModularField::Mul(y2, g_b1);
+                        ULong z0 = ModularField::Add(y0, w02);
+                        ULong z2 = ModularField::Sub(y0, w02);
+                        ULong w13 = ModularField::Mul(y3, g_b2);
+                        ULong z1 = ModularField::Add(y1, w13);
+                        ULong z3 = ModularField::Sub(y1, w13);
+                        ULong w46 = ModularField::Mul(y6, g_b1);
+                        ULong z4 = ModularField::Add(y4, w46);
+                        ULong z6 = ModularField::Sub(y4, w46);
+                        ULong w57 = ModularField::Mul(y7, g_b2);
+                        ULong z5 = ModularField::Add(y5, w57);
+                        ULong z7 = ModularField::Sub(y5, w57);
+
+                        // Layer C (outermost, len=L). Pairs (0,4),(1,5),(2,6),(3,7).
+                        ULong g_c0 = roots[j * stride];
+                        ULong g_c1 = roots[(j + qlen8) * stride];
+                        ULong g_c2 = roots[(j + qlen4) * stride];
+                        ULong g_c3 = roots[(j + qlen4 + qlen8) * stride];
+                        ULong w04 = ModularField::Mul(z4, g_c0);
+                        ULong w15 = ModularField::Mul(z5, g_c1);
+                        ULong w26 = ModularField::Mul(z6, g_c2);
+                        ULong w37 = ModularField::Mul(z7, g_c3);
+
+                        a[i + j]                          = ModularField::Add(z0, w04);
+                        a[i + j + halflen]                = ModularField::Sub(z0, w04);
+                        a[i + j + qlen8]                  = ModularField::Add(z1, w15);
+                        a[i + j + halflen + qlen8]        = ModularField::Sub(z1, w15);
+                        a[i + j + qlen4]                  = ModularField::Add(z2, w26);
+                        a[i + j + halflen + qlen4]        = ModularField::Sub(z2, w26);
+                        a[i + j + qlen4 + qlen8]          = ModularField::Add(z3, w37);
+                        a[i + j + halflen + qlen4 + qlen8] = ModularField::Sub(z3, w37);
+                    }
+                }
+            };
+            if ((SizeT)(n / 2) >= ParallelMinSize() && numBlocks > 1)
+                ParallelFor(numBlocks, body);
+            else
+                body(0, numBlocks);
+        }
+
     public:
         static void Forward(std::vector<ULong> &a, const NTTPlan &plan)
         {
@@ -294,15 +459,17 @@ namespace BigMath
             ULong *aPtr = a.data();
             const ULong *roots = plan.forwardRoots.data();
 
-            // Pair from the top: (n, n/2), (n/4, n/8), …
+            // Triple from the top: (n, n/2, n/4), (n/8, n/16, n/32), …
+            // Straggler runs at len ∈ {4, 2} depending on log2(n) mod 3.
             Int len = n;
-            while (len >= 4)
+            while (len >= 8)
             {
-                ForwardRadix4Layer(aPtr, n, len, roots);
-                len >>= 2;
+                ForwardRadix8Layer(aPtr, n, len, roots);
+                len >>= 3;
             }
-            // If log2(n) is odd, one straggler layer at len=2.
-            if (len == 2)
+            if (len == 4)
+                ForwardRadix4Layer(aPtr, n, 4, roots);
+            else if (len == 2)
                 ForwardRadix2Layer(aPtr, n, 2, roots);
         }
 
@@ -314,24 +481,30 @@ namespace BigMath
 
             if (n >= 2)
             {
-                // Pair from the bottom: (2,4), (8,16), …
-                // If log2(n) odd, run the bottom layer (len=2) standalone first
-                // so subsequent pairs start at outer_len=8.
+                // Triple from the bottom: (2,4,8), (16,32,64), …
+                // If log2(n) % 3 ∈ {1,2}, a radix-2 or radix-4 head runs first
+                // so subsequent triples start at outer_len ∈ {8, 16, 32}.
                 Int logn = __builtin_ctzll((unsigned long long)n);
+                Int rem = logn % 3;
                 Int len;
-                if (logn & 1)
+                if (rem == 1)
                 {
                     InverseRadix2Layer(aPtr, n, 2, roots);
-                    len = 8;
+                    len = 16;
+                }
+                else if (rem == 2)
+                {
+                    InverseRadix4Layer(aPtr, n, 4, roots);
+                    len = 32;
                 }
                 else
                 {
-                    len = 4;
+                    len = 8;
                 }
                 while (len <= n)
                 {
-                    InverseRadix4Layer(aPtr, n, len, roots);
-                    len <<= 2;
+                    InverseRadix8Layer(aPtr, n, len, roots);
+                    len <<= 3;
                 }
             }
 

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -277,6 +277,151 @@ namespace BigMath
       }
     }
 
+    // Radix-8 fused DIF: three layers (len, len/2, len/4) in one load/store.
+    template <typename F>
+    inline void ForwardRadix8Layer(UInt *a, Int n, Int outerLen, const UInt *roots)
+    {
+      Int halflen = outerLen >> 1;
+      Int qlen4 = outerLen >> 2;
+      Int qlen8 = outerLen >> 3;
+      Int stride = n / outerLen;
+      Int stride4 = stride << 2;
+      Int omega4_off = n / 4;
+      for (Int i = 0; i < n; i += outerLen)
+      {
+        for (Int j = 0; j < qlen8; ++j)
+        {
+          UInt x0 = a[i + j];
+          UInt x1 = a[i + j + qlen8];
+          UInt x2 = a[i + j + qlen4];
+          UInt x3 = a[i + j + qlen4 + qlen8];
+          UInt x4 = a[i + j + halflen];
+          UInt x5 = a[i + j + halflen + qlen8];
+          UInt x6 = a[i + j + halflen + qlen4];
+          UInt x7 = a[i + j + halflen + qlen4 + qlen8];
+
+          UInt g_a  = roots[j * stride];
+          UInt gw_a = roots[j * stride + omega4_off];
+          UInt g2_a = roots[2 * j * stride];
+          UInt g_b  = roots[(j + qlen8) * stride];
+          UInt gw_b = roots[(j + qlen8) * stride + omega4_off];
+          UInt g2_b = roots[2 * (j + qlen8) * stride];
+          UInt g3   = roots[j * stride4];
+
+          UInt t0 = F::Add(x0, x4);
+          UInt t1 = F::Add(x2, x6);
+          UInt t2 = F::Mul(F::Sub(x0, x4), g_a);
+          UInt t3 = F::Mul(F::Sub(x2, x6), gw_a);
+          UInt y0 = F::Add(t0, t1);
+          UInt y2 = F::Mul(F::Sub(t0, t1), g2_a);
+          UInt y4 = F::Add(t2, t3);
+          UInt y6 = F::Mul(F::Sub(t2, t3), g2_a);
+
+          UInt u0 = F::Add(x1, x5);
+          UInt u1 = F::Add(x3, x7);
+          UInt u2 = F::Mul(F::Sub(x1, x5), g_b);
+          UInt u3 = F::Mul(F::Sub(x3, x7), gw_b);
+          UInt y1 = F::Add(u0, u1);
+          UInt y3 = F::Mul(F::Sub(u0, u1), g2_b);
+          UInt y5 = F::Add(u2, u3);
+          UInt y7 = F::Mul(F::Sub(u2, u3), g2_b);
+
+          UInt z0 = F::Add(y0, y1);
+          UInt z1 = F::Mul(F::Sub(y0, y1), g3);
+          UInt z2 = F::Add(y2, y3);
+          UInt z3 = F::Mul(F::Sub(y2, y3), g3);
+          UInt z4 = F::Add(y4, y5);
+          UInt z5 = F::Mul(F::Sub(y4, y5), g3);
+          UInt z6 = F::Add(y6, y7);
+          UInt z7 = F::Mul(F::Sub(y6, y7), g3);
+
+          a[i + j]                          = z0;
+          a[i + j + qlen8]                  = z1;
+          a[i + j + qlen4]                  = z2;
+          a[i + j + qlen4 + qlen8]          = z3;
+          a[i + j + halflen]                = z4;
+          a[i + j + halflen + qlen8]        = z5;
+          a[i + j + halflen + qlen4]        = z6;
+          a[i + j + halflen + qlen4 + qlen8] = z7;
+        }
+      }
+    }
+
+    // Radix-8 fused DIT: inverse of ForwardRadix8Layer.
+    template <typename F>
+    inline void InverseRadix8Layer(UInt *a, Int n, Int outerLen, const UInt *roots)
+    {
+      Int halflen = outerLen >> 1;
+      Int qlen4 = outerLen >> 2;
+      Int qlen8 = outerLen >> 3;
+      Int stride = n / outerLen;
+      Int stride4 = stride << 2;
+      for (Int i = 0; i < n; i += outerLen)
+      {
+        for (Int j = 0; j < qlen8; ++j)
+        {
+          UInt x0 = a[i + j];
+          UInt x1 = a[i + j + qlen8];
+          UInt x2 = a[i + j + qlen4];
+          UInt x3 = a[i + j + qlen4 + qlen8];
+          UInt x4 = a[i + j + halflen];
+          UInt x5 = a[i + j + halflen + qlen8];
+          UInt x6 = a[i + j + halflen + qlen4];
+          UInt x7 = a[i + j + halflen + qlen4 + qlen8];
+
+          // Layer A (innermost, twiddle g_a).
+          UInt g_a = roots[j * stride4];
+          UInt v01 = F::Mul(x1, g_a);
+          UInt y0 = F::Add(x0, v01);
+          UInt y1 = F::Sub(x0, v01);
+          UInt v23 = F::Mul(x3, g_a);
+          UInt y2 = F::Add(x2, v23);
+          UInt y3 = F::Sub(x2, v23);
+          UInt v45 = F::Mul(x5, g_a);
+          UInt y4 = F::Add(x4, v45);
+          UInt y5 = F::Sub(x4, v45);
+          UInt v67 = F::Mul(x7, g_a);
+          UInt y6 = F::Add(x6, v67);
+          UInt y7 = F::Sub(x6, v67);
+
+          // Layer B (middle).
+          UInt g_b1 = roots[2 * j * stride];
+          UInt g_b2 = roots[2 * (j + qlen8) * stride];
+          UInt w02 = F::Mul(y2, g_b1);
+          UInt z0 = F::Add(y0, w02);
+          UInt z2 = F::Sub(y0, w02);
+          UInt w13 = F::Mul(y3, g_b2);
+          UInt z1 = F::Add(y1, w13);
+          UInt z3 = F::Sub(y1, w13);
+          UInt w46 = F::Mul(y6, g_b1);
+          UInt z4 = F::Add(y4, w46);
+          UInt z6 = F::Sub(y4, w46);
+          UInt w57 = F::Mul(y7, g_b2);
+          UInt z5 = F::Add(y5, w57);
+          UInt z7 = F::Sub(y5, w57);
+
+          // Layer C (outermost).
+          UInt g_c0 = roots[j * stride];
+          UInt g_c1 = roots[(j + qlen8) * stride];
+          UInt g_c2 = roots[(j + qlen4) * stride];
+          UInt g_c3 = roots[(j + qlen4 + qlen8) * stride];
+          UInt w04 = F::Mul(z4, g_c0);
+          UInt w15 = F::Mul(z5, g_c1);
+          UInt w26 = F::Mul(z6, g_c2);
+          UInt w37 = F::Mul(z7, g_c3);
+
+          a[i + j]                          = F::Add(z0, w04);
+          a[i + j + halflen]                = F::Sub(z0, w04);
+          a[i + j + qlen8]                  = F::Add(z1, w15);
+          a[i + j + halflen + qlen8]        = F::Sub(z1, w15);
+          a[i + j + qlen4]                  = F::Add(z2, w26);
+          a[i + j + halflen + qlen4]        = F::Sub(z2, w26);
+          a[i + j + qlen4 + qlen8]          = F::Add(z3, w37);
+          a[i + j + halflen + qlen4 + qlen8] = F::Sub(z3, w37);
+        }
+      }
+    }
+
     template <typename F>
     inline void Forward(std::vector<UInt> &a, const Plan<F> &plan)
     {
@@ -286,12 +431,14 @@ namespace BigMath
       UInt *aPtr = a.data();
 
       Int len = n;
-      while (len >= 4)
+      while (len >= 8)
       {
-        ForwardRadix4Layer<F>(aPtr, n, len, roots);
-        len >>= 2;
+        ForwardRadix8Layer<F>(aPtr, n, len, roots);
+        len >>= 3;
       }
-      if (len == 2)
+      if (len == 4)
+        ForwardRadix4Layer<F>(aPtr, n, 4, roots);
+      else if (len == 2)
         ForwardRadix2Layer<F>(aPtr, n, 2, roots);
     }
 
@@ -305,20 +452,26 @@ namespace BigMath
       if (n >= 2)
       {
         Int logn = __builtin_ctz((unsigned)n);
+        Int rem = logn % 3;
         Int len;
-        if (logn & 1)
+        if (rem == 1)
         {
           InverseRadix2Layer<F>(aPtr, n, 2, roots);
-          len = 8;
+          len = 16;
+        }
+        else if (rem == 2)
+        {
+          InverseRadix4Layer<F>(aPtr, n, 4, roots);
+          len = 32;
         }
         else
         {
-          len = 4;
+          len = 8;
         }
         while (len <= n)
         {
-          InverseRadix4Layer<F>(aPtr, n, len, roots);
-          len <<= 2;
+          InverseRadix8Layer<F>(aPtr, n, len, roots);
+          len <<= 3;
         }
       }
 


### PR DESCRIPTION
Stacks on #59 (radix-4). Merge #59 first.

## Summary
- Fuse three radix-2 layers into a single radix-8 butterfly (8-element load/store across 3 layers).
- Internally: two radix-4 butterflies on {0,2,4,6} and {1,3,5,7} + four radix-2 on the resulting pairs (Forward); reverse for Inverse.
- Dispatch: radix-8 from outer_len ≥ 8; straggler radix-4 (log2(n) mod 3 == 2) or radix-2 (mod 3 == 1).
- Applied to both \`NTTCore\` (Goldilocks) and \`NttCrt\` (3-prime templated).

## Substitution for Bailey
After discussion (cost/benefit on top of radix-4), radix-8 substitutes for the originally-planned Bailey 6-step. Bailey would need ~500-800 LOC + bit-reversal-aware twiddle indexing + scratch buffers (~500MB at 20M limbs); radix-8 captures most of the bandwidth-reduction win at ~250 LOC with no new correctness risk. Bailey is deferred to a future session targeting very-large (≥100M) operands where cache-fit dominates beyond memory-pass reduction.

## Numbers
\`mul_xl_bench\` on M1 Max, Base2_64 (CRT path):

| limbs | post-r4 (ms) | post-r8 (ms) | ratio  | vs original |
|------:|-------------:|-------------:|-------:|------------:|
|    1M |        257.6 |        256.3 |  ~flat |       1.45× |
|    2M |        865.3 |        697.3 |  1.24× |       1.51× |
|    5M |       3694.6 |       3150.5 |  1.17× |       1.65× |
|   10M |       7933.6 |       6914.9 |  1.15× |       1.61× |
|   20M |      17864.3 |      15958.0 |  1.12× |       1.58× |

## Test plan
- [x] \`mult_correctness\` — passes
- [x] \`div_correctness\` — passes
- [x] \`unit_tests\` — 242/242
- [x] \`mul_xl_bench\` — small sizes (1k-500k) also faster or flat