### PR TITLE
Retune MFA threshold and refresh dispatch docs

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,6 +1,6 @@
 # BigMath vs GMP — full benchmark suite
 
-Measured 2026-05-27 (refreshed after PR #65). Single-run snapshot capturing the state of `master` after the 2026-05 optimization pass (LIMB_64 default, multi-prime CRT NTT default, multithreaded NTT default, M-G div2by1 in `ClassicDivision`, M-G 3/2 qhat in `FastDivision` Base2_64, BZ Knuth-normalize fix, radix-4 + radix-8 fused NTT butterflies (PRs #59, #60), **Matrix Fourier Algorithm / Bailey 6-step CRT NTT for n ≥ 2^21 coefficients (PR #65)**).
+Measured 2026-05-27 (fresh local rerun). Single-run snapshot capturing the state of `master` after the 2026-05 optimization pass (LIMB_64 default, multi-prime CRT NTT default, multithreaded NTT default, M-G div2by1 in `ClassicDivision`, M-G 3/2 qhat in `FastDivision` Base2_64, BZ Knuth-normalize fix, radix-4 + radix-8 fused NTT butterflies (PRs #59, #60), **Matrix Fourier Algorithm / Bailey 6-step CRT NTT retuned to n ≥ 2^24 coefficients**).
 
 For per-subsystem deep dives — algorithms, dispatch, optimization history, rejected approaches — see:
 
@@ -35,40 +35,56 @@ Balanced (`a.size() == b.size()`):
 
 | size | BigMath ms | GMP ms | BM/GMP |
 |---|---:|---:|---:|
-| 1 000 × 1 000 | 0.002 | 0.001 | 1.89× |
-| 5 000 × 5 000 | 0.031 | 0.012 | 2.66× |
-| 10 000 × 10 000 | 0.093 | 0.028 | 3.27× |
-| 50 000 × 50 000 | 0.778 | 0.442 | 1.76× |
-| 100 000 × 100 000 | 1.239 | 0.713 | 1.74× |
-| 500 000 × 500 000 | 5.214 | 4.245 | 1.23× |
-| 1 000 000 × 1 000 000 | 10.399 | 9.085 | 1.14× |
-| **2 000 000 × 2 000 000** | **21.304** | **21.477** | **0.99×** ← parity |
-| **5 000 000 × 5 000 000** | **47.503** | **64.408** | **0.74×** ← BigMath faster |
-| **10 000 000 × 10 000 000** | **114.695** | **202.482** | **0.57×** ← BigMath 1.77× faster |
-| **20 000 000 × 20 000 000** | **273.824** | **268.497** | **1.02×** ← parity |
-| **50 000 000 × 50 000 000** | **1 230.487** | **654.249** | **1.88×** ← MFA (was 2.05×) |
-| **100 000 000 × 100 000 000** | **2 589.292** | **1 390.762** | **1.86×** ← MFA (was 2.22×) |
+| 1 000 × 1 000 | 0.002 | 0.001 | 1.92× |
+| 5 000 × 5 000 | 0.030 | 0.011 | 2.66× |
+| 10 000 × 10 000 | 0.283 | 0.086 | 3.31× |
+| 50 000 × 50 000 | 1.022 | 0.578 | 1.77× |
+| 100 000 × 100 000 | 1.352 | 0.784 | 1.72× |
+| 500 000 × 500 000 | 5.218 | 4.217 | 1.24× |
+| 1 000 000 × 1 000 000 | 10.499 | 9.061 | 1.16× |
+| **2 000 000 × 2 000 000** | **21.893** | **20.555** | **1.07×** ← near parity |
+| **5 000 000 × 5 000 000** | **46.470** | **63.450** | **0.73×** ← BigMath faster |
+| **10 000 000 × 10 000 000** | **105.381** | **211.825** | **0.50×** ← BigMath 2.01× faster |
+| **20 000 000 × 20 000 000** | **278.550** | **277.598** | **1.00×** ← parity |
+| **50 000 000 × 50 000 000** | **1 231.492** | **660.410** | **1.86×** ← MFA active |
+| **100 000 000 × 100 000 000** | **2 831.516** | **1 390.974** | **2.04×** ← MFA active |
 
 Skewed (`a.size() >> b.size()`):
 
 | size | BigMath ms | GMP ms | BM/GMP |
 |---|---:|---:|---:|
-| 100 000 × 10 000 | 0.534 | 0.303 | 1.76× |
-| 500 000 × 50 000 | 2.170 | 2.072 | 1.05× |
-| **1 000 000 × 100 000** | **4.447** | **4.645** | **0.96×** ← BigMath faster |
-| 2 000 000 × 200 000 | 9.562 | 9.372 | 1.02× |
-| 5 000 000 × 500 000 | 39.344 | 30.688 | 1.28× |
-| 10 000 000 × 1 000 000 | 99.613 | 70.688 | 1.41× |
-| 20 000 000 × 2 000 000 | 236.781 | 159.895 | 1.48× |
-| **50 000 000 × 5 000 000** | **535.509** | **663.748** | **0.81×** ← BigMath faster (MFA) |
-| 100 000 000 × 10 000 000 | 1 164.039 | 991.366 | 1.17× |
+| 100 000 × 10 000 | 0.540 | 0.306 | 1.77× |
+| 500 000 × 50 000 | 2.133 | 2.132 | 1.00× |
+| **1 000 000 × 100 000** | **4.470** | **4.786** | **0.93×** ← BigMath faster |
+| **2 000 000 × 200 000** | **9.432** | **9.454** | **1.00×** ← parity |
+| 5 000 000 × 500 000 | 38.982 | 30.610 | 1.27× |
+| 10 000 000 × 1 000 000 | 88.435 | 70.513 | 1.25× |
+| 20 000 000 × 2 000 000 | 259.758 | 161.113 | 1.61× |
+| **50 000 000 × 5 000 000** | **666.753** | **666.405** | **1.00×** ← parity |
+| 100 000 000 × 10 000 000 | 1 154.909 | 1 003.655 | 1.15× |
 
 **Observations:**
 
-- **BigMath beats GMP on balanced multiplication across the 5M-20M band, ≈parity at 2M and 20M.** Radix-4 + radix-8 fused NTT butterflies (PRs #59, #60) added 1.5-1.6× wall-clock vs prior. Sweet spot at 10M balanced: BigMath **1.77× faster** (115 ms vs 202 ms). 20M balanced is parity (1.02×). 2M now parity (was 1.25× loss).
-- **MFA / Bailey 6-step CRT NTT (PR #65) closes ≥50M balanced.** Gap narrows from 2.05× → 1.88× at 50M, 2.22× → 1.86× at 100M. The CRT path now factors n = n1·n2 and recurses through a Bailey 6-step layout for n ≥ 2^21 coefficients, replacing one giant radix-2 pass with two cache-friendly half-size NTTs plus a twiddle pass. GMP still wins these bands via SSA's `log log n` edge — see [memory: ssa-rejection-2026-05-26] for why single-level SSA in BigMath has no winning parameter band.
+- **BigMath beats GMP on balanced multiplication across the 5M-10M band and is near parity at 20M.** Radix-4 + radix-8 fused NTT butterflies (PRs #59, #60) added 1.5-1.6× wall-clock vs prior. The 2026-05-27 MFA retune moved the gate from `2^21` to `2^24`, improving the 10M balanced row from 114.140 ms to **105.381 ms** by avoiding early MFA.
+- **MFA / Bailey 6-step CRT NTT (PR #65) is now reserved for the very-large regime.** The default gate is `2^24` transform coefficients. Focused limb benchmarks show this avoids the 300k-2M limb regression band while preserving MFA wins at 3M+ limbs.
 - Below 500k, GMP's hand-tuned basecase keeps a 1.5-3.3× lead.
-- **Skewed mults: BigMath wins at 1M×100k (0.96×) and 50M×5M (0.81×, MFA-driven).** Mid-band 5M×500k through 20M×2M slipped vs prior measurement (1.22×→1.28×, 1.19×→1.41×, 1.45×→1.48×) — single-iter timing on a noisy system; the underlying CRT NTT path is unchanged. 100M×10M improved 1.27× → 1.17× via MFA.
+- **Skewed mults: BigMath is at parity around 500k×50k, 2M×200k, and 50M×5M.** Raising the MFA gate gives up the earlier 50M×5M early-MFA win, but reduces regressions in the balanced 5M-20M band. 100M×10M is 1.15× on this snapshot.
+
+### MFA focused threshold check
+
+`mul_xl_bench` was run after raising the default gate to `2^24`. These are limb counts, not decimal digits. For Base2_64 balanced multiplication, `L` limbs per operand map to transform length `bit_ceil(4L - 1)`.
+
+| limbs per operand | transform length | active path | ms |
+|---:|---:|---|---:|
+| 200 000 | 2^20 | non-MFA | 39.942 |
+| 300 000 | 2^21 | non-MFA | 90.660 |
+| 500 000 | 2^21 | non-MFA | 92.290 |
+| 1 000 000 | 2^22 | non-MFA | 255.832 |
+| 2 000 000 | 2^23 | non-MFA | 704.094 |
+| **3 000 000** | **2^24** | **MFA** | **1 269.304** |
+| **5 000 000** | **2^25** | **MFA** | **2 620.899** |
+
+The retuned gate keeps the old MFA-off path through `2^23` and enables MFA at `2^24+`, matching the measured break-even region.
 
 ### Multithreaded NTT check
 
@@ -130,33 +146,33 @@ Balanced (`a.size() == b.size()`) — quotient is 1-2 limbs, both libraries shor
 
 | size | BigMath ms | GMP ms | BM/GMP |
 |---|---:|---:|---:|
-| 1 000 × 1 000 | <0.001 | <0.001 | 5.52× |
+| 1 000 × 1 000 | <0.001 | <0.001 | 10.90× |
 | 5 000 × 5 000 | 0.001 | <0.001 | 6.41× |
 | 10 000 × 10 000 | 0.002 | <0.001 | 6.55× |
-| 50 000 × 50 000 | <0.001 | <0.001 | 0.25× |
-| 100 000 × 100 000 | <0.001 | 0.001 | 0.08× |
-| 500 000 × 500 000 | 0.003 | 0.005 | 0.64× |
-| 1 000 000 × 1 000 000 | 0.001 | 0.010 | 0.13× |
-| 5 000 000 × 5 000 000 | 1.195 | 0.166 | 7.20× |
+| 50 000 × 50 000 | <0.001 | <0.001 | 0.43× |
+| 100 000 × 100 000 | <0.001 | 0.001 | 0.23× |
+| 500 000 × 500 000 | 0.001 | 0.005 | 0.18× |
+| 1 000 000 × 1 000 000 | 0.001 | 0.010 | 0.10× |
+| 5 000 000 × 5 000 000 | 1.367 | 0.189 | 7.23× |
 
 Skewed (`a.size() >> b.size()`) — Newton/BZ band, real algorithmic work:
 
 | size | BigMath ms | GMP ms | BM/GMP |
 |---|---:|---:|---:|
-| 40 000 × 10 000 | 0.733 | 0.218 | 3.36× |
-| 100 000 × 10 000 | 2.175 | 0.449 | 4.85× |
-| 200 000 × 50 000 | 11.084 | 1.681 | 6.59× |
-| 500 000 × 100 000 | 18.302 | 4.580 | 4.00× |
-| 1 000 000 × 200 000 | 34.306 | 9.992 | 3.43× |
-| 2 000 000 × 500 000 | 82.234 | 24.255 | 3.39× |
-| 5 000 000 × 1 000 000 | 204.521 | 67.735 | 3.02× |
-| 10 000 000 × 2 000 000 | 431.147 | 151.207 | 2.85× |
-| 20 000 000 × 4 000 000 | 992.905 | 339.050 | 2.93× |
-| **50 000 000 × 10 000 000** | **2 493.757** | **1 279.508** | **1.95×** ← MFA flowing through Newton |
+| 40 000 × 10 000 | 0.729 | 0.218 | 3.35× |
+| 100 000 × 10 000 | 2.188 | 0.455 | 4.81× |
+| 200 000 × 50 000 | 10.965 | 1.733 | 6.33× |
+| 500 000 × 100 000 | 17.987 | 4.627 | 3.89× |
+| 1 000 000 × 200 000 | 33.438 | 10.117 | 3.31× |
+| 2 000 000 × 500 000 | 81.815 | 23.975 | 3.41× |
+| 5 000 000 × 1 000 000 | 200.808 | 67.367 | 2.98× |
+| 10 000 000 × 2 000 000 | 426.945 | 153.584 | 2.78× |
+| 20 000 000 × 4 000 000 | 963.159 | 347.665 | 2.77× |
+| **50 000 000 × 10 000 000** | **2 499.998** | **1 298.707** | **1.92×** ← MFA flowing through Newton |
 
 **Observations:**
 
-- **Skewed division ratio narrows from ~6.6× at 200k×50k peak to 1.95× at 50M×10M.** Newton inherits the multiplication win in the 5M-50M sweet spot; 50M×10M now picks up the MFA gain (was 1.79× without MFA, now 1.95× — a slight slip from rerun noise; the underlying multiplication path is faster, but Newton's reciprocal-setup overhead at b = ~830k limbs eats some of it).
+- **Skewed division ratio narrows from ~6.3× at 200k×50k peak to 1.92× at 50M×10M.** Newton inherits the multiplication wins in the large regime, including MFA once the internal products cross the useful MFA band. The residual gap is still division-structure overhead, not decimal I/O.
 - 200k×50k stays the worst point: divisor sits below the Newton band (2596 limbs), goes through BZ which loses ~6.6× to GMP's `mpn_dcpi1_div_q` at this size.
 - Residual 2.6-3.4× gap in the 1M-20M skewed band is the structural cost of Newton's chunked iteration vs GMP's single recursive divide with precomputed inverse.
 - Balanced cases route through FastDivision short-circuits and aren't algorithmically meaningful at this size profile. The 5M×5M balanced case was regressing 27.03× before PR #56 fix (BZ misroute on degenerate quotient); now 7.20× via FastDivision short-circuit.
@@ -181,19 +197,19 @@ Representative Base2_64 results:
 
 | size (digits) | BigMath ms | GMP ms | BM/GMP |
 |---|---:|---:|---:|
-| 1 000 | 0.002 | 0.002 | 1.53× |
-| 10 000 | 0.112 | 0.038 | 2.98× |
-| 50 000 | 1.350 | 0.391 | 3.45× |
-| 100 000 | 3.243 | 1.053 | 3.08× |
-| 500 000 | 21.397 | 8.880 | 2.41× |
-| 1 000 000 | 47.352 | 20.364 | 2.33× |
-| 2 000 000 | 103.281 | 47.714 | 2.16× |
-| 5 000 000 | 273.453 | 146.196 | 1.87× |
-| 10 000 000 | 582.362 | 340.072 | 1.71× |
-| 20 000 000 | 1 272.350 | 788.203 | 1.61× |
-| 50 000 000 | 4 734.676 | 2 619.436 | 1.81× |
+| 1 000 | 0.002 | 0.002 | 1.55× |
+| 10 000 | 0.112 | 0.038 | 2.97× |
+| 50 000 | 1.350 | 0.389 | 3.47× |
+| 100 000 | 3.287 | 1.042 | 3.15× |
+| 500 000 | 22.220 | 8.799 | 2.53× |
+| 1 000 000 | 48.652 | 20.301 | 2.40× |
+| 2 000 000 | 106.413 | 46.878 | 2.27× |
+| 5 000 000 | 266.531 | 148.477 | 1.80× |
+| 10 000 000 | 577.357 | 340.170 | 1.70× |
+| 20 000 000 | 1 252.454 | 803.190 | 1.56× |
+| 50 000 000 | 5 212.270 | 2 629.889 | 1.98× |
 
-**Observation:** ratio narrows monotonically through the 10M-20M sweet spot (3.1× at 100k → **1.61× at 20M**) where BigMath's NTT overtakes GMP's basecase. Widens back to 1.81× at 50M as GMP's SSA activates — parser inherits both the mul win and the mul recovery.
+**Observation:** ratio narrows through the 10M-20M sweet spot (3.2× at 100k → **1.56× at 20M**) where BigMath's NTT overtakes GMP's basecase. It widens back to 1.98× at 50M as GMP's SSA activates.
 
 ---
 
@@ -201,19 +217,19 @@ Representative Base2_64 results:
 
 | size (digits) | BigMath ms | GMP ms | BM/GMP |
 |---|---:|---:|---:|
-| 1 000 | 0.007 | 0.004 | 1.82× |
-| 10 000 | 0.277 | 0.079 | 3.53× |
-| 50 000 | 3.824 | 0.850 | 4.50× |
-| 100 000 | 19.512 | 2.496 | 7.82× |
-| 200 000 | 40.125 | 6.035 | 6.65× |
-| 500 000 | 109.556 | 20.076 | 5.46× |
-| 1 000 000 | 227.583 | 48.614 | 4.68× |
-| 2 000 000 | 486.198 | 116.818 | 4.16× |
-| 5 000 000 | 1 092.316 | 373.233 | 2.93× |
-| 10 000 000 | 2 409.667 | 887.427 | 2.72× |
-| 20 000 000 | 5 422.171 | 2 145.396 | 2.53× |
+| 1 000 | 0.006 | 0.003 | 1.83× |
+| 10 000 | 0.268 | 0.078 | 3.46× |
+| 50 000 | 4.001 | 0.844 | 4.74× |
+| 100 000 | 19.484 | 2.334 | 8.35× |
+| 200 000 | 39.870 | 6.043 | 6.60× |
+| 500 000 | 107.239 | 20.426 | 5.25× |
+| 1 000 000 | 224.120 | 49.792 | 4.50× |
+| 2 000 000 | 477.132 | 120.276 | 3.97× |
+| 5 000 000 | 1 100.592 | 380.412 | 2.89× |
+| 10 000 000 | 2 414.564 | 900.384 | 2.68× |
+| 20 000 000 | 5 436.545 | 2 115.685 | 2.57× |
 
-**Observation:** narrowest gap at 1k (the linear leaf, where GM div2by1 already runs); peaks at 100k (D&C overhead + Newton recip setup not yet amortized); narrows again from 200k onward as D&C asymptotic + NTT inheriting from multiplication's overtake compound — **7.82× at 100k → 2.53× at 20M**.
+**Observation:** narrowest gap at 1k (the linear leaf, where GM div2by1 already runs); peaks at 100k (D&C overhead + Newton recip setup not yet amortized); narrows again from 200k onward as D&C asymptotic + NTT inheriting from multiplication's overtake compound — **8.35× at 100k → 2.57× at 20M**.
 
 ### ToString focused warm benchmark
 
@@ -221,11 +237,14 @@ After the table above, `tests/performance/tostring_bench.cpp` was added to isola
 
 | size (digits) | pre-pass ms | post-pass ms | speedup |
 |---|---:|---:|---:|
-| 1 000 | 0.0079 | 0.0063-0.0066 | 1.2-1.3× |
-| 10 000 | 1.1224 | 0.2793-0.2924 | 3.8-4.0× |
-| 50 000 | 9.4674 | 3.95-4.05 | 2.3-2.4× |
-| 100 000 | 19.8435 | 8.94-9.05 | 2.2× |
-| 200 000 | 41.1607 | 20.28-20.65 | 2.0× |
+| 1 000 | 0.0079 | 0.0062 | 1.27× |
+| 10 000 | 1.1224 | 0.5097 | 2.20× |
+| 50 000 | 9.4674 | 4.4633 | 2.12× |
+| 100 000 | 19.8435 | 9.4409 | 2.10× |
+| 200 000 | 41.1607 | 20.5682 | 2.00× |
+| 500 000 | — | 61.1404 | — |
+| 1 000 000 | — | 135.8015 | — |
+| 2 000 000 | — | 299.5458 | — |
 
 The dominant win is cached divider-chain reuse. The `DivideAndRemainderInto` API is currently neutral because it delegates to existing Newton internals; deeper scratch-buffer reuse would need to be pushed into `DivideChunk`, multiplication, and subtraction temporaries.
 
@@ -243,28 +262,28 @@ Balanced operands (e.g. `100.10` = 100 integer + 10 fractional digits):
 |---|---|---:|---:|---:|
 | Add | 100.10 | <0.001 | <0.001 | — |
 | Add | 1000.100 | <0.001 | <0.001 | — |
-| Add | 5000.500 | 0.001 | <0.001 | 5.33× |
-| Add | 20000.2000 | 0.002 | 0.001 | 4.33× |
+| Add | 5000.500 | 0.001 | <0.001 | 5.66× |
+| Add | 20000.2000 | 0.002 | 0.001 | 4.58× |
 |---|---|---|---|---|
-| Mul | 100.10 | <0.001 | <0.001 | 3.05× |
+| Mul | 100.10 | <0.001 | <0.001 | 4.05× |
 | Mul | 1000.100 | 0.002 | 0.001 | 2.36× |
-| Mul | 5000.500 | 0.037 | 0.013 | 2.89× |
-| Mul | 20000.2000 | 0.348 | 0.090 | 3.87× |
+| Mul | 5000.500 | 0.037 | 0.013 | 2.81× |
+| Mul | 20000.2000 | 0.344 | 0.090 | 3.85× |
 |---|---|---|---|---|
-| Div | 100.10 (10 dp) | 0.001 | <0.001 | 7.67× |
-| Div | 1000.100 (100 dp) | 0.003 | 0.002 | 1.50× |
-| Div | **5000.500 (500 dp)** | **0.023** | **0.024** | **0.93×** ← BigMath faster |
-| Div | 20000.2000 (2000 dp) | 0.228 | 0.198 | 1.15× |
+| Div | 100.10 (10 dp) | 0.001 | <0.001 | 7.66× |
+| Div | 1000.100 (100 dp) | 0.003 | 0.002 | 1.48× |
+| Div | **5000.500 (500 dp)** | **0.022** | **0.024** | **0.92×** ← BigMath faster |
+| Div | 20000.2000 (2000 dp) | 0.227 | 0.202 | 1.12× |
 
 Division at varying target scales (operand = 2000 integer + 200 fractional digits):
 
 | scale (dp) | BigMath ms | GMP (mpf) ms | BM/GMP |
 |---|---:|---:|---:|
 | **0** | **0.001** | **0.005** | **0.20×** ← BigMath faster |
-| **10** | **0.003** | **0.005** | **0.61×** ← BigMath faster |
-| **100** | **0.005** | **0.005** | **0.86×** ← BigMath faster |
-| 1000 | 0.015 | 0.009 | 1.63× |
-| 5000 | 0.060 | 0.035 | 1.71× |
+| **10** | **0.003** | **0.005** | **0.60×** ← BigMath faster |
+| **100** | **0.004** | **0.005** | **0.84×** ← BigMath faster |
+| 1000 | 0.015 | 0.010 | 1.56× |
+| 5000 | 0.060 | 0.035 | 1.68× |
 
 ### Parse and ToString
 
@@ -273,35 +292,35 @@ Parse (`string → BigDecimal`):
 | size (digits) | BigMath ms | GMP (mpf) ms | BM/GMP |
 |---|---:|---:|---:|
 | 100 | 0.001 | <0.001 | 1.09× |
-| 1 000 | 0.005 | 0.004 | 1.05× |
-| 10 000 | 0.135 | 0.107 | 1.26× |
-| 50 000 | 1.460 | 1.038 | 1.41× |
+| 1 000 | 0.005 | 0.004 | 1.06× |
+| 10 000 | 0.135 | 0.106 | 1.26× |
+| 50 000 | 1.482 | 1.002 | 1.48× |
 
 ToString (`BigDecimal → string`):
 
 | size (digits) | BigMath ms | GMP (mpf) ms | BM/GMP |
 |---|---:|---:|---:|
 | 100 | <0.001 | <0.001 | 0.64× |
-| 1 000 | 0.006 | 0.004 | 1.40× |
-| 10 000 | 0.270 | 0.104 | 2.59× |
-| 50 000 | 3.887 | 1.168 | 3.33× |
+| 1 000 | 0.006 | 0.005 | 1.38× |
+| 10 000 | 0.270 | 0.103 | 2.63× |
+| 50 000 | 3.954 | 1.090 | 3.63× |
 
 **Observations:**
-- BigDecimal division beats GMP at 5000.500 to 500 dp (0.023 vs 0.025 ms).
+- BigDecimal division beats GMP at 5000.500 to 500 dp (0.022 vs 0.024 ms).
 - Scale-aware division avoids unnecessary high-precision work; up to **5× faster** than `mpf_div` at small target scales.
-- Parse and ToString stay within 1.0-3.5× of GMP across 100-50k digits.
+- Parse stays within 1.0-1.5× of GMP across 100-50k digits; ToString stays within 0.7-3.7×.
 
 ---
 
 ## Headline summary
 
-- **Multiplication 5M-20M balanced:** BigMath faster than GMP (0.74× at 5M, **0.57× at 10M**, parity at 2M and 20M). Radix-4 + radix-8 fused butterflies (PRs #59, #60) widened the win band; **MFA (PR #65)** held parity at 20M and pushed 50M / 100M from 2.05× / 2.22× → **1.88× / 1.86×**.
-- **Multiplication ≥50M balanced:** GMP still wins via SSA but the gap halved over the 2026-05 series. BigMath's MFA CRT path now factors n = n1·n2 and runs two cache-friendly half-size NTTs plus a twiddle pass instead of one giant radix-2 sweep. SSA gap remains structural — single-level SSA in BigMath has no winning band (see memory: ssa-rejection-2026-05-26); MFA-SSA is the next theoretical lever.
-- **Multiplication skewed:** wins at 1M×100k (0.96×) and **50M×5M (0.81×, MFA win)**. 100M×10M now 1.17× (was 1.27×). Mid-band 5M-20M skewed sits between 1.28×-1.48× on this snapshot — single-iter measurement noise.
-- **Division skewed:** 1.95×-6.59× behind GMP. Worst at 200k×50k (BZ band). Best at **50M×10M (1.95×)** — the MFA-driven mul speedup partially flows through Newton.
+- **Multiplication 5M-20M balanced:** BigMath faster than GMP (0.73× at 5M, **0.50× at 10M**, parity at 20M). The MFA threshold retune improved the 10M balanced row by about 8%.
+- **Multiplication ≥50M balanced:** GMP still wins via SSA. MFA remains active at 50M+ balanced, but 100M is noisy and measured 2.04× on this snapshot.
+- **Multiplication skewed:** parity around 500k×50k, 2M×200k, and 50M×5M. 100M×10M is 1.15×. Mid-band 5M-20M skewed sits between 1.25×-1.61×.
+- **Division skewed:** 1.92×-6.33× behind GMP. Worst at 200k×50k (BZ band). Best at **50M×10M (1.92×)** — the large-multiplication speedups partially flow through Newton.
 - **Division balanced 5M×5M:** PR #56 fix routes degenerate-quotient cases to FastDivision; 27.03× → 7.20×.
-- **Parse:** **1.61× at 20M** (best), widens to 1.81× at 50M as mul recovery flows in.
-- **ToString:** 2.53× at 20M, monotonically narrowing from 7.82× peak at 100k.
+- **Parse:** **1.56× at 20M** (best), widens to 1.98× at 50M as GMP's SSA path dominates.
+- **ToString:** 2.57× at 20M, narrowing from an 8.35× peak at 100k.
 - **BigDecimal division:** beats GMP at small target scales (0.20-0.86×) and at the 500 dp parity point (0.93×).
 
 For optimizations considered and rejected with measurement evidence, see the **Explored but rejected** sections of each subsystem doc. The 2026-05 optimization stack (LIMB_64 + CRT NTT + threading + M-G reciprocals + BZ Knuth fix + degenerate-quotient guard + radix-4/radix-8 fused butterflies + MFA) closed the GMP gap by 3-5× across every band up to the 20M crossover; past 20M, GMP's SSA still wins but the loss factor halved.
@@ -310,7 +329,7 @@ For optimizations considered and rejected with measurement evidence, see the **E
 
 ## Dispatch validity after MFA addition
 
-PR #65 added MFA / Bailey 6-step routing inside `NTTMultiplicationCrt` for NTT lengths `n ≥ 2^21` coefficients (≈ 2.6M-limb operands). All other dispatch thresholds are unchanged in semantics. Verified post-MFA via `tests/performance/dispatch_tuner --full` (2026-05-27):
+PR #65 added MFA / Bailey 6-step routing inside `NTTMultiplicationCrt`. The default was retuned from `n ≥ 2^21` to `n ≥ 2^24` transform coefficients on 2026-05-27. For Base2_64 balanced multiplication that starts around **2M limbs per operand** (≈40M decimal digits), because each 64-bit limb produces two CRT coefficients and the convolution has about `4L` coefficients. The retune avoids the measured `2^21`-`2^23` regression band while preserving the `2^24+` wins. All other dispatch thresholds are unchanged in semantics. Verified post-MFA via `tests/performance/dispatch_tuner --full` (2026-05-27):
 
 | Knob | Current | Tuner suggestion | Verdict |
 |---|---:|---:|---|

--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -62,11 +62,14 @@ flowchart TD
     C -- no --> D{Compare&#40;a, b&#41;}
     D -- a == b --> Eq[return &#123;1, 0&#125;]
     D -- a &lt; b --> Less[return &#123;0, a&#125;]
-    D -- a &gt; b --> E{Newton medium-skew<br/>or high-skew band?}
+    D -- a &gt; b --> E{Newton band?<br/>b ≥ 4096 and a ≥ 3b<br/>OR b ≥ 2048 and a ≥ 8b}
     E -- yes --> N[NewtonDivision]
-    E -- no --> F{Power-of-two base<br/>AND b.size &gt; BZ_THRESHOLD<br/>AND BZ band fits?}
+    E -- no --> F{Power-of-two base<br/>AND b.size &gt; 512<br/>AND BZ shape fits?}
     F -- yes --> BZ[BurnikelZieglerDivision]
     F -- no --> FD[FastDivision]
+    FD --> S{b is single limb?}
+    S -- yes --> CD[ClassicDivision]
+    S -- no --> KD[Knuth-style FastDivision]
 ```
 
 Single-limb divisor (`b.size() == 1`) is handled inside `FastDivision` itself, which short-circuits to `ClassicDivision::DivModTo`.
@@ -90,7 +93,7 @@ The current dispatch logic, paraphrased:
 1. (b.size ≥ 4096 AND a.size ≥ 3·b.size)
    OR (b.size ≥ 2048 AND a.size ≥ 8·b.size)                               → Newton
 2. (Base2_32 OR Base2_64)  AND  b.size > 512  AND
-   ( (b.size ≥ 1024 AND a.size ≤ 3·b.size)
+   ( (b.size ≥ 1024 AND a.size ≥ b.size + 32 AND a.size ≤ 3·b.size)
      OR (a.size > 2048 AND a.size > 3·b.size) )                           → Burnikel–Ziegler
 3. else                                                                   → FastDivision
 4. (b.size == 1 inside FastDivision)                                      → ClassicDivision
@@ -298,11 +301,12 @@ This is the foundation of the divide-and-conquer ToString optimization. `Parser.
 Benchmark harness: `tests/performance/bench_vs_gmp.cpp`. Build:
 
 ```
-c++ -std=c++20 -O3 -march=native -I/opt/homebrew/include -L/opt/homebrew/lib \
-    tests/performance/bench_vs_gmp.cpp -o bench_vs_gmp -lgmp
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j8 --target bench_vs_gmp
+./build/bench_vs_gmp
 ```
 
-Hardware: Apple M1 Max. Reference: GMP 6.3.0 (Homebrew). `min` over a small iteration count.
+Hardware: Apple M1 Max. Reference: GMP 6.3.0 (Homebrew). Refreshed 2026-05-27.
 
 ### Balanced division
 
@@ -314,30 +318,30 @@ Numbers below are with the full default stack: `BIGMATH_LIMB_64=1`, `BIGMATH_NTT
 
 | sizes (digits) | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| `a=40 000, b=10 000` | 0.761 | 0.225 | **3.38 ×** |
-| `a=100 000, b=10 000` | 2.194 | 0.454 | **4.83 ×** |
-| `a=200 000, b=50 000` | 11.292 | 1.674 | **6.74 ×** |
-| `a=500 000, b=100 000` | 18.243 | 4.755 | **3.84 ×** |
-| `a=1 000 000, b=200 000` | 35.215 | 10.677 | **3.30 ×** |
-| `a=2 000 000, b=500 000` | 81.141 | 25.526 | **3.18 ×** |
-| `a=5 000 000, b=1 000 000` | 191.291 | 68.730 | **2.78 ×** |
-| `a=10 000 000, b=2 000 000` | 412.358 | 156.831 | **2.63 ×** |
-| `a=20 000 000, b=4 000 000` | 909.693 | 343.664 | **2.65 ×** |
-| `a=50 000 000, b=10 000 000` | 2 355.601 | 1 312.316 | **1.79 ×** |
+| `a=40 000, b=10 000` | 0.729 | 0.218 | **3.35 ×** |
+| `a=100 000, b=10 000` | 2.188 | 0.455 | **4.81 ×** |
+| `a=200 000, b=50 000` | 10.965 | 1.733 | **6.33 ×** |
+| `a=500 000, b=100 000` | 17.987 | 4.627 | **3.89 ×** |
+| `a=1 000 000, b=200 000` | 33.438 | 10.117 | **3.31 ×** |
+| `a=2 000 000, b=500 000` | 81.815 | 23.975 | **3.41 ×** |
+| `a=5 000 000, b=1 000 000` | 200.808 | 67.367 | **2.98 ×** |
+| `a=10 000 000, b=2 000 000` | 426.945 | 153.584 | **2.78 ×** |
+| `a=20 000 000, b=4 000 000` | 963.159 | 347.665 | **2.77 ×** |
+| `a=50 000 000, b=10 000 000` | 2 499.998 | 1 298.707 | **1.92 ×** |
 
 All cases route to Newton. The dominant cost is NTT multiplication inside the Newton reciprocal iteration and inside each `DivideChunk`'s high-half mult. The large cases see the biggest wins from the threaded CRT NTT + radix-4+8 fused butterflies.
 
-**Trend at large sizes.** As operands grow into the multi-million-digit range, the ratio to GMP closes — from 4-6× at the 100k-divisor band down to **1.79× at 50M/10M**. This is because BigMath's NTT-based mult beats GMP across the 2M-20M band (see [MULTIPLICATION.md §Benchmark](MULTIPLICATION.md#benchmark-results-vs-gmp)), and Newton's internal mults inherit that win. The residual gap at the largest sizes is the structural overhead of Newton's chunked iteration vs GMP's `mpn_dcpi1_div_q` — a single recursive divide rather than reciprocal-then-chunk.
+**Trend at large sizes.** As operands grow into the multi-million-digit range, the ratio to GMP closes — from 4-6× at the 100k-divisor band down to **1.92× at 50M/10M**. This is because BigMath's NTT-based mult beats GMP across the 5M-20M band (see [MULTIPLICATION.md §Benchmark](MULTIPLICATION.md#benchmark-results-vs-gmp)), and Newton's internal mults inherit that win. The residual gap at the largest sizes is the structural overhead of Newton's chunked iteration vs GMP's `mpn_dcpi1_div_q` — a single recursive divide rather than reciprocal-then-chunk.
 
 **Historical view** of the same skewed sizes:
 
 | sizes (digits) | early 2026 | LIMB_64 | + CRT + threads | + radix-4+8 (now) |
 |---|---|---|---|---|
-| 40 000 / 10 000 | 23 × | 4.8 × | 4.77 × | **3.38 ×** |
-| 100 000 / 10 000 | 34 × | 6.9 × | 6.91 × | **4.83 ×** |
-| 200 000 / 50 000 | 72 × | 12.4 × | 5.21 × | **6.74 ×** ⁂ |
-| 500 000 / 100 000 | 12 × | 11.6 × | 4.09 × | **3.84 ×** |
-| 10 000 000 / 2 000 000 | — | — | 3.06 × | **2.63 ×** |
+| 40 000 / 10 000 | 23 × | 4.8 × | 4.77 × | **3.35 ×** |
+| 100 000 / 10 000 | 34 × | 6.9 × | 6.91 × | **4.81 ×** |
+| 200 000 / 50 000 | 72 × | 12.4 × | 5.21 × | **6.33 ×** ⁂ |
+| 500 000 / 100 000 | 12 × | 11.6 × | 4.09 × | **3.89 ×** |
+| 10 000 000 / 2 000 000 | — | — | 3.06 × | **2.78 ×** |
 | 50 000 000 / 10 000 000 | — | — | — | **1.79 ×** |
 
 ⁂ The 200k/50k case fluctuates with measurement noise (divisor sits below the Newton band at 2596 limbs and routes through BZ, which has lower NTT density per limb than Newton). The other cases all benefit monotonically from the radix-4+8 NTT speedup flowing through Newton's per-chunk multiplications.

--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -63,7 +63,7 @@ Number-theoretic transform (NTT) input is always split into 16-bit chunks regard
 
 ## Top-level dispatch
 
-`biginteger/algorithms/Multiplication.h` exposes `Multiply(a, b, base)` returning a fresh limb vector. The dispatcher inspects operand sizes and picks one of three implementations.
+`biginteger/algorithms/Multiplication.h` exposes `Multiply(a, b, base)` returning a fresh limb vector. The dispatcher inspects operand sizes and shape, then picks Classic, Karatsuba, Toom-3, or NTT. The NTT wrapper has a second-level dispatch between the Goldilocks and CRT/MFA kernels.
 
 ```mermaid
 flowchart TD
@@ -71,25 +71,39 @@ flowchart TD
     B -- yes --> Z[return &#123;0&#125;]
     B -- no --> C{a or b<br/>single limb?}
     C -- yes --> Sc[ClassicMultiplication::Multiply&#40;scalar&#41;]
-    C -- no --> D{size ≤ CLASSIC_THRESHOLD<br/>OR<br/>minSize ≤ CLASSIC_MIN_LIMB?}
+    C -- no --> D{size ≤ CLASSIC_THRESHOLD<br/>OR minSize ≤ CLASSIC_MIN_LIMB<br/>OR tiny high-skew shape?}
     D -- yes --> Cl[ClassicMultiplication::Multiply]
-    D -- no --> E{size &lt; NTT_THRESHOLD?}
+    D -- no --> E{size &lt; TOOM3_THRESHOLD?}
     E -- yes --> K[KaratsubaMultiplication::Multiply]
-    E -- no --> N[NTTMultiplication::Multiply]
+    E -- no --> T{size &lt; NTT_THRESHOLD?}
+    T -- yes --> Toom[ToomCookMultiplication::Multiply]
+    T -- no --> N[NTTMultiplication::Multiply]
+
+    N --> C1{CRT enabled<br/>AND size ≥ CRT_THRESHOLD?}
+    C1 -- no --> G[Goldilocks NTT]
+    C1 -- yes --> C2[3-prime CRT NTT]
+    C2 --> C3{transform n ≥ 2^24?}
+    C3 -- yes --> MFA[MFA / Bailey 6-step]
+    C3 -- no --> R8[radix-8 CRT NTT]
 ```
 
-`size = a.size() + b.size()`, `minSize = min(a.size(), b.size())`.
+`size = a.size() + b.size()`, `minSize = min(a.size(), b.size())`, `maxSize = max(a.size(), b.size())`. The tiny high-skew Classic guard is `minSize ≤ 64 && maxSize ≥ 10·minSize`.
 
 Default thresholds (overridable via `-D...`):
 
 | macro | default | unit | meaning |
 |---|---|---|---|
-| `BIGMATH_CLASSIC_MULTIPLICATION_THRESHOLD` | `0` | sum of limbs | Classic only for 1-limb operand |
-| `BIGMATH_CLASSIC_MIN_LIMB_THRESHOLD` | `0` | min of limbs | Same, secondary guard |
-| `BIGMATH_NTT_MULTIPLICATION_THRESHOLD` | `4096` | sum of limbs | Karatsuba below, NTT above |
+| `BIGMATH_CLASSIC_MULTIPLICATION_THRESHOLD` | `96` under LIMB_64 | sum of limbs | Classic small-product cutoff |
+| `BIGMATH_CLASSIC_MIN_LIMB_THRESHOLD` | `0` | min of limbs | Secondary Classic guard |
+| `BIGMATH_CLASSIC_SKEW_MIN_LIMB_THRESHOLD` | `64` | min of limbs | Classic for tiny high-skew products |
+| `BIGMATH_CLASSIC_SKEW_RATIO` | `10` | ratio | tiny high-skew Classic guard |
+| `BIGMATH_TOOM3_MULTIPLICATION_THRESHOLD` | `2560` | sum of limbs | Karatsuba below, Toom-3 above |
+| `BIGMATH_NTT_MULTIPLICATION_THRESHOLD` | `5120` | sum of limbs | Toom-3 below, NTT above |
+| `BIGMATH_NTT_CRT_THRESHOLD` | `5000` | sum of limbs | CRT NTT vs Goldilocks NTT |
+| `BIGMATH_NTT_MFA_THRESHOLD` | `2^24` | transform coefficients | MFA vs radix-8 CRT NTT |
 | `BIGMATH_KARATSUBA_THRESHOLD` | `48` | max of operands | Inside Karatsuba: base-case cutoff |
 
-`Toom-Cook 3` and `Toom-5` are implemented and correctness-tested but **not in the default dispatch** — see [Toom-Cook 3](#toom-cook-3) and [Toom-5](#toom-5) for why.
+`Toom-Cook 3` is now in the default dispatch for a narrow pre-NTT band. `Toom-5` is implemented and correctness-tested but **not in the default dispatch** — see [Toom-5](#toom-5) for why.
 
 `Square(a, base)` lives in `algorithms/Squaring.h` and has its own parallel dispatcher:
 
@@ -104,7 +118,7 @@ flowchart TD
     D -- no --> N[NTTSquare]
 ```
 
-`NTT_SQUARE_THRESHOLD` defaults to `512` limbs, tuned separately from multiplication because NTT squaring needs only one forward transform (the threshold uses operand size directly, not the sum).
+`NTT_SQUARE_THRESHOLD` defaults to `2048` limbs under LIMB_64, tuned separately from multiplication because NTT squaring needs only one forward transform (the threshold uses operand size directly, not the sum). Legacy LIMB_32 builds keep the older `512`-limb default.
 
 ---
 
@@ -201,7 +215,7 @@ These eliminate per-iteration branches that the compiler was not consistently ho
 
 **Complexity:** O(n^{log₃5}) ≈ O(n^1.465) multiplies. Faster asymptotic exponent than Karatsuba, but larger constant factor due to evaluation/interpolation overhead.
 
-**Status:** *implemented and validated against `mult_correctness.cpp`, but **not** in the dispatch chain.*
+**Status:** *implemented, validated against `mult_correctness.cpp`, and used in the default dispatch for total limb size `2560 ≤ size < 5120`.*
 
 **Algorithm:** split each operand into three parts, evaluate the resulting polynomials at five points {0, 1, −1, 2, ∞}, perform five sub-multiplications, and interpolate. Concretely:
 
@@ -222,9 +236,9 @@ These eliminate per-iteration branches that the compiler was not consistently ho
        a·b = c₀ + c₁·B^k + c₂·B^(2k) + c₃·B^(3k) + c₄·B^(4k)
 ```
 
-**Why it isn't in dispatch.** Toom-3's best historical case was only a small win over Karatsuba, while the NTT path dominates once operands are large enough for Toom's lower exponent to matter. Current dispatcher sweeps keep Karatsuba until roughly 2048×2048 limbs and switch to NTT from total size ~4096. There is still no measured operand-size band where Toom-3 is the production winner.
+**Why the dispatch band is narrow.** Toom-3's useful window is the gap between Karatsuba's recursion overhead and NTT's next-power-of-two setup cost. Current dispatcher sweeps keep Karatsuba below total size 2560, use Toom-3 for `[2560, 5120)`, and switch to NTT at 5120+. The main production win is avoiding an NTT length-boundary regression near total size 4608.
 
-Toom-3 is kept callable for cross-checking in `tests/mult_correctness.cpp` and as a reference implementation. See [Bodrato 2007](https://www.bodrato.it/papers/#WAIFI2007) for the optimal interpolation sequence (the implementation here uses the textbook +2 evaluation point rather than Bodrato's −2 variant, deliberately, since 2026's correctness rewrite chose clarity over the 1-mul-cheaper interpolation).
+Toom-3 is also kept callable directly for cross-checking in `tests/mult_correctness.cpp`. See [Bodrato 2007](https://www.bodrato.it/papers/#WAIFI2007) for the optimal interpolation sequence (the implementation here uses the textbook +2 evaluation point rather than Bodrato's −2 variant, deliberately, since 2026's correctness rewrite chose clarity over the 1-mul-cheaper interpolation).
 
 ### Toom-5
 
@@ -240,7 +254,7 @@ Benchmarks show no useful production band. Below the Toom-5 threshold the functi
 
 **Location:** `algorithms/multiplication/NTTMultiplication.h`.
 
-**Complexity:** O(n log n) limb multiplies. Constant factor is large (three FFT-sized transforms plus pointwise multiply), so the dispatcher keeps Karatsuba until the equal-size product reaches roughly 4096 total limbs.
+**Complexity:** O(n log n) limb multiplies. Constant factor is large (transform setup, coefficient packing, transforms, pointwise multiply, and final carry propagation), so the dispatcher keeps Karatsuba/Toom-3 until the product reaches roughly 5120 total limbs.
 
 **Setup.** Multiplication via NTT computes a cyclic convolution of the digit sequences in a finite field, then propagates carries. The choice of field is critical: it must support a root of unity of sufficient order, fast reduction, and a coefficient capacity large enough that the unreduced convolution sum cannot overflow the field.
 
@@ -341,8 +355,8 @@ References for further reading: [Cooley-Tukey FFT algorithm (Wikipedia)](https:/
 | size | algorithm | speedup vs `Multiply(a, a)` |
 |---|---|---|
 | ≤ 48 limbs | `ClassicSquare` | ~1.5× |
-| 48 – 512 limbs | `KaratsubaSquare` (pointer-based) | 1.38–1.59× |
-| ≥ 512 limbs | `NTTSquare` (single forward FFT) | 1.4–1.45× |
+| 48 – 2048 limbs under LIMB_64 | `KaratsubaSquare` (pointer-based) | 1.38–1.59× |
+| ≥ 2048 limbs under LIMB_64 | `NTTSquare` (single forward FFT) | 1.4–1.45× |
 
 **Classic schoolbook square.** Half the partial products of full multiplication:
 
@@ -379,54 +393,55 @@ Pointer-based recursion with shared workspace (≈ 8n limbs) mirrors `KaratsubaM
 Benchmark harness: `tests/performance/bench_vs_gmp.cpp`. Build:
 
 ```
-c++ -std=c++20 -O3 -march=native -I/opt/homebrew/include -L/opt/homebrew/lib \
-    tests/performance/bench_vs_gmp.cpp -o bench_vs_gmp -lgmp
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j8 --target bench_vs_gmp
+./build/bench_vs_gmp
 ```
 
-Hardware: Apple M1 Max. Reference library: GMP 6.3.0 (Homebrew). Reported numbers are `min` over 5 runs to suppress scheduling jitter. Build config: full defaults (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool).
+Hardware: Apple M1 Max. Reference library: GMP 6.3.0 (Homebrew). Refreshed 2026-05-27. Build config: full defaults (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool).
 
 | operation | size | BigMath ms | GMP ms | BM / GMP |
 |---|---|---:|---:|---:|
-| `mul` | 1 000 × 1 000 digits | 0.002 | 0.001 | 2.24 × |
-| `mul` | 5 000 × 5 000 | 0.036 | 0.014 | 2.64 × |
-| `mul` | 10 000 × 10 000 | 0.197 | 0.059 | 3.32 × |
-| `mul` | 50 000 × 50 000 | 0.600 | 0.362 | 1.66 × |
-| `mul` | 100 000 × 100 000 | 1.198 | 0.761 | **1.57 ×** |
-| `mul` | 500 000 × 500 000 | 5.014 | 4.204 | **1.19 ×** |
-| `mul` | 1 000 000 × 1 000 000 | 9.839 | 8.892 | **1.11 ×** |
-| `mul` | **2 000 000 × 2 000 000** | **19.843** | **20.823** | **0.95 ×** ← BigMath faster |
-| `mul` | **5 000 000 × 5 000 000** | **45.811** | **63.960** | **0.72 ×** ← BigMath faster |
-| `mul` | **10 000 000 × 10 000 000** | **103.018** | **213.191** | **0.48 ×** ← BigMath 2.08× faster |
-| `mul` | **20 000 000 × 20 000 000** | **276.471** | **280.078** | **0.99 ×** ← parity |
-| `mul` | 50 000 000 × 50 000 000 | 1 228.7 | 661.0 | 1.86 × ← GMP SSA still ahead |
-| `mul` | 100 000 000 × 100 000 000 | 2 589.6 | 1 389.3 | 1.86 × |
-| `mul` (skewed) | 100 000 × 10 000 | 0.543 | 0.303 | 1.79 × |
-| `mul` (skewed) | **500 000 × 50 000** | **2.010** | **2.074** | **0.97 ×** ← BigMath faster |
-| `mul` (skewed) | **1 000 000 × 100 000** | **4.269** | **4.475** | **0.95 ×** ← BigMath faster |
-| `mul` (skewed) | **2 000 000 × 200 000** | **8.512** | **9.397** | **0.91 ×** ← BigMath faster |
-| `mul` (skewed) | 5 000 000 × 500 000 | 37.312 | 30.617 | 1.22 × |
-| `mul` (skewed) | 10 000 000 × 1 000 000 | 84.151 | 70.710 | 1.19 × |
-| `mul` (skewed) | 20 000 000 × 2 000 000 | 229.908 | 158.847 | 1.45 × |
-| `mul` (skewed) | **50 000 000 × 5 000 000** | **625.327** | **665.872** | **0.94 ×** ← BigMath faster |
-| `mul` (skewed) | 100 000 000 × 10 000 000 | 1 279.684 | 1 007.119 | 1.27 × |
+| `mul` | 1 000 × 1 000 digits | 0.002 | 0.001 | 1.92 × |
+| `mul` | 5 000 × 5 000 | 0.030 | 0.011 | 2.66 × |
+| `mul` | 10 000 × 10 000 | 0.283 | 0.086 | 3.31 × |
+| `mul` | 50 000 × 50 000 | 1.022 | 0.578 | 1.77 × |
+| `mul` | 100 000 × 100 000 | 1.352 | 0.784 | **1.72 ×** |
+| `mul` | 500 000 × 500 000 | 5.218 | 4.217 | **1.24 ×** |
+| `mul` | 1 000 000 × 1 000 000 | 10.499 | 9.061 | **1.16 ×** |
+| `mul` | **2 000 000 × 2 000 000** | **21.893** | **20.555** | **1.07 ×** ← near parity |
+| `mul` | **5 000 000 × 5 000 000** | **46.470** | **63.450** | **0.73 ×** ← BigMath faster |
+| `mul` | **10 000 000 × 10 000 000** | **105.381** | **211.825** | **0.50 ×** ← BigMath 2.01× faster |
+| `mul` | **20 000 000 × 20 000 000** | **278.550** | **277.598** | **1.00 ×** ← parity |
+| `mul` | 50 000 000 × 50 000 000 | 1 231.5 | 660.4 | 1.86 × ← GMP SSA still ahead |
+| `mul` | 100 000 000 × 100 000 000 | 2 831.5 | 1 391.0 | 2.04 × |
+| `mul` (skewed) | 100 000 × 10 000 | 0.540 | 0.306 | 1.77 × |
+| `mul` (skewed) | **500 000 × 50 000** | **2.133** | **2.132** | **1.00 ×** ← parity |
+| `mul` (skewed) | **1 000 000 × 100 000** | **4.470** | **4.786** | **0.93 ×** ← BigMath faster |
+| `mul` (skewed) | **2 000 000 × 200 000** | **9.432** | **9.454** | **1.00 ×** ← parity |
+| `mul` (skewed) | 5 000 000 × 500 000 | 38.982 | 30.610 | 1.27 × |
+| `mul` (skewed) | 10 000 000 × 1 000 000 | 88.435 | 70.513 | 1.25 × |
+| `mul` (skewed) | 20 000 000 × 2 000 000 | 259.758 | 161.113 | 1.61 × |
+| `mul` (skewed) | **50 000 000 × 5 000 000** | **666.753** | **666.405** | **1.00 ×** ← parity |
+| `mul` (skewed) | 100 000 000 × 10 000 000 | 1 154.909 | 1 003.655 | 1.15 × |
 
 (Division, parse, and ToString benchmarks are in the same harness but covered in other documents.)
 
 **Reading these numbers.**
 
-- **Balanced multiplication wins from 2M through 20M digits.** Radix-4 + radix-8 fused butterflies (PRs #59, #60) widened the prior 5M-10M sweet spot to 2M-20M and pushed the peak win to **2.08× faster at 10M** (103 ms vs 213 ms). 20M is now parity (0.99×, was 1.61× loss).
-- **GMP recovers at ≥50M via Schönhage-Strassen, but the gap narrowed again.** 1.86× at 50M and 100M after the 2026-05-27 MFA / Bailey-6-step landing (was 2.05× / 2.22× immediately post-radix-8). Cumulative trajectory at 50M: 3.58× → 2.05× (radix-4+8) → 1.86× (MFA). BigMath's CRT NTT inner loop is still scalar 32-bit modular ops; the remaining gap is closeable by NEON SIMD on the CRT prime arithmetic (see [Future opportunities](#future-opportunities)).
-- **Skewed mults: four sweet spots win** (500k×50k, 1M×100k, 2M×200k, 50M×5M at 0.91-0.97×). Past 100M×10M (1.27×) GMP's SSA recovers.
+- **Balanced multiplication wins from 5M through 10M digits and is near parity at 20M.** Radix-4 + radix-8 fused butterflies (PRs #59, #60) widened the prior sweet spot. Raising the MFA gate to `2^24` improved the 10M balanced row by about 8% (114 ms → 105 ms) by avoiding early MFA.
+- **GMP recovers at ≥50M via Schönhage-Strassen.** The 2026-05-27 retuned run measured 1.86× at 50M and 2.04× at 100M. MFA remains valuable at very large limb counts, but the 100M row is noisy. BigMath's CRT NTT inner loop is still scalar 32-bit modular ops; the remaining high-risk/high-reward lever is a real CRT butterfly SIMD/assembly path (see [Future opportunities](#future-opportunities)).
+- **Skewed mults:** 500k×50k, 2M×200k, and 50M×5M are parity; 1M×100k is a BigMath win. Raising the MFA gate gives up the earlier 50M×5M early-MFA win but improves the balanced sweet spot.
 
 A historical view of the same benchmark (early 2026 vs current default stack):
 
 | op | early 2026 | CRT + threads | + radix-4+8 (now) | total improvement |
 |---|---|---|---|---|
-| mul 100 000 × 100 000 | 6.2 × | 1.74 × | **1.57 ×** | **4.0 ×** |
-| mul 1 000 000 × 1 000 000 | 4.2 × | 1.41 × | **1.11 ×** | **3.8 ×** |
-| mul 5 000 000 × 5 000 000 | ~3 × | 0.92 × | **0.72 ×** | **4.2 ×** |
-| mul 10 000 000 × 10 000 000 | ~3 × | 0.73 × | **0.48 ×** | **6.3 ×** |
-| mul 20 000 000 × 20 000 000 | — | 1.61 × | **0.99 ×** | **1.6 ×** (vs CRT) |
+| mul 100 000 × 100 000 | 6.2 × | 1.74 × | **1.72 ×** | **3.6 ×** |
+| mul 1 000 000 × 1 000 000 | 4.2 × | 1.41 × | **1.16 ×** | **3.6 ×** |
+| mul 5 000 000 × 5 000 000 | ~3 × | 0.92 × | **0.73 ×** | **4.1 ×** |
+| mul 10 000 000 × 10 000 000 | ~3 × | 0.73 × | **0.50 ×** | **6.0 ×** |
+| mul 20 000 000 × 20 000 000 | — | 1.61 × | **1.00 ×** | **1.6 ×** (vs CRT) |
 | mul 50 000 000 × 50 000 000 | — | 3.58 × | **1.86 ×** | **1.9 ×** (vs CRT) |
 | mul (skewed) 1M / 100k | 3.5 × | 1.02 × | **0.95 ×** | **3.7 ×** |
 
@@ -532,7 +547,7 @@ The threaded gain is smaller because normal CRT multiplication already runs the 
 
 ### Matrix Fourier Algorithm (MFA) / Bailey 6-step for CRT NTT (2026-05-27)
 
-Recursive 2D layout for each per-prime NTT once length exceeds `BIGMATH_NTT_MFA_THRESHOLD` (default 2^21 ≈ 2M coefficients). For length `N = N1·N2`:
+Recursive 2D layout for each per-prime NTT once length reaches `BIGMATH_NTT_MFA_THRESHOLD` (default 2^24 coefficients). The threshold is in NTT coefficients, not source limbs. For Base2_64 balanced multiplication with `L` limbs per operand, the CRT coefficient count is roughly `4L`, so the current gate starts around 2M limbs per operand (≈40M decimal digits). For length `N = N1·N2`:
 
 1. Transpose `N2×N1 → N1×N2`
 2. `N1` forward sub-FFTs of length `N2` along rows
@@ -550,18 +565,21 @@ The landed design separates the two:
 - The six forward transforms (and three inverses) dispatch as `ParallelDo(6)` / `ParallelDo(3)` with `parallel=false` passed to `ForwardMFA` / `InverseMFA` to suppress *internal* `ParallelFor` calls. Each task is one full per-prime MFA running serially in its own thread.
 - Six per-task scratch buffers are allocated on the caller stack (NOT `thread_local`) before dispatch so the capturing pointers cross threads safely.
 
-`mul_xl_bench` on M1 Max, Base2_64, CRT default, threaded:
+`mul_xl_bench` on M1 Max, Base2_64, CRT default, threaded, refreshed after the `2^24` threshold retune:
 
-| limbs | MFA off (ms) | MFA on (ms) | speedup |
-|------:|-------------:|------------:|--------:|
-|    1M |          266 |         247 |  1.07×  |
-|    2M |          710 |         596 |  1.19×  |
-|    5M |         3217 |        2670 |  1.20×  |
-|   10M |         6980 |        5524 |  1.26×  |
+| limbs per operand | transform length | active path | ms |
+|------:|------:|---|---:|
+| 200k | 2^20 | non-MFA | 39.942 |
+| 300k | 2^21 | non-MFA | 90.660 |
+| 500k | 2^21 | non-MFA | 92.290 |
+| 1M | 2^22 | non-MFA | 255.832 |
+| 2M | 2^23 | non-MFA | 704.094 |
+| **3M** | **2^24** | **MFA** | **1 269.304** |
+| **5M** | **2^25** | **MFA** | **2 620.899** |
 
-Translated to BM/GMP at the target regime: 50M went 2.05× → 1.86×, 100M went 2.22× → 1.86×. MFA narrowed the gap but did not close it; the remaining lever is NEON on the CRT inner loop ([Future opportunities](#future-opportunities)).
+This retune keeps the radix-8 CRT path through the measured regression band and enables MFA at `2^24+`, where the earlier on/off sweep showed wins. The main tradeoff is skewed `50M×5M`: it no longer trips MFA and moves from a clear BigMath win to parity, while balanced `10M×10M` improves by about 8%.
 
-Gate via `BIGMATH_NTT_MFA` (default 1) and `BIGMATH_NTT_MFA_THRESHOLD` (default 2^21). Leaf size `BIGMATH_NTT_MFA_LEAF` (default 2^13) controls the recursion stopping point — sub-FFTs at or below the leaf size hit the existing radix-4/8 chain via `ForwardPtr`.
+Gate via `BIGMATH_NTT_MFA` (default 1) and `BIGMATH_NTT_MFA_THRESHOLD` (default 2^24). Leaf size `BIGMATH_NTT_MFA_LEAF` (default 2^13) controls the recursion stopping point — sub-FFTs at or below the leaf size hit the existing radix-4/8 chain via `ForwardPtr`.
 
 ### Karatsuba pointer-based workspace
 
@@ -599,11 +617,11 @@ The profile that motivated this change showed `MultiplyClassicPtr` at 39% of `To
 
 `ClassicSquare`, `KaratsubaSquare` (pointer-based with 8n workspace), `NTTSquare` (single forward FFT instead of two), and `Square` dispatcher. Wired into `Pow10` even-d branch. Microbenchmark shows uniform 1.4–1.6× over `Multiply(a, a)` across all sizes. Real-world steady-state benefit on `Pow10`-driven ToString/Parse is ~2–3% (limited by `Pow10`'s thread-local cache being warm after the first iteration).
 
-### Toom-Cook 3 rewrite (correct but not dispatched)
+### Toom-Cook 3 rewrite and dispatch band
 
 Pre-2026 the `ToomCookMultiplication` class had an early `return KaratsubaMultiplication::Multiply(...)` in its recursive entry, making the Toom-3 evaluation/interpolation code unreachable. The dispatcher cross-checked against this dead implementation in `mult_correctness.cpp` and saw apparent correctness, but Toom-3 had never actually run.
 
-The 2026-05 rewrite implements correct Toom-3 with eval points {0, 1, −1, 2, ∞}, signed interpolation, and recursion bottoming to Karatsuba below `BIGMATH_TOOM3_THRESHOLD = 256`. Validated against `mult_correctness`. Not in dispatch — see [explored but rejected](#explored-but-rejected).
+The 2026-05 rewrite implements correct Toom-3 with eval points {0, 1, −1, 2, ∞}, signed interpolation, and recursion bottoming to Karatsuba below `BIGMATH_TOOM3_THRESHOLD = 256`. Validated against `mult_correctness`. A later focused dispatch scan found a narrow production band, so top-level `Multiply` now uses Toom-3 for total limb size `[2560, 5120)`.
 
 ### 64-bit limb refactor (2026-05, PRs #18–#30)
 
@@ -658,9 +676,13 @@ Ranked by expected ROI per unit of effort.
 
 The NTT butterfly is 95–97% of cost for large mults (confirmed via profile at 100M digits: 59.5% in 6 forwards + 36.6% in 3 inverses = 96.1% NTT). Radix-4 + radix-8 fused butterflies (PRs #59, #60) extracted **~1.6× wall-clock** at ≥2M limbs without leaving C++ — cutting memory-pass count from log₂(n) to log₈(n). The remaining gap is per-butterfly throughput. Replacing the inner loop with hand-tuned ARM64 assembly using paired loads, optimal `MUL`/`UMULH` scheduling, and explicit `CSEL` for the branchless reduce could plausibly recover further at large sizes. Cost: significant — needs a per-platform asm file with care taken for register allocation, plus a fallback C++ path for non-ARM64 targets. Maintenance burden high.
 
-### NEON SIMD on CRT primes (re-opened)
+### CRT butterfly SIMD or assembly
 
-CRT NTT (default ≥5000 limbs sum) operates on 30-bit primes with 32-bit coefficients — these fit `uint32x4_t` lanes naturally, sidestepping the 64×64→128 issue that blocked NEON for the Goldilocks butterfly. Theoretical 4× throughput per butterfly. Earlier rejection was Goldilocks-specific; the CRT path makes this a fresh opportunity. Profile evidence (see `memory: ssa-rejection-2026-05-26`) ranks this as the highest-ROI next lever for closing the ≥50M gap to GMP. Cost: NEON intrinsics path + scalar fallback, ~300-500 LOC.
+CRT NTT (default ≥5000 limbs sum) operates on 30-bit primes with 32-bit coefficients — these fit `uint32x4_t` lanes naturally, sidestepping the 64×64→128 issue that blocked NEON for the Goldilocks butterfly. The useful target is the **butterfly inner loop**, not pointwise multiplication or inverse scaling; those are too small a fraction of end-to-end time to justify a platform path. Cost: NEON intrinsics path + scalar fallback, ~300-500 LOC plus careful benchmarking.
+
+### Revisit MFA shape-aware gating
+
+The `2^24` threshold fixes balanced multiplication's early-MFA regression, but skewed `50M×5M` now falls back to the non-MFA path and lands at parity instead of the earlier early-MFA win. A future improvement would make the gate shape-aware rather than using only transform length, but that needs more shape data to avoid reintroducing the balanced regression.
 
 ### MFA recursion below the leaf
 
@@ -676,7 +698,7 @@ Each rejection has a concrete reason. Don't re-propose without new evidence over
 
 [Schönhage–Strassen](https://en.wikipedia.org/wiki/Sch%C3%B6nhage%E2%80%93Strassen_algorithm) multiplies in O(n · log n · log log n) using nested FFTs over a Fermat number ring `Z / (2^N + 1) Z`. The `log log n` factor is asymptotically better than NTT's effective `log n`, but the constant factors are dominated by the inner mod-2^N+1 arithmetic.
 
-**Updated assessment after radix-4+8 and MFA landed.** GMP's lead at ≥50M digits has now been roughly halved twice (3.58× → 2.05× via radix-4+8, then → 1.86× via MFA at 50M; analogous trajectory at 100M). SSA remains a structural lever GMP uses there. A profile probe + parameter sweep for single-level SSA at 100M digits had found:
+**Updated assessment after radix-4+8 and MFA landed.** GMP's lead at ≥50M digits remains structural. The latest local rerun measured 1.86× at 50M and 2.04× at 100M after the MFA threshold retune. SSA remains the algorithmic lever GMP uses there. A profile probe + parameter sweep for single-level SSA at 100M digits had found:
 
 - Profile: 95.5% of CRT NTT time in forwards + inverses; SSA targets exactly this.
 - Parameter sweep: single-level SSA has **no winning band** at our sizes. For M = 2¹⁶ chunks, pointwise sub-mul cost dominates (~32 sec). For M = 2²⁰, per-element N grows so large the FFT cost explodes. Sweet spot only exists with recursive sub-multiplications + MFA layout (GMP's approach).
@@ -712,20 +734,19 @@ Building the bit-reversed index map once and reusing it. Implemented during expl
 
 [Montgomery multiplication](https://en.wikipedia.org/wiki/Montgomery_modular_multiplication) avoids division by replacing it with shifts and a precomputed inverse. For general primes this is a significant win. For Goldilocks specifically, the closed-form `Reduce` is already minimal (subtraction, shift, conditional add), and Montgomery would add a forward/backward transform per multiplication with no win.
 
-### Toom-Cook 3 in dispatch (rewritten, then declined)
+### Toom-Cook 3 dispatch band
 
-The 2026-05 rewrite verified Toom-3 is correct. The current portable C++ dispatch sweep across the Karatsuba/NTT boundary is:
+The 2026-05 rewrite verified Toom-3 is correct. A later focused band scan found a narrow useful dispatch band around the Karatsuba/NTT boundary:
 
-| limbs | Karatsuba ms | NTT ms | winner |
-|---|---:|---:|---|
-| 128 | 0.0039 | 0.0161 | K |
-| 256 | 0.0133 | 0.0351 | K |
-| 512 | 0.0418 | 0.0762 | K |
-| 1 024 | 0.1258 | 0.1933 | K |
-| 2 048 | 0.4596 | 0.4174 | N |
-| 4 096 | 1.3077 | 0.8010 | N |
+| total limbs | per-operand | Karatsuba ms | Toom-3 ms | NTT ms | winner |
+|---:|---:|---:|---:|---:|---|
+| 2 560 | 1 280 | 0.42 | 0.41 | 0.77 | Toom-3 / tie |
+| 3 584 | 1 792 | 0.64 | 0.60 | 0.78 | Toom-3 |
+| 4 096 | 2 048 | 0.83 | 0.75 | 0.78 | Toom-3 |
+| 4 608 | 2 304 | 1.06 | 1.10 | 1.65 | Karatsuba / Toom-3 |
+| 5 120 | 2 560 | 1.31 | 1.24 | 0.59 | NTT |
 
-Toom-3 has no operand-size band where it has proven useful in production dispatch. Adding it to dispatch caused a 3.3× regression on `mul 5k × 5k` in earlier trials. Kept as a cross-check reference, not as a production path.
+The default dispatcher now uses Toom-3 for total limb size `[2560, 5120)` and raises the NTT threshold to 5120. Earlier broad Toom-3 dispatch attempts regressed small decimal benchmarks; the current band is intentionally narrow.
 
 ### Toom-5 in dispatch
 
@@ -743,7 +764,7 @@ The apparent wins below 512 limbs are not real Toom-5 wins because `Toom5Multipl
 
 ### Lowering `NTT_MULTIPLICATION_THRESHOLD` below 4096
 
-Direct algorithm microbenchmarks can make NTT look attractive too early. End-to-end dispatcher sweeps tell a different story: NTT-via-dispatcher below total size ~4096 is slower than Karatsuba-via-dispatcher because the path has setup overhead (coefficient packing, twiddle cache lookup, and buffer preparation) that algorithm-direct benchmarks do not fully capture. The 2026-05 portable C++ NTT plan/cache/finalization pass retuned `NTT_THRESHOLD` to 4096 total limbs. Lesson: don't tune dispatch from microbenchmarks alone.
+Direct algorithm microbenchmarks can make NTT look attractive too early. End-to-end dispatcher sweeps tell a different story: NTT-via-dispatcher below the measured crossover is slower because the path has setup overhead (coefficient packing, twiddle cache lookup, and buffer preparation) that algorithm-direct benchmarks do not fully capture. The current dispatcher keeps NTT at total size 5120+, after the Toom-3 band absorbed the old 4096-5120 boundary regression. Lesson: don't tune dispatch from microbenchmarks alone.
 
 ### Blockwise skew multiplication in dispatch
 
@@ -799,7 +820,7 @@ Implemented exactly (two-step recursive decomposition with carry tracking) on br
 - `biginteger/algorithms/Multiplication.h` — top-level dispatcher.
 - `biginteger/algorithms/multiplication/ClassicMultiplication.h` — schoolbook.
 - `biginteger/algorithms/multiplication/KaratsubaMultiplication.h` — Karatsuba with 64-bit hybrid leaf.
-- `biginteger/algorithms/multiplication/ToomCookMultiplication.h` — Toom-3 (not in dispatch).
+- `biginteger/algorithms/multiplication/ToomCookMultiplication.h` — Toom-3 dispatch band.
 - `biginteger/algorithms/multiplication/NTTMultiplication.h` — Goldilocks NTT.
 - `biginteger/algorithms/Squaring.h` — square dispatcher.
 - `biginteger/algorithms/multiplication/{Classic,Karatsuba,NTT}Square.h` — square implementations.

--- a/docs/STRING_CONVERSION.md
+++ b/docs/STRING_CONVERSION.md
@@ -369,12 +369,16 @@ flowchart TD
     P[Parse&#40;num&#41;] --> P2{length &gt; 8192?}
     P2 -- no --> PL[ParseUnsignedLinear]
     P2 -- yes --> PD[ParseUnsignedDivideConquer]
+    PD --> PP[Pow10 cache<br/>+ Multiply combine]
     PD -. recurses to .-> PL
 
-    T[ToString&#40;bigInt&#41;] --> T2{est decimal length &lt; 2048?}
+    T[ToString&#40;bigInt&#41;] --> TE[EstimateDecimalDigits]
+    TE --> T2{est decimal length &lt; 2048?}
     T2 -- yes --> TL[ToStringLinearAppend]
-    T2 -- no --> TC[BuildDecimalDcChain<br/>+ ToStringDivConquer]
-    TC -. leaves to .-> TL
+    T2 -- no --> TC[thread-local DecimalDcChain<br/>Pow10 + Newton Divider]
+    TC --> TD[ToStringDivConquer]
+    TD --> NV[NewtonDivision::Divider<br/>DivideAndRemainderInto]
+    TD -. leaves to .-> TL
 ```
 
 Thresholds (overridable via `-D...`):
@@ -393,61 +397,62 @@ The asymmetry between the parser and formatter thresholds reflects that the form
 Benchmark harness: `tests/performance/bench_vs_gmp.cpp`. Build:
 
 ```
-c++ -std=c++20 -O3 -march=native -I/opt/homebrew/include -L/opt/homebrew/lib \
-    tests/performance/bench_vs_gmp.cpp -o bench_vs_gmp -lgmp
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j8 --target bench_vs_gmp
+./build/bench_vs_gmp
 ```
 
-Hardware: Apple M1 Max. Reference: GMP 6.3.0 (Homebrew). Full default stack (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool). Min over 5 runs.
+Hardware: Apple M1 Max. Reference: GMP 6.3.0 (Homebrew). Full default stack (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool). Refreshed 2026-05-27.
 
 ### Parse
 
 | size | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| 1 000 digits | 0.003 | 0.002 | 1.58 × |
-| 10 000 digits | 0.112 | 0.039 | 2.89 × |
-| 50 000 digits | 1.343 | 0.391 | 3.44 × |
-| 100 000 digits | 3.190 | 1.059 | **3.01 ×** |
-| 500 000 digits | 21.260 | 8.905 | **2.39 ×** |
-| 1 000 000 digits | 46.496 | 20.496 | **2.27 ×** |
-| 2 000 000 digits | 101.795 | 48.581 | **2.10 ×** |
-| 5 000 000 digits | 264.905 | 147.716 | **1.79 ×** |
-| 10 000 000 digits | 570.287 | 343.762 | **1.66 ×** |
-| 20 000 000 digits | 1 242.885 | 800.282 | **1.55 ×** |
-| 50 000 000 digits | 4 665.032 | 2 674.914 | **1.74 ×** |
+| 1 000 digits | 0.002 | 0.002 | 1.55 × |
+| 10 000 digits | 0.112 | 0.038 | 2.97 × |
+| 50 000 digits | 1.350 | 0.389 | 3.47 × |
+| 100 000 digits | 3.287 | 1.042 | **3.15 ×** |
+| 500 000 digits | 22.220 | 8.799 | **2.53 ×** |
+| 1 000 000 digits | 48.652 | 20.301 | **2.40 ×** |
+| 2 000 000 digits | 106.413 | 46.878 | **2.27 ×** |
+| 5 000 000 digits | 266.531 | 148.477 | **1.80 ×** |
+| 10 000 000 digits | 577.357 | 340.170 | **1.70 ×** |
+| 20 000 000 digits | 1 252.454 | 803.190 | **1.56 ×** |
+| 50 000 000 digits | 5 212.270 | 2 629.889 | **1.98 ×** |
 
-Parse's BM/GMP ratio narrows monotonically with size — **at 20M digits the gap is 1.55×** vs 3.0× at 100k. The asymptotic D&C parser inherits BigMath's NTT lead, which now crosses GMP at 2M digits (see [MULTIPLICATION.md](MULTIPLICATION.md#benchmark-results-vs-gmp)). The 50M tick widens slightly to 1.74× as GMP's SSA recovers at sizes past BigMath's NTT sweet spot.
+Parse's BM/GMP ratio narrows with size — **at 20M digits the gap is 1.56×** vs 3.2× at 100k. The asymptotic D&C parser inherits BigMath's NTT lead, which crosses GMP in the 5M-20M balanced multiplication band (see [MULTIPLICATION.md](MULTIPLICATION.md#benchmark-results-vs-gmp)). The 50M tick widens to 1.98× as GMP's SSA recovers.
 
 ### ToString
 
 | size | BigMath ms | GMP ms | BM / GMP |
 |---|---:|---:|---:|
-| 1 000 digits | 0.006 | 0.004 | 1.74 × |
-| 10 000 digits | 0.269 | 0.077 | 3.50 × |
-| 50 000 digits | 3.833 | 0.848 | 4.52 × |
-| 100 000 digits | 19.453 | 2.360 | **8.24 ×** |
-| 200 000 digits | 39.651 | 6.309 | 6.29 × |
-| 500 000 digits | 109.246 | 20.341 | 5.37 × |
-| 1 000 000 digits | 227.797 | 48.731 | **4.67 ×** |
-| 2 000 000 digits | 479.826 | 118.745 | **4.04 ×** |
-| 5 000 000 digits | 1 074.873 | 378.272 | 2.84 × |
-| 10 000 000 digits | 2 311.310 | 918.750 | 2.52 × |
-| 20 000 000 digits | 5 237.676 | 2 115.032 | **2.48 ×** |
+| 1 000 digits | 0.006 | 0.003 | 1.83 × |
+| 10 000 digits | 0.268 | 0.078 | 3.46 × |
+| 50 000 digits | 4.001 | 0.844 | 4.74 × |
+| 100 000 digits | 19.484 | 2.334 | **8.35 ×** |
+| 200 000 digits | 39.870 | 6.043 | 6.60 × |
+| 500 000 digits | 107.239 | 20.426 | 5.25 × |
+| 1 000 000 digits | 224.120 | 49.792 | **4.50 ×** |
+| 2 000 000 digits | 477.132 | 120.276 | **3.97 ×** |
+| 5 000 000 digits | 1 100.592 | 380.412 | 2.89 × |
+| 10 000 000 digits | 2 414.564 | 900.384 | 2.68 × |
+| 20 000 000 digits | 5 436.545 | 2 115.685 | **2.57 ×** |
 
-ToString's BM/GMP ratio narrows from 8.2× at 100k to **2.48× at 20M**. Two effects compound: (1) BigMath's D&C ToString is `O(M(L) · log L)` while GMP's `mpz_get_str` is `O(n²)` by default, so the asymptotic line crosses around 100k where ratios start dropping; (2) at the larger sizes BigMath's NTT-based mult inside Newton's reciprocal chain overtakes GMP's basecase. The radix-4+8 fused butterflies (PRs #59, #60) accelerated this convergence — 10M ToString improved 2.84× → 2.52× relative to GMP.
+ToString's BM/GMP ratio narrows from 8.4× at 100k to **2.57× at 20M**. Two effects compound: (1) BigMath's D&C ToString is `O(M(L) · log L)` while GMP's `mpz_get_str` uses highly tuned low-level code; (2) at larger sizes BigMath's NTT-based multiplication inside Newton's reciprocal chain enters the same 5M-20M sweet spot as multiplication. Raising the MFA gate to `2^24` is mostly neutral for ToString in this measured range.
 
 **Historical view** showing the cumulative wins across the 2026-05 optimization pass:
 
 | size | early 2026 | CRT + threads | + radix-4+8 (now) | total |
 |---|---|---|---|---|
-| Parse 100 000 | 7.1 × | 3.10 × | **3.01 ×** | **2.4 ×** |
-| Parse 1 000 000 | 6.0 × | 2.33 × | **2.27 ×** | **2.6 ×** |
-| Parse 10 000 000 | — | 1.73 × | **1.66 ×** | — |
-| ToString 10 000 | 47 × | 11.2 × | **3.50 ×** | **13.4 ×** |
-| ToString 100 000 | **160 ×** | 9.57 × | **8.24 ×** | **19.4 ×** |
-| ToString 1 000 000 | — | 4.92 × | **4.67 ×** | — |
-| ToString 10 000 000 | — | 2.84 × | **2.52 ×** | — |
+| Parse 100 000 | 7.1 × | 3.10 × | **3.15 ×** | **2.3 ×** |
+| Parse 1 000 000 | 6.0 × | 2.33 × | **2.40 ×** | **2.5 ×** |
+| Parse 10 000 000 | — | 1.73 × | **1.70 ×** | — |
+| ToString 10 000 | 47 × | 11.2 × | **3.46 ×** | **13.6 ×** |
+| ToString 100 000 | **160 ×** | 9.57 × | **8.35 ×** | **19.2 ×** |
+| ToString 1 000 000 | — | 4.92 × | **4.50 ×** | — |
+| ToString 10 000 000 | — | 2.84 × | **2.68 ×** | — |
 
-The 100k ToString case went from 160× to 8.24× over the session — **19.4× cumulative improvement**. Wins came from:
+The 100k ToString case went from 160× to 8.35× over the session — **19.2× cumulative improvement**. Wins came from:
 
 1. D&C ToString with Newton-Divider chain (8.4× at 100k).
 2. 64-bit hybrid Karatsuba leaf (improved every `Multiply` and `Divide` call in the chain).
@@ -522,11 +527,14 @@ Focused warm benchmark on this repository's `tests/performance/tostring_bench.cp
 
 | size | baseline ms | cached-chain stack ms | speedup |
 |---|---:|---:|---:|
-| 1 000 | 0.0079 | 0.0063-0.0066 | 1.2-1.3× |
-| 10 000 | 1.1224 | 0.2793-0.2924 | 3.8-4.0× |
-| 50 000 | 9.4674 | 3.95-4.05 | 2.3-2.4× |
-| 100 000 | 19.8435 | 8.94-9.05 | 2.2× |
-| 200 000 | 41.1607 | 20.28-20.65 | 2.0× |
+| 1 000 | 0.0079 | 0.0062 | 1.27× |
+| 10 000 | 1.1224 | 0.5097 | 2.20× |
+| 50 000 | 9.4674 | 4.4633 | 2.12× |
+| 100 000 | 19.8435 | 9.4409 | 2.10× |
+| 200 000 | 41.1607 | 20.5682 | 2.00× |
+| 500 000 | — | 61.1404 | — |
+| 1 000 000 | — | 135.8015 | — |
+| 2 000 000 | — | 299.5458 | — |
 
 The cache is `thread_local` like `Pow10`; entries grow monotonically for the lifetime of the thread.
 
@@ -575,6 +583,10 @@ Pre-implementation estimate in this doc was "1–2% on ToString 100k" (capped by
 
 Ranked by expected ROI per unit of effort.
 
+### MFA threshold effects
+
+Large `ToString` calls spend most of their time in Newton division, and Newton's hot path is multiplication. The MFA gate was raised from `2^21` to `2^24` transform coefficients after a focused on/off sweep showed regressions below `2^24`. The retune is mostly neutral for ToString through 20M digits; any further string-conversion gain should come from multiplication improvements or deeper Newton scratch reuse rather than formatter orchestration.
+
 ### `BIGMATH_TOSTR_DC_THRESHOLD` tuning (re-confirmed 2026-05-26)
 
 The threshold defaults to 2 048. **Re-swept 2026-05-26** after the GM div2by1 in `ClassicDivision` (PR #43) made the linear leaf 2.13× faster at 1k digits — that shift could have moved the linear→D&C crossover. It didn't. 2 048 remains the right compromise.
@@ -597,20 +609,9 @@ Best ToString time (ms, min over many iters, M1 Max, full default stack) at each
 
 **Don't tune without re-measuring.** The pre-PR-#43 sweep gave the same answer with different absolute times. If further optimizations land that shift the linear-leaf cost again, re-run the sweep before changing the default.
 
-### Direct in-place D&C formatting (avoid `std::move` chain)
+### True scratch-buffer reuse inside Newton division
 
-`ToStringDivConquer` repeatedly moves `n` into recursive calls. Profile shows ~7.5% of ToString time in orchestration (Compare, std::move, recursive dispatch). Restructuring to operate on a pre-allocated buffer with index ranges (rather than constructing fresh `vector<DataT>` per level) could eliminate most of this. Estimated win: 3–5%. Effort: substantial restructure of `ToStringDivConquer`, moderate risk.
-
-### Full 64-bit limb refactor (large effort, moderate gain)
-
-Discussed in detail in [MULTIPLICATION.md §Future opportunities](MULTIPLICATION.md#future-opportunities). For string conversion specifically, the wins are:
-
-| op | now | est | gain |
-|---|---|---|---|
-| Parse 100 000 | 7.1 × | ~5 × | moderate (linear leaf MultiplyTo + D&C combine mults) |
-| ToString 100 000 | 18 × | ~12–14 × | moderate (linear leaf DivModTo + D&C Newton chain) |
-
-The Newton-Divider chain in the D&C ToString would benefit because Newton's internal scalar arithmetic runs in base 2³² limbs today. At base 2⁶⁴ this scalar work would halve, with corresponding improvement in the D&C ToString overall. Same caveats as elsewhere: NTT-bound multiplications inside the chain wouldn't change.
+The current `NewtonDivision::Divider::DivideAndRemainderInto` boundary API avoids rebuilding the divisor reciprocal, but it still delegates to internals that allocate temporary quotient, remainder, normalization, and multiplication vectors. A deeper scratch-aware Newton path could reduce allocation churn in `ToStringDivConquer`. Expected win is small, probably low single digits, because profiling shows the dominant cost is still NTT multiplication. This is not a first-choice optimization unless allocation profiles show otherwise.
 
 ---
 
@@ -656,7 +657,7 @@ Result (M1 Max, ToString 100k/200k/500k/1M/2M, 3 runs each, min):
 
 Why doc estimate was wrong: `std::move` of a `std::vector` is already an O(1) pointer swap — not an allocation. The "orchestration" bucket in the profile (~7% of ToString) is dominated by `Compare`, `TrimZeros`, and Newton's internal `ShiftLeftBits` during normalize — none of those go away by removing the std::move chain.
 
-The only path to a real win would be a `Divider::DivideAndRemainderInto(a, q_out, r_out)` API that writes directly into caller-provided buffers, eliminating Newton's per-call zero-init of `q` and `rem` vectors. That's ~200 lines touching `NewtonDivision::Divider` (a load-bearing class also used by `BigDecimal` and the Newton dispatch path). Worst case loss: subtle bug in the rewrite for ≤2% projected win. Not worth.
+The boundary `Divider::DivideAndRemainderInto(a, q_out, r_out)` API now exists, but it still delegates to Newton internals that allocate their own temporaries. The missing piece is deeper scratch-aware `DivideChunk` / reciprocal multiplication plumbing. That is a broader division refactor for low-single-digit expected gain, not an orchestration-layer string-formatting change.
 
 Reverted. Don't re-propose at the orchestration layer.
 
@@ -684,7 +685,7 @@ Not pursued because the constant-factor difference between the current implement
 
 ### Pre-allocated thread-local scratch buffers for D&C
 
-Each `ToStringDivConquer` recursion level constructs fresh `vector<DataT>` for `qr.first` and `qr.second`. A thread-local scratch arena could amortize allocations. Estimated win: maybe 3–5% on ToString (caught in the 7.5% orchestration overhead in the profile). Effort: moderate. Not currently prioritized.
+Each `ToStringDivConquer` recursion level constructs fresh `vector<DataT>` for `q` and `r`, but the measured in-place-lite attempt above showed that moving/swapping those vectors is not the bottleneck. A plain thread-local arena at the formatter layer is unlikely to matter. Any real buffer-reuse win has to move down into Newton division's temporary vectors, as noted in [Future opportunities](#future-opportunities).
 
 ### Customized small-int parsing (≤ 18 digits)
 

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -51,11 +51,14 @@
 #define BIGMATH_NTT_MFA_LEAF (1 << 13)
 #endif
 
-// MFA fires when transform length n exceeds this. Default 2^21 = 2,097,152
-// coeffs ≈ 8 MB per-prime buffer — already past L2 at 6-buffer working set.
-// Roughly corresponds to operand sums ≥ 1M Base2_64 limbs (≈ 20 M digits).
+// MFA fires when transform length n reaches this. Default 2^24 = 16,777,216
+// coeffs ≈ 64 MB per-prime buffer. For balanced Base2_64 multiplication this
+// starts around 2M limbs per operand (≈40M decimal digits), because each limb
+// contributes two CRT coefficients and the convolution length is about 4L.
+// Fresh M1 Max measurements showed the previous 2^21 gate was too early: MFA
+// lost through ~2^23 and won around 2^24+ transform lengths.
 #ifndef BIGMATH_NTT_MFA_THRESHOLD
-#define BIGMATH_NTT_MFA_THRESHOLD (1 << 21)
+#define BIGMATH_NTT_MFA_THRESHOLD (1 << 24)
 #endif
 
 #ifndef NTT_MULTIPLICATION_CRT


### PR DESCRIPTION
## Summary
- raise the CRT MFA threshold from 2^21 to 2^24 transform coefficients
- refresh BENCHMARK.md with the post-retune full benchmark results
- update multiplication, division, and string-conversion dispatch diagrams to match current routing

## Benchmark highlights
- 10M x 10M balanced multiply improved from 114.140 ms to 105.381 ms by avoiding early MFA
- focused mul_xl_bench keeps non-MFA through 2^23 and enables MFA at 2^24+
- 50M x 5M skewed is now parity after giving up the earlier early-MFA route

## Validation
- cmake --build build -j8
- ctest --test-dir build --output-on-failure
- ./build/mfa_correctness
- ./build/bench_vs_gmp
- git diff --check