### PR TITLE
Add prepared CRT NTT operands

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -82,6 +82,18 @@ Skewed (`a.size() >> b.size()`):
 
 The threaded path uses coarse CRT parallelism for the six forward transforms and three inverse transforms, plus chunked pointwise multiplication. Single-prime Goldilocks fallback also uses size-gated layer parallelism.
 
+### Prepared CRT NTT operands
+
+`tests/performance/prepared_ntt_bench.cpp` measures repeated multiplication by one fixed large operand. The prepared API caches that operand's CRT spectra and reuses it across partner operands.
+
+| build | limb shape | count | normal total | prepared total | setup | steady speedup | amortized speedup |
+|---|---|---:|---:|---:|---:|---:|---:|
+| threaded default | `100000x100000` | 5 | 95.100 ms | 87.037 ms | 6.921 ms | 1.09× | 1.01× |
+| threaded default | `100000x100000` | 20 | 372.320 ms | 346.550 ms | 6.996 ms | 1.07× | 1.05× |
+| serial `-DBIGMATH_USE_THREADS=0` | `100000x100000` | 5 | 291.137 ms | 198.299 ms | 16.590 ms | 1.47× | 1.35× |
+
+The default threaded gain is modest because regular CRT multiplication already overlaps the six forward transforms across the thread pool. The prepared API is still useful for repeated workloads, especially serial builds or CPU-budget-sensitive callers.
+
 ### Shape-focused multiplication dispatch
 
 `tests/performance/multiplication_shape_bench.cpp` was added to measure direct Classic, Karatsuba, NTT, dispatcher, and an experimental blockwise-skew prototype by limb shape. It found one production dispatch miss: tiny high-skew operands should not enter Karatsuba.

--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -446,6 +446,20 @@ A loosely chronological summary of optimizations that landed and stuck.
 
 `ModularField::Add`, `Sub`, and `Reduce` use `__builtin_*_overflow` returning a flag, then `mask = -flag` for conditional subtraction. The compiler turns this into `CSEL` on ARM64 / `CMOV` on x86. Earlier versions used `if (sum >= P) sum -= P;` which mispredicted ~50% of the time in the butterfly hot loop.
 
+### Multi-prime CRT NTT with 32-bit coefficients (2026-05, PRs #34-#37)
+
+`NTTMultiplication` dispatches large products to `NttCrt::Multiply` when `BIGMATH_NTT_CRT=1` and `a.size() + b.size() >= BIGMATH_NTT_CRT_THRESHOLD` (default threshold: 5000 limbs). The CRT path uses three 30-bit NTT primes:
+
+| prime | primitive root | max power-of-two length |
+|---:|---:|---:|
+| 998244353 | 3 | 2^23 |
+| 985661441 | 3 | 2^22 |
+| 754974721 | 11 | 2^24 |
+
+For `Base2_64`, each 64-bit limb is split into two 32-bit coefficients instead of the four 16-bit coefficients required by the single-prime Goldilocks path. After three independent convolutions, Garner reconstruction combines the residues and the final carry pass packs two 32-bit coefficients back into each 64-bit limb.
+
+The design trades three smaller 32-bit NTTs against one longer 64-bit Goldilocks NTT. It wins once the transform is large enough because the CRT path halves coefficient count, uses denser 32-bit buffers, and maps naturally onto the cross-prime threaded execution described below. Opt out with `-DBIGMATH_NTT_CRT=0`; adjust the crossover with `-DBIGMATH_NTT_CRT_THRESHOLD=N`.
+
 ### Radix-4 + radix-8 fused NTT butterflies (2026-05, PRs #59, #60)
 
 Adjacent radix-2 layers collapse into single load/store butterflies. **Radix-4** fuses 2 layers across 4 elements (4 muls + 4 add + 4 sub per butterfly); **radix-8** fuses 3 layers across 8 elements (12 muls + 12 add + 12 sub, structured as two radix-4 sub-butterflies on slots {0,2,4,6} and {1,3,5,7} followed by 4 radix-2 on the resulting pairs). Modular op count unchanged vs the radix-2 sequence; the win is **memory bandwidth** — radix-8 makes log₈(n) full-array sweeps instead of log₂(n), a 3× reduction.
@@ -495,6 +509,22 @@ Fresh local check on 2026-05-27, `mul_xl_bench`, M1 Max, Base2_64, CRT default:
 | 1 000 000 | 602.433 ms | 250.242 ms | 2.41× |
 
 Opt out with `-DBIGMATH_USE_THREADS=0`; cap pool size with `-DBIGMATH_MAX_THREADS=N`.
