### PR TITLE
perf: wrap-around cyclic remainder in Newton DivideChunk (−10% skewed div, −7% tostr)

### DIFF
--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -553,6 +553,51 @@ Bonus pitfall surfaced during development: `Multiply()` trims trailing zeros, so
 
 Reverted in full. Don't re-attempt unless a non-NTT multiplication path becomes dominant, or there's a Karatsuba-only Newton band big enough to matter.
 
+### Reduce NTT length — wrap-around cyclic remainder (LANDED 2026-06-11)
+
+The follow-up to the Mulders rejection above, attacking the same `DivideChunk` cost from the
+angle that *does* translate to NTT: cut the **transform length**, not the multiply count.
+Transform length is the serial critical path of a CRT-NTT multiply (the three primes already run
+in parallel; see the prepared-transform rejection in *Explored but rejected* for the measurement
+proving count-cuts don't move wall-clock).
+
+`DivideChunk` needed the full `QB = Q · b_norm` (transform length `bit_ceil(2·(2n+1))` coeffs)
+only to compute `rem = chunk − QB` and detect quotient-estimate error. But `|chunk − Q·b_norm| <
+9·b_norm < B^(n+1)`, so the *residue* `(Q·b_norm) mod (B^L − 1)` with `L ≈ n+2` determines `rem`
+exactly — and a length-`N` NTT computes products mod `(x^N − 1)` natively, so the residue costs a
+cyclic transform of `bit_ceil((n+2)·c)` coeffs — **half the full product's length**
+(GMP's `mpn_mu_div_qr` uses the same wraparound idea via `mulmod_bnm1`).
+
+Implementation: `NttCrt::MultiplyMod2km1(a, b, L, base)` (cyclic convolution at `N = L·c`,
+wrap-folding Garner finalize, canonical residue), used by `NewtonDivision::WrappedRemainder`
+which reconstructs `rem = (chunk − W) mod (B^L − 1)` and reads the sign of the true
+`t = chunk − Q·b_norm` from the residue's magnitude (`t ≥ 0` ⇒ ≤ n+1 limbs; `t < 0` ⇒ ≥ n+2
+limbs; disjoint because `L ≥ n+2` and quotient-estimate error is O(n) ≪ B). Fixup loops and the
+`FIXUP_LIMIT` bail-to-FastDivision semantics are unchanged. Gated on: power-of-two base,
+`BIGMATH_NTT_CRT`, `Q+n ≥ NTT_MULTIPLICATION_THRESHOLD`, cyclic length strictly below the linear
+length, and `N ≤ 2^22` (CRT coefficient-sum headroom; below the MFA permuted regime).
+
+Measured (M1 Max, paired back-to-back runs):
+
+| case | base | cyclic | delta |
+|---|---:|---:|---:|
+| div 1M / 200k digits | 34.9 ms | 31.1 ms | **−11%** |
+| div 5M / 1M digits | 206.1 ms | 184.9 ms | **−10%** |
+| tostr 1M digits | 147.1 ms | 136.7 ms | **−7%** |
+| tostr 200k digits | 21.3 ms | 20.4 ms | −4% |
+| div 1M/1M digits (FastDivision path) | 0.226 ms | 0.223 ms | flat (not routed) |
+
+Verified: 246 unit tests, `div_correctness`, ToString round-trips at 100k/1M/5M digits, and a
+focused stress harness at gate-active sizes (nb 2 600–16 000 limbs, ratios 1.5–15, all-max /
+sparse / zero-half adversarial patterns, `na = 2n`/`2n±1` boundaries, power-of-two cliffs) —
+cross-checked limb-for-limb against FastDivision plus the `q·b + r == a`, `r < b` identity.
+
+Remaining wraparound headroom (not yet taken): the same trick applies to `CR = chunk · R`
+(GMP's `mu_divappr` multiplies only the top `n+1` limbs of the chunk against the inverse with
+wraparound) and to the `T = D·R` / `RD = R·diff` products inside `ApproxReciprocal`
+(`invertappr`-style). Both need sharper error analysis than the QB case (the residue's "known
+high part" comes from the Newton invariant rather than an explicit `rem < b` bound).
+
 ### Parallelize NTT — multithreading (LANDED, PR #32/#38/#39)
 
 `BIGMATH_USE_THREADS=1` (default since PR #39) wires a small thread pool (size `min(hw_concurrency, BIGMATH_MAX_THREADS=8)`) into the CRT NTT path. The 6 forwards (3 of `fa`, 3 of `fb`) dispatch as one `ParallelDo` batch of 6 work units; 3 inverses dispatch as a 3-unit batch. Each NTT runs serially within its worker — **2 dispatches per Multiply**, not 100+.

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -2,6 +2,7 @@
 #define NEWTON_DIVISION
 
 #include <algorithm>
+#include <bit>
 #include <cstring>
 #include <stdexcept>
 #include <utility>
@@ -234,6 +235,85 @@ namespace BigMath
       bool ok;
     };
 
+    static SizeT TrimmedSize(vector<DataT> const &v)
+    {
+      SizeT s = (SizeT)v.size();
+      while (s > 1 && v[s - 1] == 0)
+        --s;
+      return s;
+    }
+
+    // Wrap-around remainder (GMP mu_div-style): instead of the full product
+    // QB = Q·b_norm, compute only its residue W = (Q·b_norm) mod (B^L − 1)
+    // with a cyclic NTT of HALF the transform length, and reconstruct
+    // rem = chunk − Q·b_norm from it.
+    //
+    // Exactness: Q is the truncated reciprocal estimate, so the true
+    // t = chunk − Q·b_norm satisfies |t| < 9·b_norm < B^(n+1) ≤ B^(L−1) — the
+    // residue (chunk − W) mod (B^L − 1) identifies t uniquely, and its sign is
+    // readable from the magnitude: t ≥ 0 lands in [0, B^(n+1)) (≤ n+1 limbs),
+    // t < 0 lands in (M − 9·B^n, M) (≥ n+2 limbs). L ≥ n+2 by construction.
+    //
+    // Returns false if a fixup cap blows; caller falls back to FastDivision
+    // exactly like the plain path.
+    static bool WrappedRemainder(
+        vector<DataT> const &chunk,
+        vector<DataT> const &b_norm,
+        SizeT L,
+        vector<DataT> &Q,
+        vector<DataT> &rem)
+    {
+      SizeT n = (SizeT)b_norm.size();
+      const DataT maxLimb = (CurrentBase == Base2_64) ? (DataT)~0ULL : (DataT)0xFFFFFFFFULL;
+      const vector<DataT> M(L, maxLimb); // B^L − 1
+
+      vector<DataT> W = NTTMultiplication::MultiplyMod2km1(Q, b_norm, L, CurrentBase);
+
+      // chunk mod M: fold the limbs above L back onto the low L (B^L ≡ 1).
+      vector<DataT> cm(chunk.begin(), chunk.begin() + std::min((SizeT)chunk.size(), L));
+      if (chunk.size() > L)
+      {
+        vector<DataT> hi(chunk.begin() + L, chunk.end());
+        cm = Add(cm, hi, CurrentBase);
+        while (Compare(cm, M) >= 0)
+          cm = Subtract(cm, M, CurrentBase);
+      }
+
+      // rem_m = (cm − W) mod M
+      vector<DataT> rem_m = (Compare(cm, W) >= 0)
+                                ? Subtract(cm, W, CurrentBase)
+                                : Subtract(Add(cm, M, CurrentBase), W, CurrentBase);
+
+      const int FIXUP_LIMIT = 8;
+      static const vector<DataT> one{1};
+
+      // t < 0 (Q overestimated): rem_m ≈ M − |t|, which needs > n+1 limbs.
+      int iters = 0;
+      while (TrimmedSize(rem_m) > n + 1)
+      {
+        if (++iters > FIXUP_LIMIT)
+          return false;
+        Q = Subtract(Q, one, CurrentBase);
+        rem_m = Add(rem_m, b_norm, CurrentBase);
+        while (Compare(rem_m, M) >= 0)
+          rem_m = Subtract(rem_m, M, CurrentBase);
+      }
+
+      // rem_m now equals chunk − Q·b_norm exactly.
+      iters = 0;
+      while (Compare(rem_m, b_norm) >= 0)
+      {
+        if (++iters > FIXUP_LIMIT)
+          return false;
+        rem_m = Subtract(rem_m, b_norm, CurrentBase);
+        Q = Add(Q, one, CurrentBase);
+      }
+
+      rem = std::move(rem_m);
+      TrimZerosToOne(rem);
+      return true;
+    }
+
     // Reciprocal-based divide of a single chunk by b_norm. Used by both single-block and
     // blockwise paths. Returns {q, rem, true} on success, {{}, {}, false} on fixup overflow.
     static DivideResult DivideChunk(
@@ -254,6 +334,28 @@ namespace BigMath
       else
         Q.assign(1, 0);
       TrimZerosToOne(Q);
+
+      // Remainder via half-length cyclic product when the full Q·b_norm would
+      // be CRT-NTT-routed and the cyclic transform is strictly shorter.
+#if BIGMATH_NTT_CRT
+      if ((CurrentBase == Base2_32 || CurrentBase == Base2_64) && !IsZero(Q))
+      {
+        SizeT c = (CurrentBase == Base2_64) ? 2 : 1;
+        ULong nCyc = std::bit_ceil((ULong)(n + 2) * c);
+        ULong nLinear = std::bit_ceil(((ULong)Q.size() + n) * c);
+        SizeT L = (SizeT)(nCyc / c);
+        if (Q.size() + n >= NTT_MULTIPLICATION_THRESHOLD &&
+            nCyc < nLinear && nCyc <= (1u << 22) &&
+            Q.size() <= L)
+        {
+          vector<DataT> rem;
+          if (!WrappedRemainder(chunk, b_norm, L, Q, rem))
+            return {{}, {}, false};
+          TrimZerosToOne(Q);
+          return {Q, rem, true};
+        }
+      }
+#endif
 
       QB = Multiply(Q, b_norm, CurrentBase);
 

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -154,6 +154,17 @@ namespace BigMath
             return NttCrt::Multiply(prepared, other);
         }
 
+        // (a · b) mod (B^L − 1) via a cyclic NTT of half the full-product
+        // length. See NttCrt::MultiplyMod2km1 for the caller contract.
+        static vector<DataT> MultiplyMod2km1(
+            const vector<DataT> &a,
+            const vector<DataT> &b,
+            SizeT L,
+            BaseT base)
+        {
+            return NttCrt::MultiplyMod2km1(a, b, L, base);
+        }
+
         // Multiply two vectors of digits using NTT-based convolution.
         static vector<DataT> Multiply(const vector<DataT> &a, const vector<DataT> &b, BaseT base)
         {

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -1555,6 +1555,182 @@ namespace BigMath
 
       return FinalizeProduct(fa1, fa2, fa3, coeffCount, base, a.size() + b.size() + 2);
     }
+
+    // ─── Cyclic (wrap-around) product: (a · b) mod (B^L − 1) ────────────────
+    //
+    // An NTT of length N computes coefficient products mod (x^N − 1); with
+    // N = L · coeffsPerLimb the wrapped coefficient sums carry-propagate to
+    // exactly (a · b) mod (B^L − 1), because B^L ≡ 1 there. The transform is
+    // HALF the length the full product would need — and transform length is
+    // the serial critical path of a multiply (the three primes already run in
+    // parallel), so callers that can reconstruct what they need from the
+    // residue get the product at about half the wall-clock cost.
+    //
+    // Caller contract: L · coeffsPerLimb is a power of two (so the cyclic
+    // length is an admissible NTT size), a.size() ≤ L, b.size() ≤ L, and
+    // N ≤ 2^22 (same CRT coefficient-sum headroom bound as the linear path,
+    // and safely below the MFA regime, which permutes coefficient order).
+    // Returns the canonical residue in [0, B^L − 1), trimmed.
+    inline std::vector<DataT> MultiplyMod2km1(const std::vector<DataT> &a,
+                                              const std::vector<DataT> &b,
+                                              SizeT L,
+                                              BaseT base)
+    {
+      if (IsZero(a) || IsZero(b))
+        return std::vector<DataT>{0};
+
+      SizeT coeffsPerLimb = CoeffsPerLimb(base);
+      Int n = (Int)((ULong)L * coeffsPerLimb);
+      if (n <= 1 || (n & (n - 1)) != 0 || n > (1 << 22))
+        throw std::invalid_argument("MultiplyMod2km1: L*coeffsPerLimb must be a power of two <= 2^22");
+      if (a.size() > L || b.size() > L)
+        throw std::invalid_argument("MultiplyMod2km1: operand exceeds L limbs");
+
+      static thread_local std::vector<UInt> fa1, fb1, fa2, fb2, fa3, fb3;
+      fa1.assign(n, 0); fb1.assign(n, 0);
+      fa2.assign(n, 0); fb2.assign(n, 0);
+      fa3.assign(n, 0); fb3.assign(n, 0);
+
+      PackOperand(a, base, fa1, fa2, fa3);
+      PackOperand(b, base, fb1, fb2, fb3);
+
+      const auto &plan1 = GetPlan<F1, G1>(n);
+      const auto &plan2 = GetPlan<F2, G2>(n);
+      const auto &plan3 = GetPlan<F3, G3>(n);
+
+#if BIGMATH_USE_THREADS
+      {
+        std::vector<UInt> *bufs[6] = {&fa1, &fb1, &fa2, &fb2, &fa3, &fb3};
+        const Plan<F1> *p1 = &plan1;
+        const Plan<F2> *p2 = &plan2;
+        const Plan<F3> *p3 = &plan3;
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Forward<F1>(*bufs[0], *p1); break;
+              case 1: Forward<F1>(*bufs[1], *p1); break;
+              case 2: Forward<F2>(*bufs[2], *p2); break;
+              case 3: Forward<F2>(*bufs[3], *p2); break;
+              case 4: Forward<F3>(*bufs[4], *p3); break;
+              case 5: Forward<F3>(*bufs[5], *p3); break;
+            }
+          }
+        };
+        ParallelDo(6, body);
+      }
+#else
+      Forward<F1>(fa1, plan1); Forward<F1>(fb1, plan1);
+      Forward<F2>(fa2, plan2); Forward<F2>(fb2, plan2);
+      Forward<F3>(fa3, plan3); Forward<F3>(fb3, plan3);
+#endif
+
+      {
+        UInt *p1a = fa1.data(), *p1b = fb1.data();
+        UInt *p2a = fa2.data(), *p2b = fb2.data();
+        UInt *p3a = fa3.data(), *p3b = fb3.data();
+        auto body = [p1a, p1b, p2a, p2b, p3a, p3b](Int s, Int e) {
+          for (Int i = s; i < e; ++i)
+          {
+            p1a[i] = F1::Mul(p1a[i], p1b[i]);
+            p2a[i] = F2::Mul(p2a[i], p2b[i]);
+            p3a[i] = F3::Mul(p3a[i], p3b[i]);
+          }
+        };
+        if ((SizeT)n >= ParallelMinSize()) ParallelFor(n, body);
+        else body(0, n);
+      }
+
+#if BIGMATH_USE_THREADS
+      {
+        std::vector<UInt> *bufs[3] = {&fa1, &fa2, &fa3};
+        const Plan<F1> *p1 = &plan1;
+        const Plan<F2> *p2 = &plan2;
+        const Plan<F3> *p3 = &plan3;
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Inverse<F1>(*bufs[0], *p1); break;
+              case 1: Inverse<F2>(*bufs[1], *p2); break;
+              case 2: Inverse<F3>(*bufs[2], *p3); break;
+            }
+          }
+        };
+        ParallelDo(3, body);
+      }
+#else
+      Inverse<F1>(fa1, plan1);
+      Inverse<F2>(fa2, plan2);
+      Inverse<F3>(fa3, plan3);
+#endif
+
+      // Garner-recombine and carry across exactly N coefficients (L limbs);
+      // the carry that spills past limb L wraps back to limb 0 (B^L ≡ 1).
+      const InvTable &inv = GarnerInverses();
+      std::vector<DataT> r(L, 0);
+      ULong128 carry = 0;
+      if (base == Base2_64)
+      {
+        for (SizeT i = 0; i < L; ++i)
+        {
+          ULong128 total = Garner(fa1[2 * i], fa2[2 * i], fa3[2 * i], inv) + carry;
+          ULong lo = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+          total = Garner(fa1[2 * i + 1], fa2[2 * i + 1], fa3[2 * i + 1], inv) + carry;
+          ULong hi = (ULong)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+          r[i] = (DataT)(lo | (hi << 32));
+        }
+      }
+      else
+      {
+        for (SizeT i = 0; i < L; ++i)
+        {
+          ULong128 total = Garner(fa1[i], fa2[i], fa3[i], inv) + carry;
+          r[i] = (DataT)(total & 0xFFFFFFFFULL);
+          carry = total >> 32;
+        }
+      }
+
+      const ULong limbMask = (base == Base2_64) ? ~0ULL : 0xFFFFFFFFULL;
+      const int limbBits = (base == Base2_64) ? 64 : 32;
+      while (carry > 0)
+      {
+        ULong128 cur = carry;
+        carry = 0;
+        for (SizeT i = 0; cur > 0; ++i)
+        {
+          if (i == L)
+          {
+            carry += cur; // spilled past the top again — wrap once more
+            break;
+          }
+          ULong128 s = (ULong128)(ULong)r[i] + (ULong)(cur & limbMask);
+          r[i] = (DataT)((ULong)s & limbMask);
+          cur = (cur >> limbBits) + (s >> limbBits);
+        }
+      }
+
+      // r is now in [0, B^L − 1]; the single non-canonical value is B^L − 1
+      // itself (all limbs max), which ≡ 0.
+      bool allMax = true;
+      for (SizeT i = 0; i < L; ++i)
+        if ((ULong)r[i] != limbMask)
+        {
+          allMax = false;
+          break;
+        }
+      if (allMax)
+        return std::vector<DataT>{0};
+
+      TrimZeros(r);
+      if (r.empty())
+        r.push_back(0);
+      return r;
+    }
   } // namespace NttCrt
 } // namespace BigMath
 


