### PR TITLE
perf: invertappr-style wrapped Newton iteration in ApproxReciprocal (−24% one-shot div)

### DIFF
--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -623,11 +623,48 @@ Verified with the same stress harness as the cyclic-QB change (gate-active divis
 adversarial patterns, blockwise/single-block boundaries) plus `div_correctness`, 246 unit
 tests, and ToString round-trips at 100k/1M/5M digits.
 
-Remaining wraparound headroom (not yet taken): the `T = D·R` / `RD = R·diff` products inside
-`ApproxReciprocal` (`invertappr`-style). These need sharper error analysis (the residue's
-"known high part" comes from the Newton invariant rather than an explicit `rem < b` bound),
-and the reciprocal is computed once per `Divider` — amortized away in ToString workloads, so
-the win is confined to one-shot dispatch divides.
+### Wrapped Newton iteration in `ApproxReciprocal` — invertappr style (LANDED 2026-06-11)
+
+The third wraparound lever, closing the family: the reciprocal's own doubling iterations.
+Algebra: with `E = B^(2m) − D_new·R_pad`, the exact step
+`R_new = (R_pad·(2B^(2m) − D_new·R_pad)) >> 2m` decomposes exactly into
+`R_new = R_pad + floor(R_pad·E / B^(2m))`. The seed is accurate to ~`cur` limbs, so `|E|` is
+known-small — which buys two structural cuts per iteration:
+
+1. **E recovered exactly from a cyclic residue.** `(D_new·R_pad) mod (B^L − 1)` at
+   `L ≈ 2m − cur` instead of the full `2m+1`-limb product (`T`). At the high-precision
+   extra-refine iteration (`cur = m`) the cyclic transform is **half** the linear length.
+   Sign read from residue magnitude, same window argument as `WrappedRemainder`.
+2. **Correction from top slices only.** `floor(R_pad·E / B^(2m))` has only `m − cur`
+   significant limbs; top slices of `R_pad` and `E` (20-limb guards) replace the full
+   `(m+1)×(2m+1)` `RD` product with a `(m−cur)`-sized one. Dropped tails stay sub-ulp.
+
+**The bug that cost a debugging round:** the sign/validity window was first sized at
+`B^4` headroom over the theoretical `|E| < ε·B^(2m−cur)` bound, assuming `ε` (the seed's
+ulp error) stays at a few units. It does not — **the exact-path tower itself leaves R off
+by up to ~`B^6` ulps** (integer-rounding drift accumulating through the doublings; the same
+slack the `high_precision` extra iteration exists to heal). The too-tight window
+misclassified E's sign at the second wrapped step, the then-clamp froze R at stale
+precision, and every downstream `DivideChunk` blew its fixup budget → FastDivision fallback
+on every ToString chain divide (8× regression, reproduced with a `10^500000` divisor).
+Fixes: window headroom `B^16`, slice guards widened to match (20 limbs), and out-of-window
+now falls back to the exact iteration for that step instead of clamping.
+
+Measured (M1 Max, paired runs, on top of the two levers above; one-shot divides are where
+the reciprocal isn't amortized):
+
+| case | before | after | delta |
+|---|---:|---:|---:|
+| div 1M / 200k digits | 30.7 ms | 23.4 ms | **−24%** |
+| div 3M / 600k digits | 71.7 ms | 54.6 ms | **−24%** |
+| div 5M / 1M digits | 148.2 ms | 110.7 ms | **−25%** |
+| tostr 1M digits | 122.0 ms | 117.3 ms | −4% (Divider reciprocal mostly amortized) |
+| `Divider` ctor, 10^500000 divisor | 38.9 ms | 27.8 ms | −29% |
+
+Session cumulative on div 5M/1M: 206 → 111 ms (**−46%**). Verified: 246 unit tests,
+`div_correctness`, ToString round-trips (100k/1M/5M digits), the gate-active stress harness,
+plus a dedicated Pow10-divisor suite (10^60k…10^800k at ratios 1.7/2.0/3.1 — the shape that
+exposed the window bug) cross-checked against FastDivision.
 
 ### Parallelize NTT — multithreading (LANDED, PR #32/#38/#39)
 

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -192,34 +192,131 @@ namespace BigMath
         // D_new = top new_n limbs of D.
         D_new.assign(D.begin() + (n - new_n), D.end());
 
-        // T = D_new * R_pad
-        T = Multiply(D_new, R_pad, CurrentBase);
+        // Wrapped iteration (invertappr style). Algebra: with
+        // E = B^(2m) − D_new·R_pad, the exact step
+        //   R_new = (R_pad · (2·B^(2m) − D_new·R_pad)) >> 2m
+        // decomposes EXACTLY into R_new = R_pad + floor(R_pad·E / B^(2m)).
+        // The seed is accurate to cur_n limbs, so |E| < ~B^(2m − cur_n + 1):
+        //   (1) E is recovered exactly from the residue (D_new·R_pad) mod
+        //       (B^L − 1) at L ≈ 2m − cur_n — a cyclic transform SHORTER than
+        //       the full 2m+1-limb product (half at the extra-refine iter,
+        //       where cur_n = m). Sign read from residue magnitude, same
+        //       window argument as WrappedRemainder.
+        //   (2) the correction floor(R_pad·E / B^(2m)) has only m − cur_n + 1
+        //       significant limbs, so only the top limbs of R_pad and E
+        //       contribute — a (m−cur)×(m−cur)-ish product instead of the
+        //       (m+1)×(2m+1) full RD. Truncation costs ≤ ~3 ulp, absorbed by
+        //       Newton's quadratic self-correction (non-final iters) or the
+        //       DivideChunk fixup budget (final iter).
+        bool wrappedIter = false;
+#if BIGMATH_NTT_CRT
+        if (CurrentBase == Base2_32 || CurrentBase == Base2_64)
+        {
+          SizeT m = new_n;
+          SizeT c = (CurrentBase == Base2_64) ? 2 : 1;
+          SizeT Lmin = 2 * m - cur_n + 16;
+          ULong nCyc = std::bit_ceil((ULong)(Lmin + 1) * c);
+          ULong nLin = std::bit_ceil(((ULong)D_new.size() + R_pad.size()) * c);
+          SizeT L = (SizeT)(nCyc / c);
+          if (D_new.size() + R_pad.size() >= NTT_MULTIPLICATION_THRESHOLD &&
+              nCyc < nLin && nCyc <= (1u << 22) &&
+              D_new.size() <= L && R_pad.size() <= L)
+          {
+            wrappedIter = true;
 
-        // diff = 2*B^(2*new_n) - T  (should be ≥ 0 for valid seeds).
-        two_S.assign(2 * new_n + 1, 0);
-        two_S[2 * new_n] = 2;
+            vector<DataT> W = NTTMultiplication::MultiplyMod2km1(D_new, R_pad, L, CurrentBase);
 
-        if (Compare(two_S, T) >= 0)
-        {
-          diff = Subtract(two_S, T, CurrentBase);
-        }
-        else
-        {
-          // R was over-estimate; shouldn't normally trigger. Clamp to 0.
-          diff.assign(1, 0);
-        }
+            const DataT maxLimb = (CurrentBase == Base2_64) ? (DataT)~0ULL : (DataT)0xFFFFFFFFULL;
+            const vector<DataT> M(L, maxLimb); // B^L − 1
 
-        // R_new = (R_pad * diff) >> (32 * 2 * new_n)
-        RD = Multiply(R_pad, diff, CurrentBase);
-        if (RD.size() > 2 * new_n)
-        {
-          R.assign(RD.begin() + 2 * new_n, RD.end());
+            // E = (B^(2m) − W) mod M; B^(2m) ≡ B^(2m mod L).
+            SizeT r_exp = (SizeT)((2 * (ULong)m) % L);
+            vector<DataT> Br(r_exp + 1, 0);
+            Br[r_exp] = 1;
+            vector<DataT> E = (Compare(Br, W) >= 0)
+                                  ? Subtract(Br, W, CurrentBase)
+                                  : Subtract(Add(Br, M, CurrentBase), W, CurrentBase);
+
+            // Sign window: E ≥ 0 lands below B^Lmin, E < 0 lands within
+            // B^Lmin of M. (L ≥ Lmin + 1 by construction of nCyc.)
+            bool eNeg = (TrimmedSize(E) > Lmin);
+            if (eNeg)
+              E = Subtract(M, E, CurrentBase); // |E|
+            if (TrimmedSize(E) > Lmin)
+            {
+              // Seed drift exceeds the window — can't trust the sign read.
+              // Run this step through the exact path instead.
+              wrappedIter = false;
+            }
+
+            if (wrappedIter)
+            {
+              // C = floor(R_pad·E / B^(2m)) from top slices only. Slice
+              // guards (20 limbs) sized to the B^16 drift window so the
+              // dropped tails stay sub-ulp.
+              SizeT xl = (cur_n > 20 && cur_n - 20 < (SizeT)R_pad.size()) ? cur_n - 20 : 0;
+              SizeT el = (m > 20) ? m - 20 : 0;
+              vector<DataT> C{0};
+              if (!IsZero(E) && TrimmedSize(E) > el)
+              {
+                vector<DataT> Xt(R_pad.begin() + xl, R_pad.end());
+                vector<DataT> Et(E.begin() + el, E.end());
+                vector<DataT> P = Multiply(Xt, Et, CurrentBase);
+                SizeT back = 2 * m - xl - el;
+                if (P.size() > back)
+                  C.assign(P.begin() + back, P.end());
+              }
+
+              if (!eNeg)
+              {
+                R = Add(R_pad, C, CurrentBase);
+              }
+              else
+              {
+                // Subtract with a +2 guard so R keeps the underestimate
+                // invariant despite the truncated (under-counted) correction.
+                static const vector<DataT> two{2};
+                vector<DataT> adj = Add(C, two, CurrentBase);
+                R = (Compare(R_pad, adj) >= 0) ? Subtract(R_pad, adj, CurrentBase)
+                                               : vector<DataT>{0};
+              }
+              TrimZerosToOne(R);
+            }
+          }
         }
-        else
+#endif
+
+        if (!wrappedIter)
         {
-          R = vector<DataT>{0};
+          // T = D_new * R_pad
+          T = Multiply(D_new, R_pad, CurrentBase);
+
+          // diff = 2*B^(2*new_n) - T  (should be ≥ 0 for valid seeds).
+          two_S.assign(2 * new_n + 1, 0);
+          two_S[2 * new_n] = 2;
+
+          if (Compare(two_S, T) >= 0)
+          {
+            diff = Subtract(two_S, T, CurrentBase);
+          }
+          else
+          {
+            // R was over-estimate; shouldn't normally trigger. Clamp to 0.
+            diff.assign(1, 0);
+          }
+
+          // R_new = (R_pad * diff) >> (32 * 2 * new_n)
+          RD = Multiply(R_pad, diff, CurrentBase);
+          if (RD.size() > 2 * new_n)
+          {
+            R.assign(RD.begin() + 2 * new_n, RD.end());
+          }
+          else
+          {
+            R = vector<DataT>{0};
+          }
+          TrimZerosToOne(R);
         }
-        TrimZerosToOne(R);
 
         cur_n = new_n;
       }


### PR DESCRIPTION
## What

Final lever in the wraparound family (#85 cyclic QB → #86 top-limbs CR → this): the reciprocal's own Newton doubling iterations.

With `E = B^(2m) − D_new·R_pad`, the exact step decomposes into `R_new = R_pad + floor(R_pad·E / B^(2m))`. The seed is accurate to ~cur limbs, so |E| is known-small:

1. **E exact from a cyclic residue** — `(D_new·R_pad) mod (B^L−1)` at `L ≈ 2m−cur` instead of the full `2m+1`-limb `T` product. Half the transform length at the high-precision extra-refine (`cur = m`).
2. **Correction from top slices** — `floor(R_pad·E/B^(2m))` has only `m−cur` significant limbs; 20-limb-guarded top slices of `R_pad`/`E` replace the `(m+1)×(2m+1)` `RD` product with a `(m−cur)`-sized one (dropped tails sub-ulp).

## The interesting bug

First version sized the sign/validity window at `B^4` headroom assuming the seed error stays at a few ulps. **It doesn't: the exact-path tower itself drifts up to ~`B^6` ulps** (the very slack `high_precision` exists to heal). The tight window misclassified E's sign mid-tower → clamp froze R at stale precision → every ToString chain divide blew its fixup budget → FastDivision fallback (8× regression on 1M-digit ToString, reproduced with a `10^500000` divisor). Final design: `B^16` window headroom, matching slice guards, and out-of-window falls back to the **exact iteration** for that step instead of clamping. The drift fact is now documented in DIVISION.md.

## Results (M1 Max, paired; one-shot divides — where the reciprocal isn't amortized)

| case | before | after | delta |
|---|---:|---:|---:|
| div 1M×200k digits | 30.7 ms | 23.4 ms | **−24%** |
| div 3M×600k digits | 71.7 ms | 54.6 ms | **−24%** |
| div 5M×1M digits | 148.2 ms | 110.7 ms | **−25%** |
| tostr 1M digits | 122.0 ms | 117.3 ms | −4% (Divider amortizes) |
| Divider ctor, 10^500000 | 38.9 ms | 27.8 ms | −29% |

**Session cumulative (PRs #82–#86 + this) on div 5M×1M: 206 → 111 ms (−46%).**

## Testing

- 246/246 unit tests, `div_correctness`
- ToString round-trips at 100k / 1M / 5M digits
- Gate-active stress harness (nb 2 600–16 000 limbs, ratios 1.5–15, adversarial patterns, boundary shapes)
- New Pow10-divisor suite: `10^60k…10^800k` at ratios 1.7/2.0/3.1 — the shape that exposed the window bug — all cross-checked limb-for-limb vs FastDivision

🤖 Generated with [Claude Code](https://claude.com/claude-code)