### PR TITLE
perf: retune Newton medium band (5/2 @ 2560) + new 8/5 ratio band @ 6144

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ CI (`.github/workflows/qa.yaml`) runs `nanoclaw-task qa-agent` on PRs against `o
 
 **Division dispatch** (`algorithms/Division.h`, thresholds defined in `src/algorithms/Division.cpp`):
 - `NewtonDivision` (Newton-Raphson reciprocal, O(M(n)); handles arbitrary `na/nb` via blockwise mode — top chunk in [n+1, 2n], slide down by n, thread the remainder) when any skew band holds:
-  - `b ≥ 4096` at ratio ≥ 3 (`NEWTON_SKEW` 3/1), or
+  - `b ≥ 2560` at ratio ≥ 5/2 (`NEWTON_SKEW` — lowered from 4096 @ 3/1 on 2026-06-11), or
+  - `b ≥ 6144` at ratio ≥ 8/5 (`NEWTON_RATIO2`, added 2026-06-11), or
   - `b ≥ 24576` at ratio ≥ 4/3 (`NEWTON_BALANCED` — near-balanced band; ratio lowered from 2/1 and floor from 98304 on 2026-06-11), or
   - `b ≥ 2048` at ratio ≥ 8 (`NEWTON_HIGH_SKEW` 8/1).
 - `QuotientSizedDivision` when `b ≥ 24576`, `a ≥ b + 64`, and ratio < 4/3: divides the operand TOPS (`t = Δ+4` limbs of b, `Δ+t` of a) for the (Δ+1)-limb quotient, then one Δ×nb back-multiply for the remainder — cost scales with the quotient, not the divisor.

--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -62,7 +62,7 @@ flowchart TD
     C -- no --> D{Compare&#40;a, b&#41;}
     D -- a == b --> Eq[return &#123;1, 0&#125;]
     D -- a &lt; b --> Less[return &#123;0, a&#125;]
-    D -- a &gt; b --> E{Newton band?<br/>b ≥ 4096 and a ≥ 3b<br/>OR b ≥ 24576 and 3a ≥ 4b<br/>OR b ≥ 2048 and a ≥ 8b}
+    D -- a &gt; b --> E{Newton band?<br/>b ≥ 2560 and 2a ≥ 5b<br/>OR b ≥ 6144 and 5a ≥ 8b<br/>OR b ≥ 24576 and 3a ≥ 4b<br/>OR b ≥ 2048 and a ≥ 8b}
     E -- yes --> N[NewtonDivision]
     E -- no --> F{Power-of-two base<br/>AND b.size &gt; 512<br/>AND BZ shape fits?}
     F -- yes --> BZ[BurnikelZieglerDivision]
@@ -106,6 +106,18 @@ The current dispatch logic, paraphrased:
 The ordering matters: Newton wins on **large skewed** problems because the per-divisor reciprocal setup amortizes over multiple chunks. BZ wins on **mid-size near-balanced** problems where its 2n/n recursion structure beats both FastDivision and Newton's setup cost.
 
 **Near-balanced band (PR #79; ratio lowered to 4/3 and floor to 24576 limbs on 2026-06-11).** Above `NEWTON_BALANCED_B` (24576 limbs), ratio-≥-4/3 division goes to Newton instead of BZ. BZ's recursive 2n/n halving lands its intermediate NTT multiplies just over power-of-2 transform-length boundaries for non-power-of-2 divisor sizes — the FFT length doubles and the constant factor compounds across recursion depth into a **5–60× slowdown vs Newton**, worst at `n = 2^k + 1` (measured ~90 s for a 262145-limb divisor vs Newton's ~0.9 s). Newton pads once to the working size and stays flat. Exact-power-of-2 divisor sizes are BZ's best case (it ties Newton); they regress ~4 % under this band but are rare in practice. **Band re-measured 2026-06-11** after the wraparound-Newton PRs (#85–#87) cut Newton's constant: the generic BZ/Newton crossover moved from ratio ~2 down to ~1.3 at large b, and the size floor from ~100k down to ~24k limbs (ratio-1.4 crossover ≈ 24k limbs; ratio-2 crossover ≈ 6k). Band lowered `2/1 → 4/3` and `NEWTON_BALANCED_B` `98304 → 24576`. The former ratio ∈ (1, 4/3) residual is closed by **QuotientSizedDivision** (see below). FastDivision is the default workhorse for everything else.
+
+**Medium/ratio-2 band retune (2026-06-11, follow-up to the 4/3 band).** Post-#85–#87 re-measurement
+moved the Newton/BZ crossovers down across the board: `NEWTON_MEDIUM_B` 4096 → 2560 with ratio
+3/1 → **5/2**, plus a new `NEWTON_RATIO2` band (`b ≥ 6144`, ratio ≥ **8/5**). The fractional
+ratios are deliberate cliff-avoidance: digit-derived operands land at limb ratios like
+2.0000 ± 1 limb or 3.0000 ± 1 limb, and the BZ side of a knife-edge `2/1` or `3/1` predicate
+blows up 8–12× on non-power-of-2 divisor sizes (measured: 15578×5193 limbs BZ 69 ms vs Newton
+9 ms; 20785×10393 BZ 139 ms vs Newton 12 ms — both shapes sat one limb below the old bands).
+End-to-end: 200k×50k digits 6.65× → 3.36× vs GMP; 300k×100k 24.6× → 3.07×; 400k×200k
+20.7× → 3.57×. Known residual: ratio ∈ (1, 8/5) at `b ∈ (512, 24576)` stays BZ — generically
+correct (BZ wins those crossovers) but non-pow2 pathology there remains; fixing it needs the
+quotient-sized band extended below 24576 with fresh crossover data.
 
 **Short-quotient band (`QuotientSizedDivision`, 2026-06-11).** For `b ≥ NEWTON_BALANCED_B`, `a ≥ b + 64`, ratio < 4/3: with Δ = a.size − b.size and t = Δ+4, the (Δ+1)-limb quotient is determined to ±a few units by the operand TOPS — `q_est = floor((a >> B^(nb−t)) / (b >> B^(nb−t)))` (truncating b perturbs q by ≤ ~B^(2−GUARD), sub-ulp). The tops divide (ratio ~2, size ~2Δ/Δ) goes to Newton directly at t ≥ 6144 (measured: Newton beats BZ at ratio 2 from ~6k limbs — 13 vs 22 ms at 12k, 40 vs 299 ms at 30k, 0.16 s vs 5.3 s at 65537); the exact remainder then costs one Δ×nb back-multiply plus ±few fixups (cap 8, fallback Newton). Cost scales with the **quotient**, not the divisor. Measured (nb=131073, the 2^k+1 pathology): ratios 1.05/1.10/1.25 went from 1.07 s / 2.16 s / 5.35 s (BZ) to **28 / 43 / 71 ms** (38–75×). Generic nb=120000: 37/56/116 ms → 30/39/66 ms. It also beats BZ at BZ's exact-power-of-2 best case (131072 @1.25: 65 vs 88 ms) — no regression band.
 

--- a/include/biginteger/algorithms/Division.h
+++ b/include/biginteger/algorithms/Division.h
@@ -4,7 +4,8 @@
  * Dispatch order:
  *   1. NewtonDivision (blockwise handles arbitrary ratio via reciprocal cache),
  *      when any of these skew bands hold:
- *        - b ≥ NEWTON_MEDIUM_B    AND  a ≥ NEWTON_SKEW (3/1)          · b
+ *        - b ≥ NEWTON_MEDIUM_B    AND  a ≥ NEWTON_SKEW (5/2)          · b
+ *        - b ≥ NEWTON_RATIO2_B    AND  a ≥ NEWTON_RATIO2 (8/5)        · b
  *        - b ≥ NEWTON_BALANCED_B  AND  a ≥ NEWTON_BALANCED (4/3)      · b
  *        - b ≥ NEWTON_HIGH_SKEW_B AND  a ≥ NEWTON_HIGH_SKEW (8/1)     · b
  *      The balanced (ratio ≥ 4/3) band starts at 24k limbs — the generic
@@ -41,7 +42,23 @@
 namespace BigMath
 {
 #ifndef BIGMATH_NEWTON_MEDIUM_B
-#define BIGMATH_NEWTON_MEDIUM_B 4096
+#define BIGMATH_NEWTON_MEDIUM_B 2560
+#endif
+
+// Ratio-≥8/5 band. Sits between the medium (3/1) and balanced (4/3) bands:
+// post-#85-87 Newton beats BZ at ratio 2 from ~6k limbs (measured 9.0 vs
+// 9.9 ms at 6000, 13 vs 22 ms at 12000, 24 vs 49 ms at 24000) and ties from
+// ratio ~1.6. 8/5 rather than 2/1 because digit-derived operands sit at limb
+// ratios like 2.0000 ± 1 limb and BZ blows up 8-12× on non-pow2 divisor
+// sizes right across that edge.
+#ifndef BIGMATH_NEWTON_RATIO2_B
+#define BIGMATH_NEWTON_RATIO2_B 6144
+#endif
+#ifndef BIGMATH_NEWTON_RATIO2_NUMERATOR
+#define BIGMATH_NEWTON_RATIO2_NUMERATOR 8
+#endif
+#ifndef BIGMATH_NEWTON_RATIO2_DENOMINATOR
+#define BIGMATH_NEWTON_RATIO2_DENOMINATOR 5
 #endif
 
 #ifndef BIGMATH_BZ_DIVISOR_THRESHOLD
@@ -49,11 +66,11 @@ namespace BigMath
 #endif
 
 #ifndef BIGMATH_NEWTON_SKEW_NUMERATOR
-#define BIGMATH_NEWTON_SKEW_NUMERATOR 3
+#define BIGMATH_NEWTON_SKEW_NUMERATOR 5
 #endif
 
 #ifndef BIGMATH_NEWTON_SKEW_DENOMINATOR
-#define BIGMATH_NEWTON_SKEW_DENOMINATOR 1
+#define BIGMATH_NEWTON_SKEW_DENOMINATOR 2
 #endif
 
 #ifndef BIGMATH_NEWTON_BALANCED_B
@@ -85,6 +102,9 @@ namespace BigMath
 #endif
 
   extern const SizeT NEWTON_MEDIUM_B;
+  extern const SizeT NEWTON_RATIO2_B;
+  extern const SizeT NEWTON_RATIO2_NUMERATOR;
+  extern const SizeT NEWTON_RATIO2_DENOMINATOR;
   extern const SizeT BZ_DIVISOR_THRESHOLD;
   extern const SizeT NEWTON_SKEW_NUMERATOR;
   extern const SizeT NEWTON_SKEW_DENOMINATOR;

--- a/include/biginteger/build/DispatchThresholds.h
+++ b/include/biginteger/build/DispatchThresholds.h
@@ -62,15 +62,33 @@
 #endif
 
 #ifndef BIGMATH_NEWTON_MEDIUM_B
-#define BIGMATH_NEWTON_MEDIUM_B 4096
+#define BIGMATH_NEWTON_MEDIUM_B 2560
 #endif
 
+// Ratio-≥8/5 Newton band between the medium (3/1) and balanced (4/3) bands.
+// 8/5 instead of a knife-edge 2/1: digit-derived operands land at limb ratios
+// like 2.0000 ± 1 limb, and the BZ side of the edge blows up 8-12× on
+// non-power-of-2 divisor sizes; Newton generic-ties BZ from ratio ~1.6 here.
+#ifndef BIGMATH_NEWTON_RATIO2_B
+#define BIGMATH_NEWTON_RATIO2_B 6144
+#endif
+#ifndef BIGMATH_NEWTON_RATIO2_NUMERATOR
+#define BIGMATH_NEWTON_RATIO2_NUMERATOR 8
+#endif
+#ifndef BIGMATH_NEWTON_RATIO2_DENOMINATOR
+#define BIGMATH_NEWTON_RATIO2_DENOMINATOR 5
+#endif
+
+// 5/2 rather than 3/1: digit-derived operands land at limb ratios like
+// 3.0000 ± 1 limb, and BZ blows up ~7× on non-pow2 divisor sizes across
+// that edge (15578×5193 limbs: BZ 69 ms vs Newton 9 ms). Newton wins from
+// ratio ~2.5 at b ≥ 2560 (near-tie at 2600, clear by 4096).
 #ifndef BIGMATH_NEWTON_SKEW_NUMERATOR
-#define BIGMATH_NEWTON_SKEW_NUMERATOR 3
+#define BIGMATH_NEWTON_SKEW_NUMERATOR 5
 #endif
 
 #ifndef BIGMATH_NEWTON_SKEW_DENOMINATOR
-#define BIGMATH_NEWTON_SKEW_DENOMINATOR 1
+#define BIGMATH_NEWTON_SKEW_DENOMINATOR 2
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_B

--- a/src/algorithms/Division.cpp
+++ b/src/algorithms/Division.cpp
@@ -12,6 +12,9 @@
 namespace BigMath
 {
   const SizeT NEWTON_MEDIUM_B = BIGMATH_NEWTON_MEDIUM_B;
+  const SizeT NEWTON_RATIO2_B = BIGMATH_NEWTON_RATIO2_B;
+  const SizeT NEWTON_RATIO2_NUMERATOR = BIGMATH_NEWTON_RATIO2_NUMERATOR;
+  const SizeT NEWTON_RATIO2_DENOMINATOR = BIGMATH_NEWTON_RATIO2_DENOMINATOR;
   const SizeT BZ_DIVISOR_THRESHOLD = BIGMATH_BZ_DIVISOR_THRESHOLD;
   const SizeT NEWTON_SKEW_NUMERATOR = BIGMATH_NEWTON_SKEW_NUMERATOR;
   const SizeT NEWTON_SKEW_DENOMINATOR = BIGMATH_NEWTON_SKEW_DENOMINATOR;
@@ -58,7 +61,11 @@ namespace BigMath
     bool newton_high_skew =
         b.size() >= NEWTON_HIGH_SKEW_B &&
         NEWTON_HIGH_SKEW_DENOMINATOR * a.size() >= NEWTON_HIGH_SKEW_NUMERATOR * b.size();
-    bool newton_eligible = newton_medium_skew || newton_balanced || newton_high_skew;
+    // Ratio-≥8/5 band between medium (3/1 @ 2560) and balanced (4/3 @ 24576).
+    bool newton_ratio2 =
+        b.size() >= NEWTON_RATIO2_B &&
+        NEWTON_RATIO2_DENOMINATOR * a.size() >= NEWTON_RATIO2_NUMERATOR * b.size();
+    bool newton_eligible = newton_medium_skew || newton_balanced || newton_high_skew || newton_ratio2;
     if (newton_eligible)
       return NewtonDivision::DivideAndRemainder(a, b, base, computeRemainder);
 


### PR DESCRIPTION
## What

Closes the last item from today's plan: the 200k×50k worst point (6.65× vs GMP) plus two knife-edge cliffs found while fixing it.

- `NEWTON_MEDIUM_B` 4096 → 2560, ratio 3/1 → **5/2**
- New `NEWTON_RATIO2` band: b ≥ 6144 limbs, ratio ≥ **8/5**
- Values set in `DispatchThresholds.h` (the canonical override point — a first attempt edited only Division.h's `#ifndef` fallbacks, which the build never used)

## Why fractional ratios

Digit-derived operands land at limb ratios like 2.0000 ± 1 limb. With a knife-edge `2/1`/`3/1` predicate, one limb decides between Newton and BZ — and BZ blows up 8–12× on non-pow2 divisor sizes. Measured at the cliff: 15578×5193 limbs BZ 69 ms vs Newton 9 ms; 20785×10393 BZ 139 ms vs Newton 12 ms.

## Results (digits, paired vs GMP)

| shape | before | after |
|---|---:|---:|
| 200 000 × 50 000 (BENCHMARK.md's worst div point) | 6.65× | **3.36×** |
| 300 000 × 100 000 | 24.6× (cliff) | **3.07×** |
| 400 000 × 200 000 | 20.7× (cliff) | **3.57×** |
| 150 000 × 50 000 | 5.9× | **3.77×** |

Known residual documented in DIVISION.md: ratio ∈ (1, 8/5) at b ∈ (512, 24576) stays BZ — generically correct, non-pow2 pathology remains there pending quotient-sized band extension with fresh crossover data.

## Testing

246/246 unit tests, `div_correctness`, wrap + quotient-sized stress suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)