### PR TITLE
bench: record post-#82–#89 benchsuite run; annotate two bad runs

### DIFF
--- a/tests/performance/benchsuite/HISTORY.md
+++ b/tests/performance/benchsuite/HISTORY.md
@@ -17,3 +17,31 @@ Lower ratio is better (BigMath ms / GMP ms). Rows are the entries flagged
 |----|------|-----------:|-------:|-------:|:-----:|
 | mul | 10000x10000 digits | 0.231 | 0.030 | 7.76x | ok |
 | div | 40000x10000 digits | 1.545 | 0.232 | 6.65x | ok |
+
+## run 1 — machine=Apple_M1_Max_arm64 profile=default
+
+| op | size | BigMath ms | GMP ms | BM/GMP | check |
+|----|------|-----------:|-------:|-------:|:-----:|
+| mul | 1000000x1000000 digits | 10.682 | 8.716 | 1.23x | ok |
+| div | 1000000x200000 digits | 34.660 | 10.367 | 3.34x | ok |
+
+## run 2 — machine=Apple_M1_Max_arm64 profile=default — DISCARD (ambient load avg 6–8; all BigMath rows ~2.3× inflated incl. untouched mul)
+
+| op | size | BigMath ms | GMP ms | BM/GMP | check |
+|----|------|-----------:|-------:|-------:|:-----:|
+| mul | 1000000x1000000 digits | 24.396 | 8.716 | 2.80x | ok |
+| div | 1000000x200000 digits | 58.367 | 10.367 | 5.63x | ok |
+
+## run 3 — machine=Apple_M1_Max_arm64 profile=default — DISCARD (stale cached run_bigmath binary from before PRs #82–#89; measured pre-session code)
+
+| op | size | BigMath ms | GMP ms | BM/GMP | check |
+|----|------|-----------:|-------:|-------:|:-----:|
+| mul | 1000000x1000000 digits | 10.816 | 8.716 | 1.24x | ok |
+| div | 1000000x200000 digits | 33.872 | 10.367 | 3.27x | ok |
+
+## run 4 — machine=Apple_M1_Max_arm64 profile=default — post PRs #82–#89 (FastDiv shift-norm, D&C thresholds, wraparound Newton family, balanced band 4/3 + quotient-sized division)
+
+| op | size | BigMath ms | GMP ms | BM/GMP | check |
+|----|------|-----------:|-------:|-------:|:-----:|
+| mul | 1000000x1000000 digits | 10.641 | 8.716 | 1.22x | ok |
+| div | 1000000x200000 digits | 22.706 | 10.367 | 2.19x | ok |


### PR DESCRIPTION
Records run 4 (first clean default-profile run on the merged session work) and marks runs 2/3 DISCARD with the reason inline — run 2 was load-poisoned (~2.3× inflation incl. untouched mul), run 3 silently reused a stale cached `run_bigmath` binary predating the changes. Both look plausible in isolation; the annotations prevent them being read as regressions/baselines later.

| op | run 1 (pre) | run 4 (post) | BM/GMP |
|---|---:|---:|---|
| div 1M×1M | 0.352 ms | **0.152 ms** | 10.0× → 4.3× |
| div 1M×200k | 34.7 ms | **22.7 ms** | 3.34× → 2.19× |
| tostr 1M | 232 ms | **172 ms** | 4.56× → 3.36× |
| parse 1M | 50.0 ms | **43.7 ms** | 2.33× → 2.04× |
| mul 1M×1M | 10.68 ms | 10.64 ms | 1.22× (untouched) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)