+
+### Prepared/reusable CRT NTT operands (2026-05)
+
+`NTTMultiplication::PrepareOperand(operand, maxOtherLimbs, base)` precomputes the CRT NTT spectra for one reusable operand at a transform size large enough for partners up to `maxOtherLimbs`. `NTTMultiplication::Multiply(prepared, other)` then repacks and transforms only `other`, pointwise-multiplies against the cached spectra, runs the inverse transforms, and finalizes normally.
+
+This targets repeated same-operand workloads such as multiplying many values by one large modulus-related constant or table entry. It does not change one-off `Multiply(a, b)` dispatch, and it is intentionally explicit because the prepared transform size is only valid up to the caller-provided maximum partner size.
+
+Focused `prepared_ntt_bench` results, M1 Max, Base2_64, CRT default, 100k×100k limbs:
+
+| build | count | normal total | prepare | prepared total | steady-state speedup | amortized speedup |
+|---|---:|---:|---:|---:|---:|---:|
+| threaded default | 5 | 95.100 ms | 6.921 ms | 87.037 ms | 1.09× | 1.01× |
+| threaded default | 20 | 372.320 ms | 6.996 ms | 346.550 ms | 1.07× | 1.05× |
+| serial `-DBIGMATH_USE_THREADS=0` | 5 | 291.137 ms | 16.590 ms | 198.299 ms | 1.47× | 1.35× |
+
+The threaded gain is smaller because normal CRT multiplication already runs the six forward transforms concurrently; prepared operands save CPU work and one side's packing, but wall time is partially hidden by cross-prime parallelism.
 
 ### Karatsuba pointer-based workspace
 
@@ -587,14 +617,6 @@ The same pass simplified Base2_64 finalization in `NTTMultiplication` and CRT NT
 
 Ranked by expected ROI per unit of effort.
 
