### PR TITLE
bench: average simple harnesses over k runs (default 3)

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -311,6 +311,56 @@ limb-for-limb across `na ∈ {2n-1, 2n, 2n+1, 2n+2, 3n}` × `nb` near the bounda
 
 ---
 
+## In-tree simple harnesses (k-averaged, no GMP)
+
+`tests/multperf_simple.cpp` and `tests/divperf_simple.cpp` are the standalone
+in-tree harnesses (no GMP dependency). Each compares BigMath's own algorithms
+against each other and validates the results limb-for-limb. Both take an
+optional run-count `k` (default 3); every size is timed `k` times and the
+**arithmetic mean** is reported:
+
+```
+multperf_simple 5      # avg of 5 runs per size
+divperf_simple 5
+```
+
+Measured 2026-05-31, M1 Max, `-O2`, default stack (Base2_32 internal repr,
+`k = 5`).
+
+### Multiplication — `multperf_simple 5`
+
+Two random decimal numbers of equal digit length. Speedup is vs Classical.
+
+| digits | Classical ms | Karatsuba ms | Karatsuba× | NTT ms | NTT× |
+|---:|---:|---:|---:|---:|---:|
+| 100 | 0.000 | 0.000 | 0.5× | 0.007 | — |
+| 10 000 | 0.274 | 0.094 | 2.9× | 0.391 | 0.7× |
+| 100 000 | 28.917 | 4.147 | 7.0× | 1.143 | 25.3× |
+| 500 000 | 692.964 | 45.330 | 15.3× | 4.585 | 151.1× |
+
+At 100 digits both classical and Karatsuba are sub-microsecond (rounds to
+0.000 ms); NTT loses to schoolbook at that size, as expected. Karatsuba and NTT
+cross over between 10k and 100k digits — by 500k digits NTT is **151× faster**
+than schoolbook. All three products matched exactly.
+
+### Division — `divperf_simple 5`
+
+`FastDivision` (Knuth D variant) vs `BurnikelZieglerDivision`. Speedup is
+`fast / bz` (>1 means BZ faster). Results cross-checked limb-for-limb.
+
+| shape (limbs) | FastDivision ms | BurnikelZiegler ms | fast/bz |
+|---|---:|---:|---:|
+| 1024 × 512 | 0.845 | 0.864 | 0.98× |
+| 4096 × 2048 | 7.833 | 3.218 | 2.43× |
+| 8192 × 512 | 5.154 | 5.075 | 1.02× |
+| 16384 × 512 | 10.306 | 10.311 | 1.00× |
+
+BZ's recursive halving pays off on the near-balanced `4096 × 2048` shape
+(2.43× over FastDivision). On the skewed `n × 512` shapes the two are at parity
+— the divisor is small enough that FastDivision's quadratic inner loop is short.
+
+---
+
 ## Decimal parse (string → BigInteger)
 
 | size (digits) | BigMath ms | GMP ms | BM/GMP |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ cd build && ctest --output-on-failure
 
 `mult_correctness` is fast; `div_correctness` runs a broad matrix and takes a few minutes; `unit_tests` is sub-second.
 
