### PR TITLE
perf: thin-quotient extension of the quotient-sized band (b ≥ 8192, Δ ≤ b/8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ CI (`.github/workflows/qa.yaml`) runs `nanoclaw-task qa-agent` on PRs against `o
   - `b ≥ 6144` at ratio ≥ 8/5 (`NEWTON_RATIO2`, added 2026-06-11), or
   - `b ≥ 24576` at ratio ≥ 4/3 (`NEWTON_BALANCED` — near-balanced band; ratio lowered from 2/1 and floor from 98304 on 2026-06-11), or
   - `b ≥ 2048` at ratio ≥ 8 (`NEWTON_HIGH_SKEW` 8/1).
-- `QuotientSizedDivision` when `b ≥ 24576`, `a ≥ b + 64`, and ratio < 4/3: divides the operand TOPS (`t = Δ+4` limbs of b, `Δ+t` of a) for the (Δ+1)-limb quotient, then one Δ×nb back-multiply for the remainder — cost scales with the quotient, not the divisor.
+- `QuotientSizedDivision` when (`b ≥ 24576`, `a ≥ b + 64`, ratio < 4/3) OR (thin-quotient: `b ≥ 8192`, `64 ≤ Δ ≤ b/8`): divides the operand TOPS (`t = Δ+4` limbs of b, `Δ+t` of a) for the (Δ+1)-limb quotient, then one Δ×nb back-multiply for the remainder — cost scales with the quotient, not the divisor.
 - else `BurnikelZieglerDivision` for power-of-two base when `b > 512` and the BZ band fits (near-balanced `b ≥ 1024, b+32 ≤ a ≤ 3b`, or big-and-skewed `a > 2048 && a > 3b`).
 - otherwise multi-limb → `FastDivision` (Knuth Algorithm D variant)
 - single-limb divisor → `ClassicDivision`

--- a/docs/DIVISION.md
+++ b/docs/DIVISION.md
@@ -115,9 +115,14 @@ ratios are deliberate cliff-avoidance: digit-derived operands land at limb ratio
 blows up 8–12× on non-power-of-2 divisor sizes (measured: 15578×5193 limbs BZ 69 ms vs Newton
 9 ms; 20785×10393 BZ 139 ms vs Newton 12 ms — both shapes sat one limb below the old bands).
 End-to-end: 200k×50k digits 6.65× → 3.36× vs GMP; 300k×100k 24.6× → 3.07×; 400k×200k
-20.7× → 3.57×. Known residual: ratio ∈ (1, 8/5) at `b ∈ (512, 24576)` stays BZ — generically
-correct (BZ wins those crossovers) but non-pow2 pathology there remains; fixing it needs the
-quotient-sized band extended below 24576 with fresh crossover data.
+20.7× → 3.57×. Residual narrowed 2026-06-11 (same day): a **thin-quotient extension** of the quotient-sized
+band now covers `Δ ≤ b/8` at `b ≥ 8192` (`BIGMATH_QSIZED_SMALL_B`). Sweep data: in that slice
+quotient-sized wins generic sizes modestly (8192 limbs ratio 1.1: 3.8 vs BZ 5.5 ms) and kills the
+2^k+1 pathology 3–14× (16385 ratio 1.1: 66.4 → 8.3 ms end-to-end). The remaining BZ slice —
+`Δ ∈ (b/8, ...)` at `b ∈ (512, 24576)`, plus everything at `b < 8192` below ratio 8/5 — keeps BZ
+because it genuinely wins the generic crossovers there (qsized's tops-divide recursion gets
+erratic at fat Δ below the Newton floors: measured 48 ms vs BZ 14 at 8192 ratio 1.55); its
+non-pow2 pathology stays documented as accepted.
 
 **Short-quotient band (`QuotientSizedDivision`, 2026-06-11).** For `b ≥ NEWTON_BALANCED_B`, `a ≥ b + 64`, ratio < 4/3: with Δ = a.size − b.size and t = Δ+4, the (Δ+1)-limb quotient is determined to ±a few units by the operand TOPS — `q_est = floor((a >> B^(nb−t)) / (b >> B^(nb−t)))` (truncating b perturbs q by ≤ ~B^(2−GUARD), sub-ulp). The tops divide (ratio ~2, size ~2Δ/Δ) goes to Newton directly at t ≥ 6144 (measured: Newton beats BZ at ratio 2 from ~6k limbs — 13 vs 22 ms at 12k, 40 vs 299 ms at 30k, 0.16 s vs 5.3 s at 65537); the exact remainder then costs one Δ×nb back-multiply plus ±few fixups (cap 8, fallback Newton). Cost scales with the **quotient**, not the divisor. Measured (nb=131073, the 2^k+1 pathology): ratios 1.05/1.10/1.25 went from 1.07 s / 2.16 s / 5.35 s (BZ) to **28 / 43 / 71 ms** (38–75×). Generic nb=120000: 37/56/116 ms → 30/39/66 ms. It also beats BZ at BZ's exact-power-of-2 best case (131072 @1.25: 65 vs 88 ms) — no regression band.
 

--- a/include/biginteger/algorithms/Division.h
+++ b/include/biginteger/algorithms/Division.h
@@ -89,6 +89,13 @@ namespace BigMath
 #define BIGMATH_QSIZED_MIN_DELTA 64
 #endif
 
+#ifndef BIGMATH_QSIZED_SMALL_B
+#define BIGMATH_QSIZED_SMALL_B 8192
+#endif
+#ifndef BIGMATH_QSIZED_SMALL_DELTA_DIV
+#define BIGMATH_QSIZED_SMALL_DELTA_DIV 8
+#endif
+
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_B
 #define BIGMATH_NEWTON_HIGH_SKEW_B 2048
 #endif
@@ -112,6 +119,8 @@ namespace BigMath
   extern const SizeT NEWTON_BALANCED_NUMERATOR;
   extern const SizeT NEWTON_BALANCED_DENOMINATOR;
   extern const SizeT QSIZED_MIN_DELTA;
+  extern const SizeT QSIZED_SMALL_B;
+  extern const SizeT QSIZED_SMALL_DELTA_DIV;
   extern const SizeT NEWTON_HIGH_SKEW_B;
   extern const SizeT NEWTON_HIGH_SKEW_NUMERATOR;
   extern const SizeT NEWTON_HIGH_SKEW_DENOMINATOR;

--- a/include/biginteger/build/DispatchThresholds.h
+++ b/include/biginteger/build/DispatchThresholds.h
@@ -91,6 +91,17 @@
 #define BIGMATH_NEWTON_SKEW_DENOMINATOR 2
 #endif
 
+// Thin-quotient extension of the quotient-sized band below the balanced
+// floor: delta <= b/8 at b >= 8192. Generic wins are modest (8192 limbs at
+// ratio 1.1: 3.8 vs BZ 5.5 ms) but the 2^k+1-family BZ pathology there is
+// 3-14x (16385 limbs ratio 1.1: 11.9 vs 66.4 ms).
+#ifndef BIGMATH_QSIZED_SMALL_B
+#define BIGMATH_QSIZED_SMALL_B 8192
+#endif
+#ifndef BIGMATH_QSIZED_SMALL_DELTA_DIV
+#define BIGMATH_QSIZED_SMALL_DELTA_DIV 8
+#endif
+
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_B
 #define BIGMATH_NEWTON_HIGH_SKEW_B 2048
 #endif

--- a/src/algorithms/Division.cpp
+++ b/src/algorithms/Division.cpp
@@ -22,6 +22,8 @@ namespace BigMath
   const SizeT NEWTON_BALANCED_NUMERATOR = BIGMATH_NEWTON_BALANCED_NUMERATOR;
   const SizeT NEWTON_BALANCED_DENOMINATOR = BIGMATH_NEWTON_BALANCED_DENOMINATOR;
   const SizeT QSIZED_MIN_DELTA = BIGMATH_QSIZED_MIN_DELTA;
+  const SizeT QSIZED_SMALL_B = BIGMATH_QSIZED_SMALL_B;
+  const SizeT QSIZED_SMALL_DELTA_DIV = BIGMATH_QSIZED_SMALL_DELTA_DIV;
   const SizeT NEWTON_HIGH_SKEW_B = BIGMATH_NEWTON_HIGH_SKEW_B;
   const SizeT NEWTON_HIGH_SKEW_NUMERATOR = BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR;
   const SizeT NEWTON_HIGH_SKEW_DENOMINATOR = BIGMATH_NEWTON_HIGH_SKEW_DENOMINATOR;
@@ -73,11 +75,19 @@ namespace BigMath
     // (ratio < 4/3) with a quotient big enough that FastDivision's O(n*delta)
     // loses. BZ's near-balanced path blows up 7-128x on 2^k+1-family divisor
     // sizes here; quotient-sized division scales with the quotient instead.
-    bool qsized_eligible =
-        (base == Base2_32 || base == Base2_64) &&
+    bool qsized_main =
         b.size() >= NEWTON_BALANCED_B &&
         a.size() >= b.size() + QSIZED_MIN_DELTA &&
         NEWTON_BALANCED_DENOMINATOR * a.size() < NEWTON_BALANCED_NUMERATOR * b.size();
+    // Thin-quotient extension below the balanced floor: delta <= b/8. Generic
+    // wins are modest; the point is the 3-14x BZ pathology on 2^k+1-family
+    // divisor sizes in this band.
+    bool qsized_thin =
+        b.size() >= QSIZED_SMALL_B &&
+        a.size() >= b.size() + QSIZED_MIN_DELTA &&
+        (a.size() - b.size()) * QSIZED_SMALL_DELTA_DIV <= b.size();
+    bool qsized_eligible =
+        (base == Base2_32 || base == Base2_64) && (qsized_main || qsized_thin);
     if (qsized_eligible)
       return QuotientSizedDivision::DivideAndRemainder(a, b, base, computeRemainder);
 


### PR DESCRIPTION
Lever 1 of 3: narrows the last documented division residual. Crossover sweep of the ratio < 8/5, b < 24576 BZ slice shows quotient-sized division uniformly winning the **thin-quotient** part (Δ ≤ b/8 at b ≥ 8192):

| shape (limbs) | before (BZ) | after (qsized) |
|---|---:|---:|
| 16385 (2^14+1), ratio 1.10 | 66.4 ms | **8.3 ms** (8×) |
| 16385, ratio 1.02 | 16.9 ms | **4.8 ms** |
| 8192, ratio 1.10 | 5.5 ms | **3.8 ms** |
| 20000, ratio 1.10 | 20.3 ms | **10.1 ms** |

Fatter Δ stays BZ deliberately — qsized's tops-divide recursion is erratic below the Newton floors (measured 48 vs BZ 14 ms at 8192 ratio 1.55), and BZ genuinely wins those generic crossovers. Residual documented in DIVISION.md.

Testing: 246/246 unit tests, div_correctness, thin-band identity + FastDivision cross-checks (boundary Δ 63/64/1024/1025, all-max/sparse patterns, 2^k+1 sizes, 24575 edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)