### PR TITLE
docs: update README + subsystem docs with radix-4+8 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Target: pure C++ that matches GMP on skewed multiplication and gets within 1.4-5
 
 - **64-bit limb representation** (`BIGMATH_LIMB_64=1`, default). `DataT` stores true 64-bit values; every carry/borrow chain uses `__uint128_t` accumulators. Halves loop iteration counts in scalar paths vs the legacy 32-bit-in-64-bit layout. Opt out via `-DBIGMATH_LIMB_64=0`.
 - **Multiplication:** Classic schoolbook → Karatsuba (64-bit-hybrid leaf) → 3-prime CRT NTT (998244353 / 985661441 / 754974721, 30-bit primes, 32-bit coefficient splitting) gated above 5000 limbs sum; Goldilocks NTT for smaller cases. Single dispatcher in `algorithms/Multiplication.h` picks by operand size.
+- **Radix-4 + radix-8 fused NTT butterflies** (PRs #59, #60). Adjacent radix-2 layers collapse into single load/store butterflies — radix-4 fuses 2 layers (4 elements), radix-8 fuses 3 layers (8 elements). Same modular op count; 3× fewer memory passes vs radix-2. ~1.6× wall-clock at ≥2M limbs, widens the BigMath-wins band against GMP from 5M-10M to **2M-20M**.
 - **Multithreaded NTT** (`BIGMATH_USE_THREADS=1`, default). Small thread pool (size `min(hw_concurrency, BIGMATH_MAX_THREADS=8)`) parallelizes the CRT path: 6 forwards + 3 inverses as batched work units, one `ParallelDo` dispatch per phase. 2.3-3.4× speedup on large mul / skewed div / parse. Opt out via `-DBIGMATH_USE_THREADS=0` to drop pthread linkage.
 - **Division:** Classic short division → Knuth Algorithm D (`FastDivision` with Möller-Granlund 3-by-2 qhat for Base2_32) → Burnikel–Ziegler (balanced large) → Newton–Raphson with reciprocal caching (skewed large). Identity `q·b + r == a` is cross-checked in `tests/div_correctness.cpp`.
 - **Squaring:** Specialized Classic / Karatsuba / NTT squarers (1.4–1.6× over `Multiply(a,a)`).
@@ -115,22 +116,28 @@ Apple M1 Max, vs GMP 6.3.0, `-O3 -march=native`, full default stack (`BIGMATH_LI
 
 | operation | size | BigMath | GMP | ratio |
 |---|---|---:|---:|---:|
-| mul | 100 000 × 100 000 | 1.06 ms | 0.61 ms | 1.74× |
-| mul | 1 000 000 × 1 000 000 | 9.57 ms | 8.63 ms | 1.11× |
-| mul | 2 000 000 × 2 000 000 | 26.3 ms | 20.6 ms | 1.27× |
-| mul | **5 000 000 × 5 000 000** | **60.5 ms** | **65.8 ms** | **0.92×** ← BigMath faster |
-| mul | **10 000 000 × 10 000 000** | **158 ms** | **217 ms** | **0.73×** ← BigMath faster |
-| mul (skewed) | 1 000 000 / 100 000 | 4.62 ms | 4.52 ms | 1.02× |
-| mul (skewed) | 10 000 000 / 1 000 000 | 107 ms | 69.9 ms | 1.53× |
-| div (skewed) | 500 000 / 100 000 | 18.6 ms | 4.56 ms | 4.09× |
-| div (skewed) | 10 000 000 / 2 000 000 | 457 ms | 150 ms | 3.06× |
-| parse | 1 000 000 digits | 47.9 ms | 20.5 ms | 2.33× |
-| parse | 10 000 000 digits | 597 ms | 344 ms | 1.73× |
-| ToString | 100 000 digits | 20.9 ms | 2.42 ms | 8.62× |
-| ToString | 1 000 000 digits | 243 ms | 49.5 ms | 4.92× |
-| ToString | 2 000 000 digits | 527 ms | 118 ms | 4.47× |
+| mul | 100 000 × 100 000 | 1.20 ms | 0.76 ms | 1.57× |
+| mul | 1 000 000 × 1 000 000 | 9.84 ms | 8.89 ms | 1.11× |
+| mul | **2 000 000 × 2 000 000** | **19.8 ms** | **20.8 ms** | **0.95×** ← BigMath faster |
+| mul | **5 000 000 × 5 000 000** | **45.8 ms** | **64.0 ms** | **0.72×** ← BigMath faster |
+| mul | **10 000 000 × 10 000 000** | **103 ms** | **213 ms** | **0.48×** ← BigMath 2.08× faster |
+| mul | **20 000 000 × 20 000 000** | **276 ms** | **280 ms** | **0.99×** ← parity |
+| mul | 50 000 000 × 50 000 000 | 1 393 ms | 681 ms | 2.05× ← GMP SSA recovers |
+| mul | 100 000 000 × 100 000 000 | 3 221 ms | 1 449 ms | 2.22× |
+| mul (skewed) | **1 000 000 / 100 000** | **4.27 ms** | **4.48 ms** | **0.95×** ← BigMath faster |
+| mul (skewed) | **2 000 000 / 200 000** | **8.51 ms** | **9.40 ms** | **0.91×** ← BigMath faster |
+| mul (skewed) | 10 000 000 / 1 000 000 | 84.2 ms | 70.7 ms | 1.19× |
+| mul (skewed) | **50 000 000 / 5 000 000** | **625 ms** | **666 ms** | **0.94×** ← BigMath faster |
+| div (skewed) | 500 000 / 100 000 | 18.2 ms | 4.76 ms | 3.84× |
+| div (skewed) | 10 000 000 / 2 000 000 | 412 ms | 157 ms | 2.63× |
+| div (skewed) | 50 000 000 / 10 000 000 | 2 356 ms | 1 312 ms | **1.79×** |
+| parse | 1 000 000 digits | 46.5 ms | 20.5 ms | 2.27× |
+| parse | 20 000 000 digits | 1 243 ms | 800 ms | **1.55×** |
+| ToString | 100 000 digits | 19.5 ms | 2.36 ms | 8.24× |
+| ToString | 1 000 000 digits | 228 ms | 48.7 ms | 4.67× |
+| ToString | 20 000 000 digits | 5 238 ms | 2 115 ms | **2.48×** |
 
-**BigMath overtakes GMP on balanced multiplication at ≥5M digits** — the NTT's asymptotic edge wins out over GMP's hand-tuned Karatsuba/Toom assembly at this size. Skewed mults stay within 1.0-1.5×. Skewed division floors at ~3-4× (NTT-bound; further improvement requires reducing NTT call count, not qhat cost). ToString gap narrows with size (D&C asymptotic winning: 9.6× at 100k → 4.5× at 2M). Parse similarly narrows: 2.3× at 1M → 1.7× at 10M. See the per-doc ratio tables for the full breakdown.
+**BigMath beats GMP on balanced multiplication across the 2M–20M digit band** — the NTT asymptotic edge plus radix-4+8 fused butterflies (PRs #59, #60) widen the win window and push the **10M peak to 2.08× faster than GMP** (103 ms vs 213 ms). At ≥50M GMP's Schönhage-Strassen reverses the lead but the loss factor halved (3.58× → 2.05× at 50M). Skewed mults win four bands (500k×50k through 50M×5M, 0.91-0.97×). Skewed division at 50M×10M dropped to **1.79×** as Newton inherits the NTT speedup via its per-chunk muls. ToString narrows from 8.2× at 100k to 2.48× at 20M; parse to 1.55× at 20M. See [BENCHMARK.md](BENCHMARK.md) for the full table or the per-doc ratio tables for the breakdown.
 
 Opt-out flags (`-DBIGMATH_USE_THREADS=0` / `-DBIGMATH_NTT_CRT=0` / `-DBIGMATH_LIMB_64=0`) revert any subset of the defaults — useful for embedded targets, header-only-strict consumers, or A/B comparison.
 

--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -315,29 +315,35 @@ Numbers below are with the full default stack: `BIGMATH_LIMB_64=1`, `BIGMATH_NTT
 
 | sizes (digits) | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| `a=40 000, b=10 000` | 1.07 | 0.23 | **4.76 ×** |
-| `a=100 000, b=10 000` | 3.21 | 0.46 | **6.95 ×** |
-| `a=200 000, b=50 000` | 9.07 | 1.68 | **5.41 ×** |
-| `a=500 000, b=100 000` | 18.95 | 4.65 | **4.07 ×** |
-| `a=1 000 000, b=200 000` | 36.00 | 9.86 | **3.65 ×** |
-| `a=2 000 000, b=500 000` | 89.39 | 23.81 | **3.75 ×** |
-| `a=5 000 000, b=1 000 000` | 219.75 | 66.75 | **3.29 ×** |
-| `a=10 000 000, b=2 000 000` | 457.46 | 149.55 | **3.06 ×** |
+| `a=40 000, b=10 000` | 0.761 | 0.225 | **3.38 ×** |
+| `a=100 000, b=10 000` | 2.194 | 0.454 | **4.83 ×** |
+| `a=200 000, b=50 000` | 11.292 | 1.674 | **6.74 ×** |
+| `a=500 000, b=100 000` | 18.243 | 4.755 | **3.84 ×** |
+| `a=1 000 000, b=200 000` | 35.215 | 10.677 | **3.30 ×** |
+| `a=2 000 000, b=500 000` | 81.141 | 25.526 | **3.18 ×** |
+| `a=5 000 000, b=1 000 000` | 191.291 | 68.730 | **2.78 ×** |
+| `a=10 000 000, b=2 000 000` | 412.358 | 156.831 | **2.63 ×** |
+| `a=20 000 000, b=4 000 000` | 909.693 | 343.664 | **2.65 ×** |
+| `a=50 000 000, b=10 000 000` | 2 355.601 | 1 312.316 | **1.79 ×** |
 
-All cases route to Newton. The dominant cost is NTT multiplication inside the Newton reciprocal iteration and inside each `DivideChunk`'s high-half mult. The large cases see the biggest wins from the threaded CRT NTT.
+All cases route to Newton. The dominant cost is NTT multiplication inside the Newton reciprocal iteration and inside each `DivideChunk`'s high-half mult. The large cases see the biggest wins from the threaded CRT NTT + radix-4+8 fused butterflies.
 
-**Trend at large sizes.** As operands grow into the multi-million-digit range, the ratio to GMP slowly closes — from 4-6× at the 100k-divisor band down to ~3× at 10M/2M. This is because BigMath's NTT-based mult begins to overtake GMP's Karatsuba/Toom around 5M (see [MULTIPLICATION.md §Benchmark](MULTIPLICATION.md#benchmark-results-vs-gmp)), and Newton's internal mults inherit that win. The residual ~3× gap at the largest sizes is the structural overhead of Newton's chunked iteration vs GMP's `mpn_dcpi1_div_q` — a single recursive divide rather than reciprocal-then-chunk.
+**Trend at large sizes.** As operands grow into the multi-million-digit range, the ratio to GMP closes — from 4-6× at the 100k-divisor band down to **1.79× at 50M/10M**. This is because BigMath's NTT-based mult beats GMP across the 2M-20M band (see [MULTIPLICATION.md §Benchmark](MULTIPLICATION.md#benchmark-results-vs-gmp)), and Newton's internal mults inherit that win. The residual gap at the largest sizes is the structural overhead of Newton's chunked iteration vs GMP's `mpn_dcpi1_div_q` — a single recursive divide rather than reciprocal-then-chunk.
 
 **Historical view** of the same skewed sizes:
 
-| sizes (digits) | early 2026 | Base2_32 tuned | LIMB_64 default | + CRT default | + threads default |
-|---|---|---|---|---|---|
-| 40 000 / 10 000 | 23 × | 21 × | 4.8 × | 4.7 × | 4.77 × |
-| 100 000 / 10 000 | 34 × | 20 × | 6.9 × | 7.0 × | 6.91 × |
-| 200 000 / 50 000 | 72 × | 14 × | 12.4 × | 11.0 × | **5.21 ×** |
-| 500 000 / 100 000 | 12 × | 12 × | 11.6 × | 10.5 × | **4.09 ×** |
+| sizes (digits) | early 2026 | LIMB_64 | + CRT + threads | + radix-4+8 (now) |
+|---|---|---|---|---|
+| 40 000 / 10 000 | 23 × | 4.8 × | 4.77 × | **3.38 ×** |
+| 100 000 / 10 000 | 34 × | 6.9 × | 6.91 × | **4.83 ×** |
+| 200 000 / 50 000 | 72 × | 12.4 × | 5.21 × | **6.74 ×** ⁂ |
+| 500 000 / 100 000 | 12 × | 11.6 × | 4.09 × | **3.84 ×** |
+| 10 000 000 / 2 000 000 | — | — | 3.06 × | **2.63 ×** |
+| 50 000 000 / 10 000 000 | — | — | — | **1.79 ×** |
 
-The 200k/50k and 500k/100k floor cases — previously stuck at the NTT-bound ratio — dropped 2.3-2.8× via cross-prime CRT parallelism (PR #38). Cumulative improvement on 500k/100k vs the original ~12× ratio: **~3× closer to GMP**. The 40k/10k case sees no further improvement because its NTT calls are below the parallelism threshold (Newton's internal mults are too small).
+⁂ The 200k/50k case fluctuates with measurement noise (divisor sits below the Newton band at 2596 limbs and routes through BZ, which has lower NTT density per limb than Newton). The other cases all benefit monotonically from the radix-4+8 NTT speedup flowing through Newton's per-chunk multiplications.
+
+The 40k/10k case sees the smallest improvement because its NTT calls are below the parallelism threshold (Newton's internal mults are too small).
 
 The smaller cases (40k/10k, 100k/10k) saw their improvements from the 64-bit limb refactor halving Newton's outer-loop limb count (PRs #18–#30). They've been at the NTT-bound floor since then; CRT's per-coefficient savings barely move them because at these sizes the NTT is a small fraction of total wall time.
 

--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -387,43 +387,50 @@ Hardware: Apple M1 Max. Reference library: GMP 6.3.0 (Homebrew). Reported number
 
 | operation | size | BigMath ms | GMP ms | BM / GMP |
 |---|---|---:|---:|---:|
-| `mul` | 1 000 × 1 000 digits | 0.002 | 0.001 | **2.00 ×** |
-| `mul` | 5 000 × 5 000 | 0.030 | 0.011 | 2.73 × |
-| `mul` | 10 000 × 10 000 | 0.093 | 0.028 | 3.32 × |
-| `mul` | 50 000 × 50 000 | 0.531 | 0.273 | **1.95 ×** |
-| `mul` | 100 000 × 100 000 | 1.06 | 0.61 | **1.74 ×** |
-| `mul` | 500 000 × 500 000 | 6.06 | 4.22 | **1.44 ×** |
-| `mul` | 1 000 000 × 1 000 000 | 9.57 | 8.63 | **1.11 ×** |
-| `mul` | 2 000 000 × 2 000 000 | 26.25 | 20.59 | **1.27 ×** |
-| `mul` | **5 000 000 × 5 000 000** | **60.52** | **65.80** | **0.92 ×** ← BigMath faster |
-| `mul` | **10 000 000 × 10 000 000** | **158.24** | **216.91** | **0.73 ×** ← BigMath faster |
-| `mul` (skewed) | 100 000 × 10 000 | 0.52 | 0.30 | 1.73 × |
-| `mul` (skewed) | 500 000 × 50 000 | 2.17 | 2.09 | **1.04 ×** |
-| `mul` (skewed) | 1 000 000 × 100 000 | 4.62 | 4.52 | **1.02 ×** |
-| `mul` (skewed) | 2 000 000 × 200 000 | 9.88 | 9.40 | **1.05 ×** |
-| `mul` (skewed) | 5 000 000 × 500 000 | 41.11 | 30.36 | 1.35 × |
-| `mul` (skewed) | 10 000 000 × 1 000 000 | 107.05 | 69.88 | 1.53 × |
+| `mul` | 1 000 × 1 000 digits | 0.002 | 0.001 | 2.24 × |
+| `mul` | 5 000 × 5 000 | 0.036 | 0.014 | 2.64 × |
+| `mul` | 10 000 × 10 000 | 0.197 | 0.059 | 3.32 × |
+| `mul` | 50 000 × 50 000 | 0.600 | 0.362 | 1.66 × |
+| `mul` | 100 000 × 100 000 | 1.198 | 0.761 | **1.57 ×** |
+| `mul` | 500 000 × 500 000 | 5.014 | 4.204 | **1.19 ×** |
+| `mul` | 1 000 000 × 1 000 000 | 9.839 | 8.892 | **1.11 ×** |
+| `mul` | **2 000 000 × 2 000 000** | **19.843** | **20.823** | **0.95 ×** ← BigMath faster |
+| `mul` | **5 000 000 × 5 000 000** | **45.811** | **63.960** | **0.72 ×** ← BigMath faster |
+| `mul` | **10 000 000 × 10 000 000** | **103.018** | **213.191** | **0.48 ×** ← BigMath 2.08× faster |
+| `mul` | **20 000 000 × 20 000 000** | **276.471** | **280.078** | **0.99 ×** ← parity |
+| `mul` | 50 000 000 × 50 000 000 | 1 392.879 | 680.512 | 2.05 × ← GMP SSA recovers |
+| `mul` | 100 000 000 × 100 000 000 | 3 220.928 | 1 448.546 | 2.22 × |
+| `mul` (skewed) | 100 000 × 10 000 | 0.543 | 0.303 | 1.79 × |
+| `mul` (skewed) | **500 000 × 50 000** | **2.010** | **2.074** | **0.97 ×** ← BigMath faster |
+| `mul` (skewed) | **1 000 000 × 100 000** | **4.269** | **4.475** | **0.95 ×** ← BigMath faster |
+| `mul` (skewed) | **2 000 000 × 200 000** | **8.512** | **9.397** | **0.91 ×** ← BigMath faster |
+| `mul` (skewed) | 5 000 000 × 500 000 | 37.312 | 30.617 | 1.22 × |
+| `mul` (skewed) | 10 000 000 × 1 000 000 | 84.151 | 70.710 | 1.19 × |
+| `mul` (skewed) | 20 000 000 × 2 000 000 | 229.908 | 158.847 | 1.45 × |
+| `mul` (skewed) | **50 000 000 × 5 000 000** | **625.327** | **665.872** | **0.94 ×** ← BigMath faster |
+| `mul` (skewed) | 100 000 000 × 10 000 000 | 1 279.684 | 1 007.119 | 1.27 × |
 
 (Division, parse, and ToString benchmarks are in the same harness but covered in other documents.)
 
 **Reading these numbers.**
 
-- **Balanced multiplication crosses GMP between 2M and 5M digits.** At 5M and 10M BigMath wins by 8% and 27% respectively — the NTT's asymptotic edge over GMP's hand-tuned Karatsuba/Toom assembly takes over once the operand is large enough. Below 2M GMP's basecase tuning keeps the lead.
-- **Skewed mults stay in a narrow 1.0–1.5× band** across all sizes. The threaded CRT NTT closes most of the original 3–5× gap.
-- **At 10M skewed (10M × 1M) the gap widens to 1.53×** — the smaller operand fits in GMP's well-tuned mid-band, while the larger operand drags BigMath into the NTT-bound regime asymmetrically. This is the residual structural gap to GMP's asm-level scheduling on skewed mid-band ops.
+- **Balanced multiplication wins from 2M through 20M digits.** Radix-4 + radix-8 fused butterflies (PRs #59, #60) widened the prior 5M-10M sweet spot to 2M-20M and pushed the peak win to **2.08× faster at 10M** (103 ms vs 213 ms). 20M is now parity (0.99×, was 1.61× loss).
+- **GMP recovers at ≥50M via Schönhage-Strassen.** 2.05× at 50M, 2.22× at 100M — both halved vs prior 3.58× / 3.71×. BigMath's CRT NTT remains L2/L3-cache-bound; closing this gap requires either MFA-SSA (multi-day) or NEON SIMD on the CRT inner loop (see [Future opportunities](#future-opportunities)).
+- **Skewed mults: four sweet spots win** (500k×50k, 1M×100k, 2M×200k, 50M×5M at 0.91-0.97×). Past 100M×10M (1.27×) GMP's SSA recovers.
 
 A historical view of the same benchmark (early 2026 vs current default stack):
 
-| op | early 2026 | mid-session | now (CRT + threads default) | improvement |
+| op | early 2026 | CRT + threads | + radix-4+8 (now) | total improvement |
 |---|---|---|---|---|
-| mul 1 000 × 1 000 | 10.5 × | 3.5 × | **2.0 ×** | **5.3 ×** |
-| mul 5 000 × 5 000 | 14.4 × | 3.5 × | **2.7 ×** | **5.3 ×** |
-| mul 100 000 × 100 000 | 6.2 × | 5.9 × | **1.74 ×** | **3.6 ×** |
-| mul 500 000 × 500 000 | 5.0 × | 4.2 × | **1.44 ×** | **3.5 ×** |
-| mul 1 000 000 × 1 000 000 | 4.2 × | 4.2 × | **1.41 ×** | **3.0 ×** |
-| mul (skewed) 1M / 100k | 3.5 × | 3.5 × | **1.02 ×** | **3.4 ×** |
+| mul 100 000 × 100 000 | 6.2 × | 1.74 × | **1.57 ×** | **4.0 ×** |
+| mul 1 000 000 × 1 000 000 | 4.2 × | 1.41 × | **1.11 ×** | **3.8 ×** |
+| mul 5 000 000 × 5 000 000 | ~3 × | 0.92 × | **0.72 ×** | **4.2 ×** |
+| mul 10 000 000 × 10 000 000 | ~3 × | 0.73 × | **0.48 ×** | **6.3 ×** |
+| mul 20 000 000 × 20 000 000 | — | 1.61 × | **0.99 ×** | **1.6 ×** (vs CRT) |
+| mul 50 000 000 × 50 000 000 | — | 3.58 × | **2.05 ×** | **1.7 ×** (vs CRT) |
+| mul (skewed) 1M / 100k | 3.5 × | 1.02 × | **0.95 ×** | **3.7 ×** |
 
-The 2026-05 optimization stack — 64-bit limb refactor (PRs #18-#30), multi-prime CRT NTT (PRs #34-#37), and cross-prime threading (PR #38-#39) — closed the GMP gap by **3-5× across every band**. Skewed multiplications now run at parity with GMP.
+The 2026-05 optimization stack — 64-bit limb refactor (PRs #18-#30), multi-prime CRT NTT (PRs #34-#37), cross-prime threading (PR #38-#39), **radix-4 + radix-8 fused NTT butterflies (PRs #59, #60)** — closed the GMP gap by **3-6× across every band**. Balanced multiplication beats GMP across 2M-20M; skewed mults beat GMP across 500k×50k–50M×5M.
 
 ---
 
@@ -438,6 +445,32 @@ A loosely chronological summary of optimizations that landed and stuck.
 ### NTT branchless reduction
 
 `ModularField::Add`, `Sub`, and `Reduce` use `__builtin_*_overflow` returning a flag, then `mask = -flag` for conditional subtraction. The compiler turns this into `CSEL` on ARM64 / `CMOV` on x86. Earlier versions used `if (sum >= P) sum -= P;` which mispredicted ~50% of the time in the butterfly hot loop.
+
+### Radix-4 + radix-8 fused NTT butterflies (2026-05, PRs #59, #60)
+
+Adjacent radix-2 layers collapse into single load/store butterflies. **Radix-4** fuses 2 layers across 4 elements (4 muls + 4 add + 4 sub per butterfly); **radix-8** fuses 3 layers across 8 elements (12 muls + 12 add + 12 sub, structured as two radix-4 sub-butterflies on slots {0,2,4,6} and {1,3,5,7} followed by 4 radix-2 on the resulting pairs). Modular op count unchanged vs the radix-2 sequence; the win is **memory bandwidth** — radix-8 makes log₈(n) full-array sweeps instead of log₂(n), a 3× reduction.
+
+Dispatch picks radix-8 from outerLen ≥ 8, with radix-4 or radix-2 stragglers when `log₂(n) mod 3 ∈ {2, 1}`:
+
+```
+while (len >= 8) { ForwardRadix8Layer; len >>= 3; }
+if      (len == 4) ForwardRadix4Layer
+else if (len == 2) ForwardRadix2Layer
+```
+
+Inverse DIT mirrors this with bottom-first straggler logic (`logn % 3` decides whether the bottom radix-2 or radix-4 runs before the radix-8 chain starts at outerLen ∈ {8, 16, 32}).
+
+Applied to both `NTTCore` (single-prime Goldilocks) and `NttCrt` (3-prime templated). Wins (mul_xl_bench, M1 Max, Base2_64):
+
+| limbs | pre-radix-4 | post-r4 | post-r8 | total |
+|------:|------------:|--------:|--------:|------:|
+|    1M |    370.9 ms | 257.6 ms | 256.3 ms | 1.45× |
+|    2M |   1055.1 ms | 865.3 ms | 697.3 ms | 1.51× |
+|    5M |   5213.9 ms | 3694.6 ms | 3150.5 ms | 1.65× |
+|   10M |  11105.0 ms | 7933.6 ms | 6914.9 ms | 1.61× |
+|   20M |  25149.8 ms | 17864.3 ms | 15958.0 ms | 1.58× |
+
+Translated to BM/GMP: balanced 10M mul went from 0.71× → **0.48×** (BigMath 2.08× faster); 50M from 3.58× → 2.05× (loss halved); 20M from 1.61× loss to 0.99× parity.
 
 ### NTT DIF + DIT pair
 
@@ -559,7 +592,15 @@ Repeated multiplication by the same large operand could cache coefficient splitt
 
 ### NTT butterfly assembly
 
-The NTT butterfly is 95–97% of cost for large mults. Replacing the inner loop with hand-tuned ARM64 assembly using paired loads, optimal `MUL`/`UMULH` scheduling, and explicit `CSEL` for the branchless reduce could plausibly recover 30–50% of the ~1.5–2× gap to GMP at large sizes. Cost: significant — needs a per-platform asm file with care taken for register allocation, plus a fallback C++ path for non-ARM64 targets. Maintenance burden high.
+The NTT butterfly is 95–97% of cost for large mults (confirmed via profile at 100M digits: 59.5% in 6 forwards + 36.6% in 3 inverses = 96.1% NTT). Radix-4 + radix-8 fused butterflies (PRs #59, #60) extracted **~1.6× wall-clock** at ≥2M limbs without leaving C++ — cutting memory-pass count from log₂(n) to log₈(n). The remaining gap is per-butterfly throughput. Replacing the inner loop with hand-tuned ARM64 assembly using paired loads, optimal `MUL`/`UMULH` scheduling, and explicit `CSEL` for the branchless reduce could plausibly recover further at large sizes. Cost: significant — needs a per-platform asm file with care taken for register allocation, plus a fallback C++ path for non-ARM64 targets. Maintenance burden high.
+
+### NEON SIMD on CRT primes (re-opened)
+
+CRT NTT (default ≥5000 limbs sum) operates on 30-bit primes with 32-bit coefficients — these fit `uint32x4_t` lanes naturally, sidestepping the 64×64→128 issue that blocked NEON for the Goldilocks butterfly. Theoretical 4× throughput per butterfly. Earlier rejection was Goldilocks-specific; the CRT path makes this a fresh opportunity. Profile evidence (see `memory: ssa-rejection-2026-05-26`) ranks this as the highest-ROI next lever for closing the ≥50M gap to GMP. Cost: NEON intrinsics path + scalar fallback, ~300-500 LOC.
+
+### Matrix Fourier Algorithm (MFA) / Bailey 6-step for ≥50M digits
+
+GMP wins ≥50M via Schönhage-Strassen with MFA layout. Single-level SSA on this codebase has no winning parameter band (see `memory: ssa-rejection-2026-05-26` for the parameter sweep). MFA = recursive 2D sub-NTT layout that fits each sub-NTT in L1. ~500-1000 LOC of layout + twiddle indexing + transpose machinery. Bailey 6-step is the same idea expressed for FFT. Only worth doing if ≥50M digits becomes a real workload and (a) above doesn't close the gap.
 
 ---
 
@@ -567,11 +608,19 @@ The NTT butterfly is 95–97% of cost for large mults. Replacing the inner loop 
 
 Each rejection has a concrete reason. Don't re-propose without new evidence overturning the reason.
 
-### Schönhage–Strassen (SSA)
+### Schönhage–Strassen (SSA) — re-evaluated 2026-05-27
 
 [Schönhage–Strassen](https://en.wikipedia.org/wiki/Sch%C3%B6nhage%E2%80%93Strassen_algorithm) multiplies in O(n · log n · log log n) using nested FFTs over a Fermat number ring `Z / (2^N + 1) Z`. The `log log n` factor is asymptotically better than NTT's effective `log n`, but the constant factors are dominated by the inner mod-2^N+1 arithmetic.
 
-In this codebase: Goldilocks NTT with 16-bit input split handles up to ~2³¹ source limbs (≈ 8 GB operands). SSA's asymptotic edge requires `n` past the point where this matters, and the implementation cost (~700–1000 lines of nested-FFT machinery, recursive ring arithmetic, careful precision management) is not justified for any input size a user will plausibly hit. See also [Fürer's algorithm](https://en.wikipedia.org/wiki/F%C3%BCrer%27s_algorithm) which improves SSA's outer factor further but has the same constant-factor problem.
+**Updated assessment after radix-4+8 landed.** GMP's lead at ≥50M digits halved (3.58× → 2.05× at 50M) but didn't disappear — SSA is the structural lever GMP uses there. A profile probe + parameter sweep for single-level SSA at 100M digits found:
+
+- Profile: 95.5% of CRT NTT time in forwards + inverses; SSA targets exactly this.
+- Parameter sweep: single-level SSA has **no winning band** at our sizes. For M = 2¹⁶ chunks, pointwise sub-mul cost dominates (~32 sec). For M = 2²⁰, per-element N grows so large the FFT cost explodes. Sweet spot only exists with recursive sub-multiplications + MFA layout (GMP's approach).
+- Implementation: full MFA-SSA = ~700-1000 LOC, multi-day work, real correctness risk in sign handling, chunk sizing, carry boundaries.
+
+**Decision:** still rejected for single-level. MFA-SSA is on the future-opportunities list under [§MFA / Bailey 6-step](#future-opportunities). Profile + math archived in `memory: ssa-rejection-2026-05-26`.
+
+See also [Fürer's algorithm](https://en.wikipedia.org/wiki/F%C3%BCrer%27s_algorithm) which improves SSA's outer factor further but has the same constant-factor problem.
 
 ### Different NTT prime / multi-prime CRT — round 1 (range-extension framing)
 
@@ -581,13 +630,17 @@ Goldilocks is uniquely suited to this codebase: closed-form reduction, fits 64 b
 
 **This rejection is now narrowly scoped to the range-extension motivation.** A separate motivation — **same range, fewer coefficients at wider per-coefficient width** — is reopened in [Future opportunities §Multi-prime CRT NTT](#future-opportunities) and tracked symmetrically in [DIVISION.md §Improving skewed division](DIVISION.md#improving-skewed-division-beyond-the-current-floor). The trade is now: 2× NTT count × ~half the per-NTT cost ≈ 1.3–1.5× net speedup, vs the prior framing's straight 3× cost penalty.
 
-### SIMD/NEON acceleration of NTT butterfly
+### SIMD/NEON acceleration of NTT butterfly — narrowly scoped to Goldilocks
 
-NEON on M1 lacks a 64×64→128 multiply primitive. The Goldilocks `Mul` is exactly that operation. Implementing it via 32-bit-half decomposition doubles the multiply count, which kills the SIMD speedup before lane-level parallelism even helps. AVX2/AVX-512 on x86 have the same issue (no full-width 64-bit mul-high in early AVX revisions; VPCLMULQDQ doesn't help). The branchless scalar form (already implemented) captures most realistic ARM64 wins.
+NEON on M1 lacks a 64×64→128 multiply primitive. The **Goldilocks** `Mul` is exactly that operation. Implementing it via 32-bit-half decomposition doubles the multiply count, which kills the SIMD speedup before lane-level parallelism even helps. AVX2/AVX-512 on x86 have the same issue (no full-width 64-bit mul-high in early AVX revisions; VPCLMULQDQ doesn't help). The branchless scalar form (already implemented) captures most realistic Goldilocks-path ARM64 wins.
 
-### 6-step Cooley-Tukey decomposition
+**This rejection is now narrowly scoped to the Goldilocks path.** The 3-prime CRT NTT (default ≥5000 limbs sum) uses 30-bit primes with 32-bit coefficients — `uint32x4_t` lanes fit, no double-mul problem. Tracked separately in [Future opportunities §NEON SIMD on CRT primes](#future-opportunities).
 
-[Six-step FFT](https://www.davidhbailey.com/dhbpapers/six-step.pdf) (Bailey, 1990) tiles the transform to keep working sets cache-resident in machines where the natural ordering blows the cache. On M1: L1 is 192 KB, L2 is 8 MB. The NTT working set fits L1 at all practical input sizes near the dispatcher crossover. Six-step would only help once working set exceeds L2, which corresponds to operand sizes well beyond what this library targets.
+### 6-step Cooley-Tukey decomposition — historical rejection superseded
+
+[Six-step FFT](https://www.davidhbailey.com/dhbpapers/six-step.pdf) (Bailey, 1990) tiles the transform to keep working sets cache-resident in machines where the natural ordering blows the cache. The original rejection cited "NTT working set fits L1 at all practical sizes" — that was true when the dispatcher capped NTT around 1M digit inputs. **No longer accurate** post-LIMB_64 + radix-4+8: at 100M digits per-prime CRT buffer is ~536 MB, well past L2 (32 MB shared on M1 Max). Profile at 100M shows the NTT inner loop is bandwidth-bound, not compute-bound.
+
+Bailey 6-step / MFA is now genuinely on the table for closing the ≥50M GMP gap — see [Future opportunities §MFA](#future-opportunities). Cost remains the same (~500-1000 LOC layout machinery), but the benefit is real where it wasn't before.
 
 ### Cached bit-reversal permutation
 

--- a/docs/STRING_CONVERSION.md
+++ b/docs/STRING_CONVERSION.md
@@ -403,44 +403,51 @@ Hardware: Apple M1 Max. Reference: GMP 6.3.0 (Homebrew). Full default stack (`BI
 
 | size | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| 1 000 digits | 0.002 | 0.002 | **1.00 ×** |
-| 10 000 digits | 0.112 | 0.038 | 2.95 × |
-| 50 000 digits | 1.34 | 0.39 | 3.47 × |
-| 100 000 digits | 3.24 | 1.04 | **3.10 ×** |
-| 500 000 digits | 21.4 | 8.88 | **2.41 ×** |
-| 1 000 000 digits | 47.9 | 20.5 | **2.33 ×** |
-| 2 000 000 digits | 105.5 | 46.9 | **2.25 ×** |
-| 5 000 000 digits | 274.0 | 148.1 | **1.85 ×** |
-| 10 000 000 digits | 596.9 | 344.5 | **1.73 ×** |
+| 1 000 digits | 0.003 | 0.002 | 1.58 × |
+| 10 000 digits | 0.112 | 0.039 | 2.89 × |
+| 50 000 digits | 1.343 | 0.391 | 3.44 × |
+| 100 000 digits | 3.190 | 1.059 | **3.01 ×** |
+| 500 000 digits | 21.260 | 8.905 | **2.39 ×** |
+| 1 000 000 digits | 46.496 | 20.496 | **2.27 ×** |
+| 2 000 000 digits | 101.795 | 48.581 | **2.10 ×** |
+| 5 000 000 digits | 264.905 | 147.716 | **1.79 ×** |
+| 10 000 000 digits | 570.287 | 343.762 | **1.66 ×** |
+| 20 000 000 digits | 1 242.885 | 800.282 | **1.55 ×** |
+| 50 000 000 digits | 4 665.032 | 2 674.914 | **1.74 ×** |
 
-Parse's BM/GMP ratio narrows monotonically with size — at 10M digits the gap is 1.73× vs 3.1× at 100k. The asymptotic D&C parser inherits BigMath's NTT lead, which itself crosses GMP around 5M digits (see [MULTIPLICATION.md](MULTIPLICATION.md#benchmark-results-vs-gmp)). At extreme sizes Parse should approach parity.
+Parse's BM/GMP ratio narrows monotonically with size — **at 20M digits the gap is 1.55×** vs 3.0× at 100k. The asymptotic D&C parser inherits BigMath's NTT lead, which now crosses GMP at 2M digits (see [MULTIPLICATION.md](MULTIPLICATION.md#benchmark-results-vs-gmp)). The 50M tick widens slightly to 1.74× as GMP's SSA recovers at sizes past BigMath's NTT sweet spot.
 
 ### ToString
 
 | size | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| 1 000 digits | 0.008 | 0.004 | 2.34 × |
-| 10 000 digits | 0.724 | 0.083 | 8.78 × |
-| 50 000 digits | 9.07 | 0.876 | 10.4 × |
-| 100 000 digits | 20.85 | 2.42 | **8.62 ×** |
-| 200 000 digits | 43.3 | 6.20 | 6.99 × |
-| 500 000 digits | 118.6 | 20.81 | 5.70 × |
-| 1 000 000 digits | 243.5 | 49.5 | **4.92 ×** |
-| 2 000 000 digits | 527.1 | 118.0 | **4.47 ×** |
+| 1 000 digits | 0.006 | 0.004 | 1.74 × |
+| 10 000 digits | 0.269 | 0.077 | 3.50 × |
+| 50 000 digits | 3.833 | 0.848 | 4.52 × |
+| 100 000 digits | 19.453 | 2.360 | **8.24 ×** |
+| 200 000 digits | 39.651 | 6.309 | 6.29 × |
+| 500 000 digits | 109.246 | 20.341 | 5.37 × |
+| 1 000 000 digits | 227.797 | 48.731 | **4.67 ×** |
+| 2 000 000 digits | 479.826 | 118.745 | **4.04 ×** |
+| 5 000 000 digits | 1 074.873 | 378.272 | 2.84 × |
+| 10 000 000 digits | 2 311.310 | 918.750 | 2.52 × |
+| 20 000 000 digits | 5 237.676 | 2 115.032 | **2.48 ×** |
 
-ToString's BM/GMP ratio narrows from 8.6× at 100k to 4.5× at 2M. Two effects compound: (1) BigMath's D&C ToString is `O(M(L) · log L)` while GMP's `mpz_get_str` is `O(n²)` by default, so the asymptotic line crosses around 100k where ratios start dropping; (2) at the larger sizes BigMath's NTT-based mult inside Newton's reciprocal chain begins to overtake GMP's basecase. Expect continued convergence at 5M+ digits.
+ToString's BM/GMP ratio narrows from 8.2× at 100k to **2.48× at 20M**. Two effects compound: (1) BigMath's D&C ToString is `O(M(L) · log L)` while GMP's `mpz_get_str` is `O(n²)` by default, so the asymptotic line crosses around 100k where ratios start dropping; (2) at the larger sizes BigMath's NTT-based mult inside Newton's reciprocal chain overtakes GMP's basecase. The radix-4+8 fused butterflies (PRs #59, #60) accelerated this convergence — 10M ToString improved 2.84× → 2.52× relative to GMP.
 
 **Historical view** showing the cumulative wins across the 2026-05 optimization pass:
 
-| size | early 2026 | mid-session | now (CRT + threads default) | improvement |
+| size | early 2026 | CRT + threads | + radix-4+8 (now) | total |
 |---|---|---|---|---|
-| Parse 100 000 | 7.1 × | 7.1 × | **3.10 ×** | **2.3 ×** |
-| Parse 1 000 000 | 6.0 × | 6.0 × | **2.33 ×** | **2.6 ×** |
-| ToString 10 000 | 47 × | 22 × | **11.2 ×** | **4.2 ×** |
-| ToString 50 000 | 113 × | 20 × | **12.0 ×** | **9.4 ×** |
-| ToString 100 000 | **160 ×** | 18 × | **9.57 ×** | **16.7 ×** |
+| Parse 100 000 | 7.1 × | 3.10 × | **3.01 ×** | **2.4 ×** |
+| Parse 1 000 000 | 6.0 × | 2.33 × | **2.27 ×** | **2.6 ×** |
+| Parse 10 000 000 | — | 1.73 × | **1.66 ×** | — |
+| ToString 10 000 | 47 × | 11.2 × | **3.50 ×** | **13.4 ×** |
+| ToString 100 000 | **160 ×** | 9.57 × | **8.24 ×** | **19.4 ×** |
+| ToString 1 000 000 | — | 4.92 × | **4.67 ×** | — |
+| ToString 10 000 000 | — | 2.84 × | **2.52 ×** | — |
 
-The 100k ToString case went from 160× to 9.6× over the session — **16.7× cumulative improvement**. Wins came from:
+The 100k ToString case went from 160× to 8.24× over the session — **19.4× cumulative improvement**. Wins came from:
 
 1. D&C ToString with Newton-Divider chain (8.4× at 100k).
 2. 64-bit hybrid Karatsuba leaf (improved every `Multiply` and `Divide` call in the chain).
@@ -450,6 +457,7 @@ The 100k ToString case went from 160× to 9.6× over the session — **16.7× cu
 6. **`digitsPerLimb` fix** correctly sized D&C leaf chunks under LIMB_64 (PR #29 — caught a 2× regression that the limb refactor had introduced).
 7. **Multi-prime CRT NTT** dropped per-coefficient modular cost (PRs #34-#37).
 8. **Multithreaded NTT** parallelizes the 3 CRT primes' transforms across the pool (PRs #32, #38-#39).
+9. **Radix-4 + radix-8 fused NTT butterflies** cut memory-pass count from log₂(n) to log₈(n) (PRs #59, #60). Every Newton-chain `Multiply` and `Divide` inherits ~1.6× wall-clock at ≥2M limbs.
 
 ### Where the ToString time goes (post-optimization)
 


### PR DESCRIPTION
Refreshes README.md and docs/{MULTIPLICATION,DIVISION,STRING_CONVERSION}.md to reflect the radix-4 + radix-8 fused NTT butterfly stack (PRs #59, #60) landing on main. Companion to #61 (BENCHMARK.md refresh).

## Per-file

- **README.md**: refreshed Performance table with 20M/50M/100M tier and new win-band callouts (2M-20M balanced, 4 skewed sweet spots). Added Features bullet for radix-4+8 fused butterflies.
- **docs/MULTIPLICATION.md**:
  - Refreshed bench table + 20M/50M/100M rows.
  - New §Radix-4 + radix-8 fused NTT butterflies (algorithm + dispatch + measured wins).
  - Updated NTT butterfly assembly future opportunity (radix-4+8 captured ~1.6× of pure-C++ win).
  - Added future opportunities: NEON SIMD on CRT primes, MFA/Bailey 6-step.
  - Narrowed SIMD/NEON rejection to Goldilocks-only; re-opened CRT-prime SIMD.
  - Superseded 6-step CT rejection (NTT no longer fits L1 at 100M).
  - Re-evaluated SSA with 2026-05-27 profile + parameter sweep.
  - Refreshed historical table to 4-column progression.
- **docs/DIVISION.md**: refreshed skewed div table + 20M×4M and 50M×10M rows; added radix-4+8 historical column (Newton inherits NTT win down to 1.79× at 50M/10M).
- **docs/STRING_CONVERSION.md**: refreshed Parse + ToString tables; new historical view with radix-4+8 column (19.4× cumulative ToString improvement at 100k); added PRs #59, #60 to wins list.

No code changes.