+The standalone perf harnesses `multperf_simple` and `divperf_simple` (BigMath-internal, no GMP) take an optional run-count `k` (default 3); each size is timed `k` times and the mean reported:
+
+```sh
+./build/multperf_simple 5   # average of 5 runs per size
+./build/divperf_simple 5
+```
+
+See [BENCHMARK.md](BENCHMARK.md#in-tree-simple-harnesses-k-averaged-no-gmp) for the latest k=5 numbers.
+
 ## Use
 
 ```cpp

--- a/tests/divperf_simple.cpp
+++ b/tests/divperf_simple.cpp
@@ -23,21 +23,30 @@ static vector<DataT> RandomNumber(SizeT limbs, mt19937_64 &gen)
   return value.empty() ? vector<DataT>{0} : value;
 }
 
-static void Run(SizeT dividendLimbs, SizeT divisorLimbs)
+static void Run(SizeT dividendLimbs, SizeT divisorLimbs, int k)
 {
   mt19937_64 gen(98765 + dividendLimbs + divisorLimbs);
   vector<DataT> a = RandomNumber(dividendLimbs, gen);
   vector<DataT> b = RandomNumber(divisorLimbs, gen);
 
-  auto start = chrono::high_resolution_clock::now();
-  auto fast = FastDivision::DivideAndRemainder(a, b, BigInteger::Base());
-  auto end = chrono::high_resolution_clock::now();
-  double fastMs = chrono::duration<double, milli>(end - start).count();
+  double fastMs = 0, bzMs = 0;
+  pair<vector<DataT>, vector<DataT>> fast, bz;
 
-  start = chrono::high_resolution_clock::now();
-  auto bz = BurnikelZieglerDivision::DivideAndRemainder(a, b, BigInteger::Base());
-  end = chrono::high_resolution_clock::now();
-  double bzMs = chrono::duration<double, milli>(end - start).count();
+  for (int run = 0; run < k; ++run)
+  {
+    auto start = chrono::high_resolution_clock::now();
+    fast = FastDivision::DivideAndRemainder(a, b, BigInteger::Base());
+    auto end = chrono::high_resolution_clock::now();
+    fastMs += chrono::duration<double, milli>(end - start).count();
+
+    start = chrono::high_resolution_clock::now();
+    bz = BurnikelZieglerDivision::DivideAndRemainder(a, b, BigInteger::Base());
+    end = chrono::high_resolution_clock::now();
+    bzMs += chrono::duration<double, milli>(end - start).count();
+  }
+
+  fastMs /= k;
+  bzMs /= k;
 
   bool match = Compare(fast.first, bz.first) == 0 && Compare(fast.second, bz.second) == 0;
 
@@ -52,11 +61,15 @@ static void Run(SizeT dividendLimbs, SizeT divisorLimbs)
     exit(1);
 }
 
-int main()
+int main(int argc, char **argv)
 {
-  Run(1024, 512);
-  Run(4096, 2048);
-  Run(8192, 512);
-  Run(16384, 512);
+  int k = (argc > 1) ? atoi(argv[1]) : 3;
+  if (k < 1) k = 1;
+
+  cout << "Runs per size (k): " << k << endl;
+  Run(1024, 512, k);
+  Run(4096, 2048, k);
+  Run(8192, 512, k);
+  Run(16384, 512, k);
   return 0;
 }

--- a/tests/multperf_simple.cpp
+++ b/tests/multperf_simple.cpp
@@ -31,10 +31,11 @@ string GenerateRandomDigits(int length)
     return s;
 }
 
-void RunBenchmarkForSize(int digits)
+void RunBenchmarkForSize(int digits, int k)
 {
     cout << "---------------------------------------------" << endl;
-    cout << "Benchmarking with two " << digits << "-digit random numbers" << endl;
+    cout << "Benchmarking with two " << digits << "-digit random numbers"
+         << " (avg of " << k << " runs)" << endl;
     cout << "---------------------------------------------" << endl;
 
     string s_a = GenerateRandomDigits(digits);
@@ -46,23 +47,33 @@ void RunBenchmarkForSize(int digits)
     const auto &vecA = a.GetInteger();
     const auto &vecB = b.GetInteger();
 
-    // 1. Classical Multiplication
-    auto start = chrono::high_resolution_clock::now();
-    vector<DataT> rClassic = ClassicMultiplication::Multiply(vecA, vecB, BigInteger::Base());
-    auto end = chrono::high_resolution_clock::now();
-    double timeClassic = chrono::duration<double, milli>(end - start).count();
+    double timeClassic = 0, timeKara = 0, timeNTT = 0;
+    vector<DataT> rClassic, rKara, rNTT;
 
-    // 2. Karatsuba Multiplication
-    start = chrono::high_resolution_clock::now();
-    vector<DataT> rKara = KaratsubaMultiplication::Multiply(vecA, vecB, BigInteger::Base());
-    end = chrono::high_resolution_clock::now();
-    double timeKara = chrono::duration<double, milli>(end - start).count();
+    for (int run = 0; run < k; ++run)
+    {
+        // 1. Classical Multiplication
+        auto start = chrono::high_resolution_clock::now();
+        rClassic = ClassicMultiplication::Multiply(vecA, vecB, BigInteger::Base());
+        auto end = chrono::high_resolution_clock::now();
+        timeClassic += chrono::duration<double, milli>(end - start).count();
 
-    // 3. NTT Multiplication
-    start = chrono::high_resolution_clock::now();
-    vector<DataT> rNTT = NTTMultiplication::Multiply(vecA, vecB, BigInteger::Base());
-    end = chrono::high_resolution_clock::now();
-    double timeNTT = chrono::duration<double, milli>(end - start).count();
+        // 2. Karatsuba Multiplication
+        start = chrono::high_resolution_clock::now();
+        rKara = KaratsubaMultiplication::Multiply(vecA, vecB, BigInteger::Base());
+        end = chrono::high_resolution_clock::now();
+        timeKara += chrono::duration<double, milli>(end - start).count();
+
+        // 3. NTT Multiplication
+        start = chrono::high_resolution_clock::now();
+        rNTT = NTTMultiplication::Multiply(vecA, vecB, BigInteger::Base());
+        end = chrono::high_resolution_clock::now();
+        timeNTT += chrono::duration<double, milli>(end - start).count();
+    }
+
+    timeClassic /= k;
+    timeKara /= k;
+    timeNTT /= k;
 
     // Validate correctness
     bool cmp_kara_ok = (Compare(rClassic, rKara) == 0);
@@ -85,16 +96,20 @@ void RunBenchmarkForSize(int digits)
     printf("NTT:        %8.3f ms (Speedup vs Classic: %4.1fx)\n", timeNTT, timeClassic / timeNTT);
 }
 
-int main()
+int main(int argc, char **argv)
 {
+    int k = (argc > 1) ? atoi(argv[1]) : 3;
+    if (k < 1) k = 1;
+
     cout << "BigInteger Multiplication Performance Benchmark" << endl;
     cout << "Internal representation: Base 2^32 (" << BigInteger::Base() << ")" << endl;
+    cout << "Runs per size (k): " << k << endl;
     cout << "---------------------------------------------" << endl;
 
-    RunBenchmarkForSize(100);
-    RunBenchmarkForSize(10000);
-    RunBenchmarkForSize(100000);
-    RunBenchmarkForSize(500000);
+    RunBenchmarkForSize(100, k);
+    RunBenchmarkForSize(10000, k);
+    RunBenchmarkForSize(100000, k);
+    RunBenchmarkForSize(500000, k);
 
     return 0;
 }


### PR DESCRIPTION
## What

`multperf_simple` and `divperf_simple` now time each size `k` times and report the **arithmetic mean** instead of a single run. `k` is read from `argv[1]`, default 3, clamped to ≥1.

```sh
./multperf_simple 5   # avg of 5 runs per size
./divperf_simple 5
```

Correctness validation still runs (products / quotients matched limb-for-limb; results are identical across runs).

## Docs

- README: documents the `k` flag on both simple harnesses.
- BENCHMARK.md: new "In-tree simple harnesses (k-averaged, no GMP)" section with fresh k=5 numbers (2026-05-31, M1 Max, `-O2`). Existing GMP-comparison tables from `bench_vs_gmp.cpp` are untouched — different harness/methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)