-### Multi-prime CRT NTT with 32-bit coefficients (high effort, 1.3–1.5× on NTT)
-
-Also covered in [DIVISION.md §Improving skewed division](DIVISION.md#improving-skewed-division-beyond-the-current-floor) under "Faster NTT kernel". The original rejection (see below) was about extending the operand-size range; the current motivation is fewer coefficients at the same range. Worth a fresh look if multithreading isn't enough.
-
-### Prepared/reusable NTT operands
-
-Repeated multiplication by the same large operand could cache coefficient splitting, transform size, and forward spectra. This does not help one-off `Multiply(a, b)` because the legal transform size depends on both operands. A useful implementation needs an explicit prepared-operand API and invalidation rules for Goldilocks vs CRT modes.
-
 ### NTT butterfly assembly
 
 The NTT butterfly is 95–97% of cost for large mults (confirmed via profile at 100M digits: 59.5% in 6 forwards + 36.6% in 3 inverses = 96.1% NTT). Radix-4 + radix-8 fused butterflies (PRs #59, #60) extracted **~1.6× wall-clock** at ≥2M limbs without leaving C++ — cutting memory-pass count from log₂(n) to log₈(n). The remaining gap is per-butterfly throughput. Replacing the inner loop with hand-tuned ARM64 assembly using paired loads, optimal `MUL`/`UMULH` scheduling, and explicit `CSEL` for the branchless reduce could plausibly recover further at large sizes. Cost: significant — needs a per-platform asm file with care taken for register allocation, plus a fallback C++ path for non-ARM64 targets. Maintenance burden high.
@@ -633,7 +655,7 @@ Replacing Goldilocks with a different prime (Solinas, generalized Mersenne, etc.
 
 Goldilocks is uniquely suited to this codebase: closed-form reduction, fits 64 bits, supports 16-bit input coefficients with full safety margin out to ~2³¹ source limbs (≈ 16 GB operands). A multi-prime scheme triples the transform cost without enabling a larger range anyone uses.
 
-**This rejection is now narrowly scoped to the range-extension motivation.** A separate motivation — **same range, fewer coefficients at wider per-coefficient width** — is reopened in [Future opportunities §Multi-prime CRT NTT](#future-opportunities) and tracked symmetrically in [DIVISION.md §Improving skewed division](DIVISION.md#improving-skewed-division-beyond-the-current-floor). The trade is now: 2× NTT count × ~half the per-NTT cost ≈ 1.3–1.5× net speedup, vs the prior framing's straight 3× cost penalty.
+**This rejection is now narrowly scoped to the range-extension motivation.** A separate motivation — **same range, fewer coefficients at wider per-coefficient width** — became the implemented [multi-prime CRT NTT](#multi-prime-crt-ntt-with-32-bit-coefficients-2026-05-prs-34-37). The trade is now: three 32-bit NTTs at roughly half coefficient length, plus CRT reconstruction, versus one longer 64-bit Goldilocks NTT.
 
 ### SIMD/NEON acceleration of NTT butterfly — narrowly scoped to Goldilocks
 

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -133,6 +133,27 @@ namespace BigMath
         }
 
     public:
+        using PreparedOperand = NttCrt::PreparedOperand;
+
+        // Precompute the CRT NTT spectra for `operand` so repeated
+        // multiplications by operands up to `maxOtherLimbs` can skip one side's
+        // packing and forward transforms. This targets repeated same-operand
+        // workloads; one-off Multiply(a,b) remains unchanged.
+        static PreparedOperand PrepareOperand(
+            const vector<DataT> &operand,
+            SizeT maxOtherLimbs,
+            BaseT base)
+        {
+            return NttCrt::PrepareOperand(operand, maxOtherLimbs, base);
+        }
+
+        static vector<DataT> Multiply(
+            const PreparedOperand &prepared,
+            const vector<DataT> &other)
+        {
+            return NttCrt::Multiply(prepared, other);
+        }
+
         // Multiply two vectors of digits using NTT-based convolution.
         static vector<DataT> Multiply(const vector<DataT> &a, const vector<DataT> &b, BaseT base)
         {

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -35,6 +35,7 @@
 #include <array>
 #include <bit>
 #include <cstdint>
+#include <stdexcept>
 #include <unordered_map>
 #include <vector>
 
@@ -526,6 +527,282 @@ namespace BigMath
       return (ULong128)u1 + (ULong128)P1 * u2 + inv.p1p2 * u3;
     }
 
+    inline SizeT CoeffsPerLimb(BaseT base)
+    {
+      return base == Base2_64 ? 2u : 1u;
+    }
+
+    inline void PackOperand(const std::vector<DataT> &v,
+                            BaseT base,
+                            std::vector<UInt> &dst1,
+                            std::vector<UInt> &dst2,
+                            std::vector<UInt> &dst3)
+    {
+      if (base == Base2_64)
+      {
+        for (SizeT i = 0; i < v.size(); ++i)
+        {
+          SizeT j = i * 2;
+          UInt lo = (UInt)(v[i] & 0xFFFFFFFFULL);
+          UInt hi = (UInt)((v[i] >> 32) & 0xFFFFFFFFULL);
+          dst1[j]     = lo % P1; dst1[j + 1] = hi % P1;
+          dst2[j]     = lo % P2; dst2[j + 1] = hi % P2;
+          dst3[j]     = lo % P3; dst3[j + 1] = hi % P3;
+        }
+      }
+      else
+      {
+        // Base2_32: each limb is already a 32-bit value.
+        for (SizeT i = 0; i < v.size(); ++i)
+        {
+          UInt vv = (UInt)v[i];
+          dst1[i] = vv % P1;
+          dst2[i] = vv % P2;
+          dst3[i] = vv % P3;
+        }
+      }
+    }
+
+    inline std::vector<DataT> FinalizeProduct(const std::vector<UInt> &fa1,
+                                              const std::vector<UInt> &fa2,
+                                              const std::vector<UInt> &fa3,
+                                              ULong coeffCount,
+                                              BaseT base,
+                                              SizeT reserveLimbs)
+    {
+      const InvTable &inv = GarnerInverses();
+      std::vector<DataT> result;
+      result.reserve(reserveLimbs);
+
+      if (base == Base2_64)
+      {
+        // 2 coefficients per output limb, each 32 bits → 64-bit limb. Carry
+        // propagation needs more than the per-coeff width; use ULong128.
+        ULong128 carry = 0;
+        SizeT i = 0;
+        for (; i + 1 < (SizeT)coeffCount; i += 2)
+        {
+          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
+          ULong lo = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+
+          total = Garner(fa1[i + 1], fa2[i + 1], fa3[i + 1], inv) + carry;
+          ULong hi = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+
+          result.push_back((DataT)(lo | (hi << 32)));
+        }
+
+        ULong limb_acc = 0;
+        int slot = 0;
+        if (i < (SizeT)coeffCount)
+        {
+          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
+          limb_acc = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+          slot = 1;
+        }
+        while (carry > 0)
+        {
+          ULong digit = (ULong)(carry & 0xFFFFFFFFULL);
+          carry >>= 32;
+          limb_acc |= digit << (slot * 32);
+          ++slot;
+          if (slot == 2)
+          {
+            result.push_back((DataT)limb_acc);
+            limb_acc = 0;
+            slot = 0;
+          }
+        }
+        if (slot != 0)
+          result.push_back((DataT)limb_acc);
+      }
+      else
+      {
+        // Base2_32: 1 coefficient per output limb (already 32-bit).
+        ULong128 carry = 0;
+        for (SizeT i = 0; i < (SizeT)coeffCount; ++i)
+        {
+          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
+          result.push_back((DataT)(total & 0xFFFFFFFFULL));
+          carry = total >> 32;
+        }
+        while (carry > 0)
+        {
+          result.push_back((DataT)(carry & 0xFFFFFFFFULL));
+          carry >>= 32;
+        }
+      }
+
+      TrimZeros(result);
+      return result;
+    }
+
+    struct PreparedOperand
+    {
+      BaseT base = Base2_32;
+      SizeT operandLimbs = 0;
+      SizeT maxOtherLimbs = 0;
+      SizeT coeffsPerLimb = 1;
+      ULong operandCoeffSize = 0;
+      Int n = 0;
+      std::vector<UInt> f1;
+      std::vector<UInt> f2;
+      std::vector<UInt> f3;
+
+      bool Empty() const { return n == 0 || f1.empty(); }
+    };
+
+    inline PreparedOperand PrepareOperand(const std::vector<DataT> &operand,
+                                          SizeT maxOtherLimbs,
+                                          BaseT base)
+    {
+      PreparedOperand prepared;
+      prepared.base = base;
+      prepared.operandLimbs = (SizeT)operand.size();
+      prepared.maxOtherLimbs = maxOtherLimbs;
+      prepared.coeffsPerLimb = CoeffsPerLimb(base);
+
+      if (IsZero(operand))
+        return prepared;
+      if (maxOtherLimbs == 0)
+        throw std::invalid_argument("prepared NTT maxOtherLimbs must be non-zero");
+
+      prepared.operandCoeffSize = (ULong)operand.size() * prepared.coeffsPerLimb;
+      ULong maxOtherCoeffSize = (ULong)maxOtherLimbs * prepared.coeffsPerLimb;
+      ULong maxCoeffCount = prepared.operandCoeffSize + maxOtherCoeffSize - 1;
+      prepared.n = (Int)std::max<ULong>(2, std::bit_ceil(maxCoeffCount));
+
+      prepared.f1.assign(prepared.n, 0);
+      prepared.f2.assign(prepared.n, 0);
+      prepared.f3.assign(prepared.n, 0);
+      PackOperand(operand, base, prepared.f1, prepared.f2, prepared.f3);
+
+      const auto &plan1 = GetPlan<F1, G1>(prepared.n);
+      const auto &plan2 = GetPlan<F2, G2>(prepared.n);
+      const auto &plan3 = GetPlan<F3, G3>(prepared.n);
+
+#if BIGMATH_USE_THREADS
+      {
+        PreparedOperand *p = &prepared;
+        const Plan<F1> *pl1 = &plan1;
+        const Plan<F2> *pl2 = &plan2;
+        const Plan<F3> *pl3 = &plan3;
+        auto body = [p, pl1, pl2, pl3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Forward<F1>(p->f1, *pl1); break;
+              case 1: Forward<F2>(p->f2, *pl2); break;
+              case 2: Forward<F3>(p->f3, *pl3); break;
+            }
+          }
+        };
+        ParallelDo(3, body);
+      }
+#else
+      Forward<F1>(prepared.f1, plan1);
+      Forward<F2>(prepared.f2, plan2);
+      Forward<F3>(prepared.f3, plan3);
+#endif
+
+      return prepared;
+    }
+
+    inline std::vector<DataT> Multiply(const PreparedOperand &prepared,
+                                       const std::vector<DataT> &other)
+    {
+      if (prepared.Empty() || IsZero(other))
+        return std::vector<DataT>();
+      if (other.size() > prepared.maxOtherLimbs)
+        throw std::invalid_argument("prepared NTT operand exceeds maxOtherLimbs");
+
+      ULong otherCoeffSize = (ULong)other.size() * prepared.coeffsPerLimb;
+      ULong coeffCount = prepared.operandCoeffSize + otherCoeffSize - 1;
+
+      static thread_local std::vector<UInt> fb1, fb2, fb3;
+      fb1.assign(prepared.n, 0);
+      fb2.assign(prepared.n, 0);
+      fb3.assign(prepared.n, 0);
+      PackOperand(other, prepared.base, fb1, fb2, fb3);
+
+      const auto &plan1 = GetPlan<F1, G1>(prepared.n);
+      const auto &plan2 = GetPlan<F2, G2>(prepared.n);
+      const auto &plan3 = GetPlan<F3, G3>(prepared.n);
+
+#if BIGMATH_USE_THREADS
+      {
+        std::vector<UInt> *bufs[3] = {&fb1, &fb2, &fb3};
+        const Plan<F1> *p1 = &plan1;
+        const Plan<F2> *p2 = &plan2;
+        const Plan<F3> *p3 = &plan3;
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Forward<F1>(*bufs[0], *p1); break;
+              case 1: Forward<F2>(*bufs[1], *p2); break;
+              case 2: Forward<F3>(*bufs[2], *p3); break;
+            }
+          }
+        };
+        ParallelDo(3, body);
+      }
+#else
+      Forward<F1>(fb1, plan1);
+      Forward<F2>(fb2, plan2);
+      Forward<F3>(fb3, plan3);
+#endif
+
+      {
+        UInt *p1a = fb1.data(), *p2a = fb2.data(), *p3a = fb3.data();
+        const UInt *p1b = prepared.f1.data();
+        const UInt *p2b = prepared.f2.data();
+        const UInt *p3b = prepared.f3.data();
+        auto body = [p1a, p2a, p3a, p1b, p2b, p3b](Int s, Int e) {
+          for (Int i = s; i < e; ++i)
+          {
+            p1a[i] = F1::Mul(p1a[i], p1b[i]);
+            p2a[i] = F2::Mul(p2a[i], p2b[i]);
+            p3a[i] = F3::Mul(p3a[i], p3b[i]);
+          }
+        };
+        if ((SizeT)prepared.n >= ParallelMinSize()) ParallelFor(prepared.n, body);
+        else body(0, prepared.n);
+      }
+
+#if BIGMATH_USE_THREADS
+      {
+        std::vector<UInt> *bufs[3] = {&fb1, &fb2, &fb3};
+        const Plan<F1> *p1 = &plan1;
+        const Plan<F2> *p2 = &plan2;
+        const Plan<F3> *p3 = &plan3;
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Inverse<F1>(*bufs[0], *p1); break;
+              case 1: Inverse<F2>(*bufs[1], *p2); break;
+              case 2: Inverse<F3>(*bufs[2], *p3); break;
+            }
+          }
+        };
+        ParallelDo(3, body);
+      }
+#else
+      Inverse<F1>(fb1, plan1);
+      Inverse<F2>(fb2, plan2);
+      Inverse<F3>(fb3, plan3);
+#endif
+
+      return FinalizeProduct(
+          fb1, fb2, fb3, coeffCount, prepared.base, prepared.operandLimbs + other.size() + 2);
+    }
+
     // ─── Public Multiply ─────────────────────────────────────────────────────
 
     inline std::vector<DataT> Multiply(const std::vector<DataT> &a,
@@ -539,8 +816,7 @@ namespace BigMath
       // Split into 32-bit coefficients. Works for Base2_32 (1 coeff per limb)
       // and Base2_64 (2 coeffs per limb). Pre-CRT bounds: each coefficient is
       // < 2^32, convolution sum at length N is < N · 2^64.
-      bool b64 = (base == Base2_64);
-      SizeT coeffsPerLimb = b64 ? 2u : 1u;
+      SizeT coeffsPerLimb = CoeffsPerLimb(base);
 
       ULong aCoeffSize = (ULong)a.size() * coeffsPerLimb;
       ULong bCoeffSize = (ULong)b.size() * coeffsPerLimb;
@@ -553,35 +829,8 @@ namespace BigMath
       fa2.assign(n, 0); fb2.assign(n, 0);
       fa3.assign(n, 0); fb3.assign(n, 0);
 
-      auto pack = [&](const std::vector<DataT> &v, std::vector<UInt> &dst1,
-                      std::vector<UInt> &dst2, std::vector<UInt> &dst3) {
-        if (b64)
-        {
-          for (SizeT i = 0; i < v.size(); ++i)
-          {
-            SizeT j = i * 2;
-            UInt lo = (UInt)(v[i] & 0xFFFFFFFFULL);
-            UInt hi = (UInt)((v[i] >> 32) & 0xFFFFFFFFULL);
-            dst1[j]     = lo % P1; dst1[j + 1] = hi % P1;
-            dst2[j]     = lo % P2; dst2[j + 1] = hi % P2;
-            dst3[j]     = lo % P3; dst3[j + 1] = hi % P3;
-          }
-        }
-        else
-        {
-          // Base2_32: each limb is already a 32-bit value.
-          for (SizeT i = 0; i < v.size(); ++i)
-          {
-            UInt vv = (UInt)v[i];
-            dst1[i] = vv % P1;
-            dst2[i] = vv % P2;
-            dst3[i] = vv % P3;
-          }
-        }
-      };
-
-      pack(a, fa1, fa2, fa3);
-      pack(b, fb1, fb2, fb3);
+      PackOperand(a, base, fa1, fa2, fa3);
+      PackOperand(b, base, fb1, fb2, fb3);
 
       const auto &plan1 = GetPlan<F1, G1>(n);
       const auto &plan2 = GetPlan<F2, G2>(n);
@@ -657,74 +906,7 @@ namespace BigMath
       Inverse<F3>(fa3, plan3);
 #endif
 
-      // CRT reconstruct + propagate carries into output limbs.
-      const InvTable &inv = GarnerInverses();
-      std::vector<DataT> result;
-      result.reserve(a.size() + b.size() + 2);
-
-      if (b64)
-      {
-        // 2 coefficients per output limb, each 32 bits → 64-bit limb. Carry
-        // propagation needs more than the per-coeff width; use ULong128.
-        ULong128 carry = 0;
-        SizeT i = 0;
-        for (; i + 1 < (SizeT)coeffCount; i += 2)
-        {
-          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
-          ULong lo = (ULong)(total & 0xFFFFFFFFULL);
-          carry = total >> 32;
-
-          total = Garner(fa1[i + 1], fa2[i + 1], fa3[i + 1], inv) + carry;
-          ULong hi = (ULong)(total & 0xFFFFFFFFULL);
-          carry = total >> 32;
-
-          result.push_back((DataT)(lo | (hi << 32)));
-        }
-
-        ULong limb_acc = 0;
-        int slot = 0;
-        if (i < (SizeT)coeffCount)
-        {
-          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
-          limb_acc = (ULong)(total & 0xFFFFFFFFULL);
-          carry = total >> 32;
-          slot = 1;
-        }
-        while (carry > 0)
-        {
-          ULong digit = (ULong)(carry & 0xFFFFFFFFULL);
-          carry >>= 32;
-          limb_acc |= digit << (slot * 32);
-          ++slot;
-          if (slot == 2)
-          {
-            result.push_back((DataT)limb_acc);
-            limb_acc = 0;
-            slot = 0;
-          }
-        }
-        if (slot != 0)
-          result.push_back((DataT)limb_acc);
-      }
-      else
-      {
-        // Base2_32: 1 coefficient per output limb (already 32-bit).
-        ULong128 carry = 0;
-        for (SizeT i = 0; i < (SizeT)coeffCount; ++i)
-        {
-          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
-          result.push_back((DataT)(total & 0xFFFFFFFFULL));
-          carry = total >> 32;
-        }
-        while (carry > 0)
-        {
-          result.push_back((DataT)(carry & 0xFFFFFFFFULL));
-          carry >>= 32;
-        }
-      }
-
-      TrimZeros(result);
-      return result;
+      return FinalizeProduct(fa1, fa2, fa3, coeffCount, base, a.size() + b.size() + 2);
     }
   } // namespace NttCrt
 } // namespace BigMath

