### PR TITLE
perf: top-limbs quotient estimate in Newton DivideChunk (−20% at gate-active sizes)

### DIFF
--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -592,11 +592,42 @@ focused stress harness at gate-active sizes (nb 2 600–16 000 limbs, ratios 1.5
 sparse / zero-half adversarial patterns, `na = 2n`/`2n±1` boundaries, power-of-two cliffs) —
 cross-checked limb-for-limb against FastDivision plus the `q·b + r == a`, `r < b` identity.
 
-Remaining wraparound headroom (not yet taken): the same trick applies to `CR = chunk · R`
-(GMP's `mu_divappr` multiplies only the top `n+1` limbs of the chunk against the inverse with
-wraparound) and to the `T = D·R` / `RD = R·diff` products inside `ApproxReciprocal`
-(`invertappr`-style). Both need sharper error analysis than the QB case (the residue's "known
-high part" comes from the Newton invariant rather than an explicit `rem < b` bound).
+### Truncate the quotient-estimate product — top-limbs CR (LANDED 2026-06-11)
+
+The CR-side follow-up (GMP `mu_divappr` style): `CR = chunk · R` only feeds
+`Q = CR >> 2n`, and because `b_norm` is normalized (top bit set, `b ≥ B^n/2`) the bottom
+`chunk.size() − (n+1)` limbs of the chunk contribute under 1 ulp to Q
+(`c_lo / b < 2·B^(sh−n) ≤ 2/B`). `DivideChunk` therefore multiplies only the **top n+1 limbs**
+of the chunk against R — the product shrinks from `(chunk + R)` to `(n+1 + R)` limbs, halving
+the transform whenever the two sizes straddle a power-of-two boundary (`bit_ceil` gate; at
+sizes where both round to the same transform length the approximation is skipped entirely).
+
+The estimate underestimates Q by ≤ ~3 extra steps (floor truncations; same direction as the
+existing reciprocal error), absorbed by a relaxed fixup budget (12 on the approx attempt vs 8
+exact). Safety net: if the approx attempt ever blows its budget, `DivideChunk` retries once
+with the exact full product before falling back to FastDivision — the worst case is bounded at
+~1.4× a normal chunk, never quadratic.
+
+Measured (M1 Max, paired runs, on top of the cyclic-QB win above):
+
+| case | cyclic QB only | + top-limbs CR | delta |
+|---|---:|---:|---:|
+| div 3M / 600k digits | 90.2 ms | 72.3 ms | **−20%** |
+| div 5M / 1M digits | 187.6 ms | 149.7 ms | **−20%** |
+| tostr 1M digits | 138.5 ms | 122.7 ms | **−11%** |
+| div 1M / 200k digits | 30.9 ms | 30.8 ms | flat (gate off: equal `bit_ceil`) |
+
+The win lands on the ~1/3 of sizes (log-uniform) where `(3n+1)·c` and `(2n+2)·c` straddle a
+transform-length boundary; elsewhere the gate keeps the exact product and cost is unchanged.
+Verified with the same stress harness as the cyclic-QB change (gate-active divisor sizes,
+adversarial patterns, blockwise/single-block boundaries) plus `div_correctness`, 246 unit
+tests, and ToString round-trips at 100k/1M/5M digits.
+
+Remaining wraparound headroom (not yet taken): the `T = D·R` / `RD = R·diff` products inside
+`ApproxReciprocal` (`invertappr`-style). These need sharper error analysis (the residue's
+"known high part" comes from the Newton invariant rather than an explicit `rem < b` bound),
+and the reciprocal is computed once per `Divider` — amortized away in ToString workloads, so
+the win is confined to one-shot dispatch divides.
 
 ### Parallelize NTT — multithreading (LANDED, PR #32/#38/#39)
 

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -255,13 +255,15 @@ namespace BigMath
     // t < 0 lands in (M − 9·B^n, M) (≥ n+2 limbs). L ≥ n+2 by construction.
     //
     // Returns false if a fixup cap blows; caller falls back to FastDivision
-    // exactly like the plain path.
+    // exactly like the plain path. `fixupLimit` must stay ≪ B so the
+    // magnitude window (|t| < (fixupLimit+1)·b_norm < B^(n+1)) holds.
     static bool WrappedRemainder(
         vector<DataT> const &chunk,
         vector<DataT> const &b_norm,
         SizeT L,
         vector<DataT> &Q,
-        vector<DataT> &rem)
+        vector<DataT> &rem,
+        int fixupLimit)
     {
       SizeT n = (SizeT)b_norm.size();
       const DataT maxLimb = (CurrentBase == Base2_64) ? (DataT)~0ULL : (DataT)0xFFFFFFFFULL;
@@ -284,14 +286,13 @@ namespace BigMath
                                 ? Subtract(cm, W, CurrentBase)
                                 : Subtract(Add(cm, M, CurrentBase), W, CurrentBase);
 
-      const int FIXUP_LIMIT = 8;
       static const vector<DataT> one{1};
 
       // t < 0 (Q overestimated): rem_m ≈ M − |t|, which needs > n+1 limbs.
       int iters = 0;
       while (TrimmedSize(rem_m) > n + 1)
       {
-        if (++iters > FIXUP_LIMIT)
+        if (++iters > fixupLimit)
           return false;
         Q = Subtract(Q, one, CurrentBase);
         rem_m = Add(rem_m, b_norm, CurrentBase);
@@ -303,7 +304,7 @@ namespace BigMath
       iters = 0;
       while (Compare(rem_m, b_norm) >= 0)
       {
-        if (++iters > FIXUP_LIMIT)
+        if (++iters > fixupLimit)
           return false;
         rem_m = Subtract(rem_m, b_norm, CurrentBase);
         Q = Add(Q, one, CurrentBase);
@@ -311,6 +312,61 @@ namespace BigMath
 
       rem = std::move(rem_m);
       TrimZerosToOne(rem);
+      return true;
+    }
+
+    // Remainder + quotient fixups for one chunk: computes rem = chunk − Q·b_norm,
+    // adjusting Q until 0 ≤ rem < b_norm. Routes through the half-length cyclic
+    // product when the full Q·b_norm would be CRT-NTT-routed and the cyclic
+    // transform is strictly shorter; plain full product otherwise. Returns
+    // false when the fixup budget blows.
+    static bool RemainderAndFixups(
+        vector<DataT> const &chunk,
+        vector<DataT> const &b_norm,
+        vector<DataT> &Q,
+        vector<DataT> &rem,
+        int fixupLimit)
+    {
+      SizeT n = (SizeT)b_norm.size();
+
+#if BIGMATH_NTT_CRT
+      if ((CurrentBase == Base2_32 || CurrentBase == Base2_64) && !IsZero(Q))
+      {
+        SizeT c = (CurrentBase == Base2_64) ? 2 : 1;
+        ULong nCyc = std::bit_ceil((ULong)(n + 2) * c);
+        ULong nLinear = std::bit_ceil(((ULong)Q.size() + n) * c);
+        SizeT L = (SizeT)(nCyc / c);
+        if (Q.size() + n >= NTT_MULTIPLICATION_THRESHOLD &&
+            nCyc < nLinear && nCyc <= (1u << 22) &&
+            Q.size() <= L)
+          return WrappedRemainder(chunk, b_norm, L, Q, rem, fixupLimit);
+      }
+#endif
+
+      vector<DataT> &QB = Scratch().v2;
+      QB = Multiply(Q, b_norm, CurrentBase);
+
+      static const vector<DataT> one{1};
+
+      int iters = 0;
+      while (Compare(QB, chunk) > 0)
+      {
+        if (++iters > fixupLimit)
+          return false;
+        Q = Subtract(Q, one, CurrentBase);
+        QB = Subtract(QB, b_norm, CurrentBase);
+      }
+      rem = Subtract(chunk, QB, CurrentBase);
+
+      iters = 0;
+      while (Compare(rem, b_norm) >= 0)
+      {
+        if (++iters > fixupLimit)
+          return false;
+        rem = Subtract(rem, b_norm, CurrentBase);
+        Q = Add(Q, one, CurrentBase);
+      }
+
       return true;
     }
 
@@ -325,65 +381,62 @@ namespace BigMath
       auto &scratch = Scratch();
       vector<DataT> &CR = scratch.v0;
       vector<DataT> &Q = scratch.v1;
-      vector<DataT> &QB = scratch.v2;
 
-      // Q ≈ (chunk * R) >> (2n limbs)
-      CR = Multiply(chunk, R, CurrentBase);
-      if (CR.size() > 2 * n)
-        Q.assign(CR.begin() + 2 * n, CR.end());
-      else
-        Q.assign(1, 0);
-      TrimZerosToOne(Q);
-
-      // Remainder via half-length cyclic product when the full Q·b_norm would
-      // be CRT-NTT-routed and the cyclic transform is strictly shorter.
+      // Approximate quotient estimate from the TOP n+1 limbs of the chunk
+      // (GMP mu_divappr style). b_norm is normalized (top bit set, so
+      // b ≥ B^n/2), which bounds the dropped low limbs' contribution to Q by
+      // c_lo / b < 2·B^(sh−n) ≤ 2/B — under 1 ulp; with the floor truncations
+      // the estimate underestimates Q by ≤ ~3 extra steps, absorbed by the
+      // fixup loop. The product shrinks from (chunk + R) to (n+1 + R) limbs;
+      // gated on the smaller transform actually being shorter. If the relaxed
+      // fixup budget ever blows, retry once with the exact full product before
+      // falling back to FastDivision.
+      bool tryApprox = false;
 #if BIGMATH_NTT_CRT
-      if ((CurrentBase == Base2_32 || CurrentBase == Base2_64) && !IsZero(Q))
+      if ((CurrentBase == Base2_32 || CurrentBase == Base2_64) &&
+          chunk.size() > n + 1)
       {
         SizeT c = (CurrentBase == Base2_64) ? 2 : 1;
-        ULong nCyc = std::bit_ceil((ULong)(n + 2) * c);
-        ULong nLinear = std::bit_ceil(((ULong)Q.size() + n) * c);
-        SizeT L = (SizeT)(nCyc / c);
-        if (Q.size() + n >= NTT_MULTIPLICATION_THRESHOLD &&
-            nCyc < nLinear && nCyc <= (1u << 22) &&
-            Q.size() <= L)
-        {
-          vector<DataT> rem;
-          if (!WrappedRemainder(chunk, b_norm, L, Q, rem))
-            return {{}, {}, false};
-          TrimZerosToOne(Q);
-          return {Q, rem, true};
-        }
+        ULong nFull = std::bit_ceil(((ULong)chunk.size() + R.size()) * c);
+        ULong nTop = std::bit_ceil(((ULong)n + 1 + R.size()) * c);
+        tryApprox = (chunk.size() + R.size() >= NTT_MULTIPLICATION_THRESHOLD) &&
+                    nTop < nFull;
       }
 #endif
 
-      QB = Multiply(Q, b_norm, CurrentBase);
-
-      const int FIXUP_LIMIT = 8;
-      static const vector<DataT> one{1};
-
-      int iters = 0;
-      while (Compare(QB, chunk) > 0)
+      for (int attempt = tryApprox ? 0 : 1; attempt < 2; ++attempt)
       {
-        if (++iters > FIXUP_LIMIT)
-          return {{}, {}, false};
-        Q = Subtract(Q, one, CurrentBase);
-        QB = Subtract(QB, b_norm, CurrentBase);
+        SizeT drop = 2 * n;
+        if (attempt == 0)
+        {
+          SizeT sh = (SizeT)chunk.size() - (n + 1);
+          vector<DataT> c_top(chunk.begin() + sh, chunk.end());
+          CR = Multiply(c_top, R, CurrentBase);
+          drop = 2 * n - sh;
+        }
+        else
+        {
+          // Q ≈ (chunk * R) >> (2n limbs)
+          CR = Multiply(chunk, R, CurrentBase);
+        }
+
+        if (CR.size() > drop)
+          Q.assign(CR.begin() + drop, CR.end());
+        else
+          Q.assign(1, 0);
+        TrimZerosToOne(Q);
+
+        vector<DataT> rem;
+        if (RemainderAndFixups(chunk, b_norm, Q, rem, attempt == 0 ? 12 : 8))
+        {
+          TrimZerosToOne(Q);
+          TrimZerosToOne(rem);
+          return {Q, rem, true};
+        }
+        // Approx attempt blew its budget — retry once with the exact product.
       }
-      vector<DataT> rem = Subtract(chunk, QB, CurrentBase);
 
-      iters = 0;
-      while (Compare(rem, b_norm) >= 0)
-      {
-        if (++iters > FIXUP_LIMIT)
-          return {{}, {}, false};
-        rem = Subtract(rem, b_norm, CurrentBase);
-        Q = Add(Q, one, CurrentBase);
-      }
-
-      TrimZerosToOne(Q);
-
-      return {Q, rem, true};
+      return {{}, {}, false};
     }
 
     static pair<vector<DataT>, vector<DataT>> DivideNormalizedWithReciprocal(


### PR DESCRIPTION
## What

Third wraparound-family lever (follows #85's cyclic QB): GMP `mu_divappr`-style truncated quotient estimate.

`CR = chunk·R` in `DivideChunk` only feeds `Q = CR >> 2n`. With the divisor normalized (`b ≥ B^n/2`), the bottom `chunk.size()−(n+1)` limbs of the chunk contribute under 1 ulp to Q (`c_lo/b < 2/B`). So multiply only the **top n+1 limbs** of the chunk against R: the product shrinks from `(chunk+R)` to `(n+1+R)` limbs — halving the transform length whenever the two straddle a power-of-two boundary.

## Safety design

- **Error**: estimate underestimates Q by ≤ ~3 extra steps (floor truncations, same direction as the existing reciprocal error). Approx attempt runs with fixup budget 12 (vs 8 exact); the wrapped-remainder sign-window stays sound (`13·b < B^(n+1)`).
- **No perf cliff**: if the approx attempt blows its budget, `DivideChunk` retries once with the exact full product before the FastDivision fallback — worst case ~1.4× a normal chunk, never quadratic.
- **No-regression gate**: `bit_ceil` comparison skips the approximation when both products round to the same transform length (then it would save nothing and cost a slice).
- Fixup/remainder logic extracted into `RemainderAndFixups`, shared by both attempts.

## Results (M1 Max, paired runs, on top of #85)

| case | cyclic QB only | + top-limbs CR | delta |
|---|---:|---:|---:|
| div 3M×600k digits | 90.2 ms | 72.3 ms | **−20%** |
| div 5M×1M digits | 187.6 ms | 149.7 ms | **−20%** |
| tostr 1M digits | 138.5 ms | 122.7 ms | **−11%** |
| div 1M×200k digits | 30.9 ms | 30.8 ms | flat (gate off: equal bit_ceil) |

Win lands on the ~1/3 of sizes (log-uniform) where the transform-length boundary is straddled; elsewhere the gate keeps the exact product, cost unchanged. Cumulative for the session at 5M×1M: 206 → 150 ms (−27%).

## Testing

- 246/246 unit tests, `div_correctness` (all cross-checks + identity)
- ToString round-trips at 100k / 1M / 5M digits
- Gate-active stress harness: nb 2 600–16 000 limbs, ratios 1.5–15, all-max / sparse / zero-half patterns, `na = 2n`/`2n±1` and power-of-two boundaries — limb-for-limb vs FastDivision + `q·b + r == a`, `r < b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)