### PR TITLE
Document threaded NTT benchmark results

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -70,6 +70,18 @@ Skewed (`a.size() >> b.size()`):
 - Below 500k, GMP's hand-tuned basecase keeps a 1.5-3.3× lead.
 - **Skewed mults: BigMath wins from 500k×50k through 50M×5M.** Four sweet spots: 0.97× / 0.95× / 0.91× / 0.94×. Past 100M×10M (1.27×) GMP recovers via SSA.
 
+### Multithreaded NTT check
+
+`BIGMATH_USE_THREADS=1` is the default. A focused `mul_xl_bench` run on 2026-05-27 compared the default build against `-DBIGMATH_USE_THREADS=0`:
+
+| limb size | serial ms | threaded ms | speedup |
+|---:|---:|---:|---:|
+| 100 000 | 55.171 | 17.634 | 3.13× |
+| 500 000 | 257.394 | 90.207 | 2.85× |
+| 1 000 000 | 602.433 | 250.242 | 2.41× |
+
+The threaded path uses coarse CRT parallelism for the six forward transforms and three inverse transforms, plus chunked pointwise multiplication. Single-prime Goldilocks fallback also uses size-gated layer parallelism.
+
 ### Shape-focused multiplication dispatch
 
 `tests/performance/multiplication_shape_bench.cpp` was added to measure direct Classic, Karatsuba, NTT, dispatcher, and an experimental blockwise-skew prototype by limb shape. It found one production dispatch miss: tiny high-skew operands should not enter Karatsuba.

--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -480,6 +480,22 @@ Forward decimation-in-frequency leaves the output in bit-reversed order; inverse
 
 Thread-local `unordered_map<Int, vector<ULong>>` per (size, direction). The second multiplication at the same NTT size pays only a hash lookup rather than rebuilding roots — important when Newton division iterates at a fixed size.
 
+### Multithreaded NTT (2026-05, default on)
+
+`BIGMATH_USE_THREADS=1` activates the shared thread pool from `common/Parallel.h`. The production CRT path uses coarse-grained cross-prime work: the 6 forward transforms (`fa`/`fb` for 3 primes) run as one `ParallelDo` batch, the pointwise multiply is chunked with `ParallelFor`, and the 3 inverse transforms run as a second `ParallelDo` batch. This keeps dispatch overhead low: two coarse transform dispatches per multiply instead of one dispatch per NTT layer.
+
+The Goldilocks fallback path also uses `ParallelFor` for large root generation, butterfly layers, pointwise multiply, and inverse scaling, gated by `ParallelMinSize()` to avoid small-input regressions.
+
+Fresh local check on 2026-05-27, `mul_xl_bench`, M1 Max, Base2_64, CRT default:
+
+| limbs | serial (`-DBIGMATH_USE_THREADS=0`) | threaded default | speedup |
+|---:|---:|---:|---:|
+| 100 000 | 55.171 ms | 17.634 ms | 3.13× |
+| 500 000 | 257.394 ms | 90.207 ms | 2.85× |
+| 1 000 000 | 602.433 ms | 250.242 ms | 2.41× |
+
+Opt out with `-DBIGMATH_USE_THREADS=0`; cap pool size with `-DBIGMATH_MAX_THREADS=N`.
+
 ### Karatsuba pointer-based workspace
 
 `KaratsubaMultiplication::MultiplyRecursive` uses `unique_ptr<DataT[]>` of size 8n for workspace, skipping the per-recursion `vector` zero-initialization that a naive implementation incurs.
@@ -570,17 +586,6 @@ The same pass simplified Base2_64 finalization in `NTTMultiplication` and CRT NT
 ## Future opportunities
 
 Ranked by expected ROI per unit of effort.
-
-### Multithreaded NTT (architectural, 1.5–3× on large NTT-bound ops)
-
-Detailed in [DIVISION.md §Improving skewed division](DIVISION.md#improving-skewed-division-beyond-the-current-floor). Applies symmetrically to multiplication — `Multiply` at ≥ 100k digits is NTT-bound and would benefit identically. The architectural lift is the same (header-only library + thread pool design), so the cost amortizes across both subsystems.
-
-Predicted end-to-end multiplication wins:
-
-| size | now (1 thread) | est 2 threads | est 4 threads |
-|---|---:|---:|---:|
-| mul 100k×100k | 3.48 ms | ~2.2 ms | ~1.4 ms |
-| mul 1M×1M | 36.5 ms | ~22 ms | ~14 ms |
 
 ### Multi-prime CRT NTT with 32-bit coefficients (high effort, 1.3–1.5× on NTT)
 


### PR DESCRIPTION
## Summary

- move multithreaded NTT from future work into implemented multiplication optimizations
- document the current CRT/Goldilocks threading model
- add focused default-vs-serial `mul_xl_bench` numbers to `BENCHMARK.md`

## Benchmarks

Focused `mul_xl_bench` run on 2026-05-27, comparing default `BIGMATH_USE_THREADS=1` against `-DBIGMATH_USE_THREADS=0`:

| limbs | serial | threaded | speedup |
|---:|---:|---:|---:|
| 100,000 | 55.171 ms | 17.634 ms | 3.13x |
| 500,000 | 257.394 ms | 90.207 ms | 2.85x |
| 1,000,000 | 602.433 ms | 250.242 ms | 2.41x |

## Verification

- `git diff --check`
- `tests/mult_correctness.cpp` compiled and passed during the benchmark/doc update
