### PR TITLE
Refresh README benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 Arbitrary-precision integer library in C++20. Header-light with a thin static-library shell. 64-bit limbs, 3-prime CRT NTT multiplication (multithreaded by default), Newton–Raphson division with cached reciprocals, divide-and-conquer base conversion. Includes a REPL calculator built on top.
 
-Target: pure C++ that matches GMP on skewed multiplication and gets within 1.4-5× on the rest, without dropping to platform-specific assembly.
+Target: pure C++ that reaches parity or better than GMP in selected multiplication and BigDecimal division bands, while keeping portable scalar fallbacks instead of platform-specific assembly.
 
 ---
 
 ## Features
 
 - **64-bit limb representation** (`BIGMATH_LIMB_64=1`, default). `DataT` stores true 64-bit values; every carry/borrow chain uses `__uint128_t` accumulators. Halves loop iteration counts in scalar paths vs the legacy 32-bit-in-64-bit layout. Opt out via `-DBIGMATH_LIMB_64=0`.
-- **Multiplication:** Classic schoolbook → Karatsuba (64-bit-hybrid leaf) → 3-prime CRT NTT (998244353 / 985661441 / 754974721, 30-bit primes, 32-bit coefficient splitting) gated above 5000 limbs sum; Goldilocks NTT for smaller cases. Single dispatcher in `algorithms/Multiplication.h` picks by operand size.
-- **Radix-4 + radix-8 fused NTT butterflies** (PRs #59, #60). Adjacent radix-2 layers collapse into single load/store butterflies — radix-4 fuses 2 layers (4 elements), radix-8 fuses 3 layers (8 elements). Same modular op count; 3× fewer memory passes vs radix-2. ~1.6× wall-clock at ≥2M limbs, widens the BigMath-wins band against GMP from 5M-10M to **2M-20M**.
+- **Multiplication:** Classic schoolbook → Karatsuba (64-bit-hybrid leaf) → narrow Toom-3 pre-NTT band → NTT. Large products use a 3-prime CRT NTT (2013265921 / 469762049 / 1811939329, 32-bit coefficient splitting) gated above 5000 limbs sum; Goldilocks NTT handles smaller NTT cases.
+- **Radix-4 + radix-8 fused NTT butterflies** (PRs #59, #60). Adjacent radix-2 layers collapse into single load/store butterflies — radix-4 fuses 2 layers (4 elements), radix-8 fuses 3 layers (8 elements). Same modular op count; 3× fewer memory passes vs radix-2. ~1.6× wall-clock at ≥2M limbs.
+- **MFA / Bailey 6-step CRT NTT** (`BIGMATH_NTT_MFA_THRESHOLD=2^24`, default). Very large CRT transforms switch to a cache-friendly matrix Fourier layout. The threshold was retuned upward from `2^21` to avoid regressions in the 300k-2M limb band while keeping wins at `2^24+` transform sizes.
 - **Multithreaded NTT** (`BIGMATH_USE_THREADS=1`, default). Small thread pool (size `min(hw_concurrency, BIGMATH_MAX_THREADS=8)`) parallelizes the CRT path: 6 forwards + 3 inverses as batched work units, one `ParallelDo` dispatch per phase. 2.3-3.4× speedup on large mul / skewed div / parse. Opt out via `-DBIGMATH_USE_THREADS=0` to drop pthread linkage.
 - **Division:** Classic short division → Knuth Algorithm D (`FastDivision` with Möller-Granlund 3-by-2 qhat for Base2_32) → Burnikel–Ziegler (balanced large) → Newton–Raphson with reciprocal caching (skewed large). Identity `q·b + r == a` is cross-checked in `tests/div_correctness.cpp`.
 - **Squaring:** Specialized Classic / Karatsuba / NTT squarers (1.4–1.6× over `Multiply(a,a)`).
@@ -22,15 +23,13 @@ Target: pure C++ that matches GMP on skewed multiplication and gets within 1.4-5
 ## Layout
 
 ```
-include/biginteger/    public BigInteger headers (algorithms, ops, common)
-include/bigdecimal/    public BigDecimal headers
-src/                   non-inline BigInteger implementations
-bigdecimal/            BigDecimal implementation
-include/biginteger/    public headers (algorithms, ops, common)
-src/                   non-inline implementations
-tests/                 correctness, performance, unit tests
-calculator/            REPL frontend
-docs/                  technical references (see below)
+include/biginteger/  public BigInteger headers (algorithms, ops, common)
+include/bigdecimal/  public BigDecimal headers
+src/                 non-inline BigInteger implementations
+bigdecimal/          BigDecimal implementation
+tests/               correctness, performance, unit tests
+calculator/          REPL frontend
+docs/                technical references (see below)
 ```
 
 ## Requirements
@@ -116,28 +115,28 @@ Apple M1 Max, vs GMP 6.3.0, `-O3 -march=native`, full default stack (`BIGMATH_LI
 
 | operation | size | BigMath | GMP | ratio |
 |---|---|---:|---:|---:|
-| mul | 100 000 × 100 000 | 1.20 ms | 0.76 ms | 1.57× |
-| mul | 1 000 000 × 1 000 000 | 9.84 ms | 8.89 ms | 1.11× |
-| mul | **2 000 000 × 2 000 000** | **19.8 ms** | **20.8 ms** | **0.95×** ← BigMath faster |
-| mul | **5 000 000 × 5 000 000** | **45.8 ms** | **64.0 ms** | **0.72×** ← BigMath faster |
-| mul | **10 000 000 × 10 000 000** | **103 ms** | **213 ms** | **0.48×** ← BigMath 2.08× faster |
-| mul | **20 000 000 × 20 000 000** | **276 ms** | **280 ms** | **0.99×** ← parity |
-| mul | 50 000 000 × 50 000 000 | 1 393 ms | 681 ms | 2.05× ← GMP SSA recovers |
-| mul | 100 000 000 × 100 000 000 | 3 221 ms | 1 449 ms | 2.22× |
-| mul (skewed) | **1 000 000 / 100 000** | **4.27 ms** | **4.48 ms** | **0.95×** ← BigMath faster |
-| mul (skewed) | **2 000 000 / 200 000** | **8.51 ms** | **9.40 ms** | **0.91×** ← BigMath faster |
-| mul (skewed) | 10 000 000 / 1 000 000 | 84.2 ms | 70.7 ms | 1.19× |
-| mul (skewed) | **50 000 000 / 5 000 000** | **625 ms** | **666 ms** | **0.94×** ← BigMath faster |
-| div (skewed) | 500 000 / 100 000 | 18.2 ms | 4.76 ms | 3.84× |
-| div (skewed) | 10 000 000 / 2 000 000 | 412 ms | 157 ms | 2.63× |
-| div (skewed) | 50 000 000 / 10 000 000 | 2 356 ms | 1 312 ms | **1.79×** |
-| parse | 1 000 000 digits | 46.5 ms | 20.5 ms | 2.27× |
-| parse | 20 000 000 digits | 1 243 ms | 800 ms | **1.55×** |
-| ToString | 100 000 digits | 19.5 ms | 2.36 ms | 8.24× |
-| ToString | 1 000 000 digits | 228 ms | 48.7 ms | 4.67× |
-| ToString | 20 000 000 digits | 5 238 ms | 2 115 ms | **2.48×** |
+| mul | 100 000 × 100 000 | 1.35 ms | 0.78 ms | 1.72× |
+| mul | 1 000 000 × 1 000 000 | 10.5 ms | 9.06 ms | 1.16× |
+| mul | 2 000 000 × 2 000 000 | 21.9 ms | 20.6 ms | 1.07× |
+| mul | **5 000 000 × 5 000 000** | **46.5 ms** | **63.5 ms** | **0.73×** ← BigMath faster |
+| mul | **10 000 000 × 10 000 000** | **105 ms** | **212 ms** | **0.50×** ← BigMath 2.01× faster |
+| mul | 20 000 000 × 20 000 000 | 279 ms | 278 ms | 1.00× ← parity |
+| mul | 50 000 000 × 50 000 000 | 1 231 ms | 660 ms | 1.86× ← GMP SSA recovers |
+| mul | 100 000 000 × 100 000 000 | 2 832 ms | 1 391 ms | 2.04× |
+| mul (skewed) | **1 000 000 / 100 000** | **4.47 ms** | **4.79 ms** | **0.93×** ← BigMath faster |
+| mul (skewed) | 2 000 000 / 200 000 | 9.43 ms | 9.45 ms | 1.00× ← parity |
+| mul (skewed) | 10 000 000 / 1 000 000 | 88.4 ms | 70.5 ms | 1.25× |
+| mul (skewed) | 50 000 000 / 5 000 000 | 667 ms | 666 ms | 1.00× ← parity |
+| div (skewed) | 500 000 / 100 000 | 18.0 ms | 4.63 ms | 3.89× |
+| div (skewed) | 10 000 000 / 2 000 000 | 427 ms | 154 ms | 2.78× |
+| div (skewed) | 50 000 000 / 10 000 000 | 2 500 ms | 1 299 ms | **1.92×** |
+| parse | 1 000 000 digits | 48.7 ms | 20.3 ms | 2.40× |
+| parse | 20 000 000 digits | 1 252 ms | 803 ms | **1.56×** |
+| ToString | 100 000 digits | 19.5 ms | 2.33 ms | 8.35× |
+| ToString | 1 000 000 digits | 224 ms | 49.8 ms | 4.50× |
+| ToString | 20 000 000 digits | 5 437 ms | 2 116 ms | **2.57×** |
 
-**BigMath beats GMP on balanced multiplication across the 2M–20M digit band** — the NTT asymptotic edge plus radix-4+8 fused butterflies (PRs #59, #60) widen the win window and push the **10M peak to 2.08× faster than GMP** (103 ms vs 213 ms). At ≥50M GMP's Schönhage-Strassen reverses the lead but the loss factor halved (3.58× → 2.05× at 50M). Skewed mults win four bands (500k×50k through 50M×5M, 0.91-0.97×). Skewed division at 50M×10M dropped to **1.79×** as Newton inherits the NTT speedup via its per-chunk muls. ToString narrows from 8.2× at 100k to 2.48× at 20M; parse to 1.55× at 20M. See [BENCHMARK.md](BENCHMARK.md) for the full table or the per-doc ratio tables for the breakdown.
+**BigMath beats GMP on balanced multiplication across the 5M–10M digit band** and is roughly parity at 20M. The current peak is **10M balanced at 2.01× faster than GMP** (105 ms vs 212 ms). The MFA threshold retune improved that row by avoiding early MFA; at ≥50M GMP's Schönhage-Strassen still recovers. Skewed multiplication is a BigMath win around 1M×100k and parity at 2M×200k and 50M×5M. Skewed division at 50M×10M is **1.92×** as Newton inherits the large-multiplication speedups. ToString narrows from 8.35× at 100k to 2.57× at 20M; parse to 1.56× at 20M. See [BENCHMARK.md](BENCHMARK.md) for the full table or the per-doc ratio tables for the breakdown.
 
 Opt-out flags (`-DBIGMATH_USE_THREADS=0` / `-DBIGMATH_NTT_CRT=0` / `-DBIGMATH_LIMB_64=0`) revert any subset of the defaults — useful for embedded targets, header-only-strict consumers, or A/B comparison.
 


### PR DESCRIPTION
## Summary
- refresh README feature descriptions for current multiplication and MFA dispatch
- update README benchmark table from the latest benchmark run
- clarify current GMP comparison bands

## Validation
- git diff --check