--- a/tests/mult_correctness.cpp
+++ b/tests/mult_correctness.cpp
@@ -44,6 +44,13 @@ static bool CheckSize(int digits)
   vector<DataT> toom = ToomCookMultiplication::Multiply(av, bv, BigInteger::Base());
   vector<DataT> toom5 = Toom5Multiplication::Multiply(av, bv, BigInteger::Base());
   vector<DataT> ntt = NTTMultiplication::Multiply(av, bv, BigInteger::Base());
+  bool okPrepared = true;
+  if (av.size() + bv.size() >= 512)
+  {
+    auto prepared = NTTMultiplication::PrepareOperand(av, (SizeT)bv.size(), BigInteger::Base());
+    vector<DataT> preparedProduct = NTTMultiplication::Multiply(prepared, bv);
+    okPrepared = Compare(classic, preparedProduct) == 0;
+  }
   bool okKara = Compare(classic, kara) == 0;
   bool okToom = Compare(classic, toom) == 0;
   bool okToom5 = Compare(classic, toom5) == 0;
@@ -65,6 +72,7 @@ static bool CheckSize(int digits)
        << " toom=" << okToom
        << " toom5=" << okToom5
        << " ntt=" << okNtt
+       << " pntt=" << okPrepared
        << " csq=" << okCsq
        << " ksq=" << okKsq
        << " nsq=" << okNsq
