### PR TITLE
NTT-CRT: skip redundant zero-fills of transform + scratch buffers

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -1207,11 +1207,25 @@ namespace BigMath
       ULong coeffCount = aCoeffSize + bCoeffSize - 1;
       Int n = (Int)std::bit_ceil(coeffCount);
 
-      // Three parallel transforms.
+      // Three parallel transforms. PackOperand writes the coefficient head
+      // [0, *CoeffSize) of each buffer; only the zero-pad tail needs clearing.
+      // Using assign(n, 0) here would zero the whole buffer and then have
+      // PackOperand overwrite the head — double-writing ~aCoeffSize+bCoeffSize
+      // elements per call. On a bandwidth-bound kernel that waste is real, so
+      // resize (no fill at steady state, size already n) + tail-only fill.
       static thread_local std::vector<UInt> fa1, fb1, fa2, fb2, fa3, fb3;
-      fa1.assign(n, 0); fb1.assign(n, 0);
-      fa2.assign(n, 0); fb2.assign(n, 0);
-      fa3.assign(n, 0); fb3.assign(n, 0);
+      fa1.resize(n); fb1.resize(n);
+      fa2.resize(n); fb2.resize(n);
+      fa3.resize(n); fb3.resize(n);
+
+      const std::ptrdiff_t aHead = (std::ptrdiff_t)aCoeffSize;
+      const std::ptrdiff_t bHead = (std::ptrdiff_t)bCoeffSize;
+      std::fill(fa1.begin() + aHead, fa1.end(), 0u);
+      std::fill(fa2.begin() + aHead, fa2.end(), 0u);
+      std::fill(fa3.begin() + aHead, fa3.end(), 0u);
+      std::fill(fb1.begin() + bHead, fb1.end(), 0u);
+      std::fill(fb2.begin() + bHead, fb2.end(), 0u);
+      std::fill(fb3.begin() + bHead, fb3.end(), 0u);
 
       PackOperand(a, base, fa1, fa2, fa3);
       PackOperand(b, base, fb1, fb2, fb3);
@@ -1231,7 +1245,10 @@ namespace BigMath
       MfaPlanTree<F3> tree3;
       if (useMfa)
       {
-        for (int i = 0; i < 6; ++i) mfaScratch[i].assign(n, 0);
+        // No zero-fill: each scratch is fully written by the step-1 Transpose
+        // before any read (recursive sub-calls likewise write their slice
+        // before reading). assign(n, 0) here was ~6n wasted writes per call.
+        for (int i = 0; i < 6; ++i) mfaScratch[i].resize(n);
         // Pre-warm all plans in main thread: worker threads cannot call
         // GetPlan() safely from inside ParallelDo (BuildRoots reenters pool).
         BuildMfaPlanTree<F1, G1>(n, tree1);


### PR DESCRIPTION
## What

The CRT-NTT multiply is memory-bandwidth bound at large sizes (profiled: serial→8-thread = 3.08×, single-core IPC 2.49, 4 shared-nothing processes aggregate only 2.6×). Two per-call zero-fills were pure wasted memory traffic:

- `mfaScratch[0..5]` were `assign(n, 0)` before use, but each scratch is fully written by the step-1 `Transpose` (recursive sub-calls write their slice) before any read → ~6n redundant writes/multiply. Now `resize(n)`.
- `fa/fb` forward buffers were `assign(n, 0)`, then `PackOperand` overwrote the head `[0, *CoeffSize)`. Only the zero-pad tail needs clearing → `resize(n)` + `std::fill` of the tail, removing a double-write of ~aCoeffSize+bCoeffSize elements/multiply.

## Benchmark (mul_xl_bench, M1 Max, base 2^64, best-of-5)

| size | digits | before | after | Δ |
|---|---|---|---|---|
| 1.3M limbs | 25M | 1018.7 ms | 960.9 ms | **−5.6%** |
| 2.6M limbs | 50M | 1786.9 ms | 1726.4 ms | **−3.3%** |
| 5.2M limbs | 100M | 3916.4 ms | 3909.2 ms | −0.1% |

Win concentrates below the MFA band (n < 2^24) where the dropped fills are a larger fraction; at 100M digits the MFA transform passes dominate and zero-fill (ideal sequential write) is a small time share. No regression at any size.

## Correctness

`tests/mult_correctness.cpp` passes — all algorithms match the classic reference across all sizes including max-carry and unbalanced cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)