### PR DESCRIPTION
## What

The second lever from the 2026-06-11 profiling session: GMP `mu_div`-style wraparound for the `QB = Q·b_norm` product in `NewtonDivision::DivideChunk`.

`DivideChunk` needed the full QB only to compute `rem = chunk − QB` and detect quotient-estimate error. Since `|chunk − Q·b_norm| < 9·b_norm < B^(n+1)`, the residue `(Q·b_norm) mod (B^L − 1)` with `L ≈ n+2` determines `rem` exactly — and a length-N NTT computes products mod `(x^N − 1)` natively, at **half the transform length** of the full product.

## Why this one works where the last two didn't

Transform *length* is the serial critical path of a CRT-NTT multiply — the three primes already run in parallel. PR #84 measured that cutting transform *count* (prepared operands) moves CPU time but not wall-clock; the May Mulders rejection showed exact-MulHigh decomposition doesn't help when NTT cost is linear. Halving the length shortens the serial chain itself.

## Implementation

- `NttCrt::MultiplyMod2km1(a, b, L, base)` — cyclic convolution at `N = L·coeffsPerLimb`, batched-6 forward dispatch (same threading shape as the linear path), wrap-folding Garner finalize, canonical residue.
- `NewtonDivision::WrappedRemainder` — reconstructs `rem = (chunk − W) mod (B^L − 1)`; the sign of the true `t = chunk − Q·b_norm` is read from residue magnitude (`t ≥ 0` ⇒ ≤ n+1 limbs, `t < 0` ⇒ ≥ n+2 limbs; disjoint since `L ≥ n+2` and estimate error is O(n) ≪ B). `FIXUP_LIMIT` bail-to-FastDivision semantics unchanged.
- Gates: power-of-two base, `BIGMATH_NTT_CRT`, `Q+n ≥ NTT_MULTIPLICATION_THRESHOLD`, cyclic length strictly below linear, `N ≤ 2^22` (CRT coefficient-sum headroom; below the MFA permuted regime).

## Results (M1 Max, paired back-to-back runs)

| case | base | cyclic | delta |
|---|---:|---:|---:|
| div 1M×200k digits | 34.9 ms | 31.1 ms | **−11%** |
| div 5M×1M digits | 206.1 ms | 184.9 ms | **−10%** |
| tostr 1M digits | 147.1 ms | 136.7 ms | **−7%** |
| tostr 200k digits | 21.3 ms | 20.4 ms | −4% |
| div 1M×1M (FastDivision path) | 0.226 ms | 0.223 ms | flat (not routed) |

## Testing

- 246/246 unit tests, `div_correctness` (all algorithms cross-checked, identity verified)
- ToString round-trips at 100k / 1M / 5M digits
- Focused stress harness at gate-active sizes: nb 2 600–16 000 limbs, ratios 1.5–15, all-max / sparse / zero-half adversarial patterns, `na = 2n`/`2n±1` boundaries, power-of-two cliffs — limb-for-limb vs FastDivision + `q·b + r == a`, `r < b`

`docs/DIVISION.md` gains a landed section; remaining wraparound headroom (CR product, `invertappr`-style reciprocal) documented as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)