@@ -72,7 +80,7 @@ static bool CheckSize(int digits)
        << " limbs=" << av.size()
        << endl;
 
-  return okKara && okToom && okToom5 && okNtt && okCsq && okKsq && okNsq && okDsq;
+  return okKara && okToom && okToom5 && okNtt && okPrepared && okCsq && okKsq && okNsq && okDsq;
 }
 
 static bool CheckVectors(vector<DataT> const &a, vector<DataT> const &b, const char *label)
@@ -82,6 +90,13 @@ static bool CheckVectors(vector<DataT> const &a, vector<DataT> const &b, const c
   vector<DataT> toom = ToomCookMultiplication::Multiply(a, b, BigInteger::Base());
   vector<DataT> toom5 = Toom5Multiplication::Multiply(a, b, BigInteger::Base());
   vector<DataT> ntt = NTTMultiplication::Multiply(a, b, BigInteger::Base());
+  bool okPrepared = true;
+  if (a.size() + b.size() >= 512)
+  {
+    auto prepared = NTTMultiplication::PrepareOperand(a, (SizeT)b.size(), BigInteger::Base());
+    vector<DataT> preparedProduct = NTTMultiplication::Multiply(prepared, b);
+    okPrepared = Compare(classic, preparedProduct) == 0;
+  }
   bool okKara = Compare(classic, kara) == 0;
   bool okToom = Compare(classic, toom) == 0;
   bool okToom5 = Compare(classic, toom5) == 0;
@@ -92,10 +107,11 @@ static bool CheckVectors(vector<DataT> const &a, vector<DataT> const &b, const c
        << " toom=" << okToom
        << " toom5=" << okToom5
        << " ntt=" << okNtt
+       << " pntt=" << okPrepared
        << " limbs=" << a.size() << "x" << b.size()
        << endl;
 
-  return okKara && okToom && okToom5 && okNtt;
+  return okKara && okToom && okToom5 && okNtt && okPrepared;
 }
 
 int main()

--- a/tests/performance/prepared_ntt_bench.cpp
+++ b/tests/performance/prepared_ntt_bench.cpp
@@ -1,0 +1,124 @@
+// Repeated same-operand benchmark for the prepared CRT NTT API.
+
+#include "biginteger/BigInteger.h"
+#include "biginteger/algorithms/multiplication/NTTMultiplication.h"
+#include "biginteger/common/Comparator.h"
+#include "biginteger/common/Util.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+
+using namespace BigMath;
+
+namespace
+{
+  volatile SizeT sink = 0;
+
+  std::vector<DataT> RandomNumber(SizeT limbs, std::mt19937_64 &gen)
+  {
+    std::vector<DataT> value(limbs);
+    for (SizeT i = 0; i < limbs; ++i)
+    {
+#if BIGMATH_LIMB_64
+      value[i] = (DataT)gen();
+#else
+      value[i] = (DataT)(gen() & 0xFFFFFFFFULL);
+#endif
+    }
+    if (!value.empty())
+      value.back() |= (DataT)1 << (LimbBits - 1);
+    TrimZerosToOne(value);
+    return value;
+  }
+
+  template <class F>
+  double TimeMs(F &&fn)
+  {
+    auto start = std::chrono::steady_clock::now();
+    SizeT check = fn();
+    auto end = std::chrono::steady_clock::now();
+    sink += check;
+    return std::chrono::duration<double, std::milli>(end - start).count();
+  }
+
+  void CheckEqual(
+      const std::vector<DataT> &actual,
+      const std::vector<DataT> &expected,
+      SizeT index)
+  {
+    if (Compare(actual, expected) != 0)
+    {
+      std::cerr << "prepared NTT mismatch at index " << index
+                << " actual_limbs=" << actual.size()
+                << " expected_limbs=" << expected.size() << '\n';
+      std::abort();
+    }
+  }
+}
+
+int main(int argc, char **argv)
+{
+  SizeT preparedLimbs = argc > 1 ? (SizeT)std::strtoull(argv[1], nullptr, 10) : 100000;
+  SizeT otherLimbs = argc > 2 ? (SizeT)std::strtoull(argv[2], nullptr, 10) : preparedLimbs;
+  SizeT count = argc > 3 ? (SizeT)std::strtoull(argv[3], nullptr, 10) : 5;
+
+  std::mt19937_64 gen(0xC0FFEE123456789ULL);
+  std::vector<DataT> fixed = RandomNumber(preparedLimbs, gen);
+  std::vector<std::vector<DataT>> others;
+  others.reserve(count);
+  for (SizeT i = 0; i < count; ++i)
+    others.push_back(RandomNumber(otherLimbs, gen));
+
+  std::vector<std::vector<DataT>> expected;
+  expected.reserve(count);
+
+  double normalMs = TimeMs([&]() {
+    SizeT total = 0;
+    for (SizeT i = 0; i < count; ++i)
+    {
+      auto product = NTTMultiplication::Multiply(fixed, others[i], BigInteger::Base());
+      total += (SizeT)product.size();
+      expected.push_back(std::move(product));
+    }
+    return total;
+  });
+
+  NTTMultiplication::PreparedOperand prepared;
+  double prepareMs = TimeMs([&]() {
+    prepared = NTTMultiplication::PrepareOperand(fixed, otherLimbs, BigInteger::Base());
+    return (SizeT)prepared.n;
+  });
+
+  double preparedMs = TimeMs([&]() {
+    SizeT total = 0;
+    for (SizeT i = 0; i < count; ++i)
+    {
+      auto product = NTTMultiplication::Multiply(prepared, others[i]);
+      CheckEqual(product, expected[i], i);
+      total += (SizeT)product.size();
+    }
+    return total;
+  });
+
+  std::cout << "base=" << BigInteger::Base()
+            << " prepared_limbs=" << preparedLimbs
+            << " other_limbs=" << otherLimbs
+            << " count=" << count
+            << " transform_n=" << prepared.n << '\n';
+  std::cout << std::fixed << std::setprecision(3)
+            << "normal_ms=" << normalMs
+            << " prepare_ms=" << prepareMs
+            << " prepared_ms=" << preparedMs
+            << " prepared_with_setup_ms=" << (prepareMs + preparedMs)
+            << " steady_state_speedup=" << (normalMs / preparedMs)
+            << " amortized_speedup=" << (normalMs / (prepareMs + preparedMs))
+            << '\n';
+  std::cerr << "checksum=" << sink << '\n';
+  return 0;
+}


### PR DESCRIPTION
## Summary

- add explicit prepared CRT NTT operand support for repeated same-operand multiplication
- expose `NTTMultiplication::PrepareOperand(...)` and `NTTMultiplication::Multiply(prepared, other)`
- refactor CRT operand packing/finalization so normal and prepared paths share the same code
- add `prepared_ntt_bench` and prepared NTT correctness coverage
- document benchmark results and move prepared operands out of future work

## Benchmarks

`prepared_ntt_bench`, `100000x100000` limbs:

| build | count | normal | prepared | setup | speedup |
|---|---:|---:|---:|---:|---:|
| threaded default | 5 | 95.100 ms | 87.037 ms | 6.921 ms | 1.09x steady, 1.01x amortized |
| threaded default | 20 | 372.320 ms | 346.550 ms | 6.996 ms | 1.07x steady, 1.05x amortized |
| serial | 5 | 291.137 ms | 198.299 ms | 16.590 ms | 1.47x steady, 1.35x amortized |

The threaded gain is modest because normal CRT multiplication already overlaps the six forward transforms. The serial gain is larger because the prepared operand removes one side's forward transforms from the critical path.

## Verification

- `git diff --check`
- `tests/mult_correctness.cpp` compiled and passed with `pntt=1` coverage
- `prepared_ntt_bench` validates prepared products against normal NTT products
