### PR TITLE
perf: separate gate for cyclic NTT products (1280 vs 5120 full-product threshold)

### DIFF
--- a/docs/STRING_CONVERSION.md
+++ b/docs/STRING_CONVERSION.md
@@ -613,6 +613,22 @@ Best ToString time (ms, min over many iters, M1 Max, full default stack) at each
 
 **Don't tune without re-measuring.** The pre-PR-#43 sweep gave the same answer with different absolute times. If further optimizations land that shift the linear-leaf cost again, re-run the sweep before changing the default.
 
+### Cyclic-NTT gate retune for chain construction (2026-06-11)
+
+Cold-path profiling (fresh `topDigits` per call, so the divider-chain cache never hits) showed
+~100% of a cold 100k-digit `ToString` inside `Divider` construction — `ApproxReciprocal` towers
+whose multiplies all sit below the 5120-limb NTT dispatch threshold, i.e. pure Karatsuba.
+
+The wraparound machinery (cyclic `mod B^L−1` products in the reciprocal iteration and
+`WrappedRemainder`) had inherited `NTT_MULTIPLICATION_THRESHOLD` as its gate — but a cyclic
+product runs at HALF the transform length of the full product that threshold was tuned for, so
+its crossover vs Karatsuba sits proportionally lower. New `BIGMATH_CYCLIC_NTT_THRESHOLD`
+(default **1280** total limbs) gates the cyclic paths independently.
+
+Paired sweep (cold ToString, BM/GMP ratio, machine under load so ratios not absolute):
+100k digits 7.3–7.4× → **4.6–5.2×**, 200k −33%, 500k+ neutral, 640 regresses. The win flows to
+every Newton divide with sub-5120-limb internals, not just ToString.
+
 ### True scratch-buffer reuse inside Newton division
 
 The current `NewtonDivision::Divider::DivideAndRemainderInto` boundary API avoids rebuilding the divisor reciprocal, but it still delegates to internals that allocate temporary quotient, remainder, normalization, and multiplication vectors. A deeper scratch-aware Newton path could reduce allocation churn in `ToStringDivConquer`. Expected win is small, probably low single digits, because profiling shows the dominant cost is still NTT multiplication. This is not a first-choice optimization unless allocation profiles show otherwise.

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -17,6 +17,17 @@ using namespace std;
 #include "ClassicDivision.h"
 #include "FastDivision.h"
 
+// Gate for the cyclic (wrap-around) NTT products inside Newton division.
+// Separate from NTT_MULTIPLICATION_THRESHOLD because a cyclic product runs at
+// HALF the transform length of the full product the threshold was tuned for —
+// its crossover vs Karatsuba sits proportionally lower. Swept 2026-06-11 on
+// cold ToString (whose divider-chain reciprocal towers run entirely in this
+// band at <= 500k digits): 1280 beats 5120 by ~30% at 100k-200k digits and
+// is neutral at 500k+; 640 regresses. Tunable for re-sweeps.
+#ifndef BIGMATH_CYCLIC_NTT_THRESHOLD
+#define BIGMATH_CYCLIC_NTT_THRESHOLD 1280
+#endif
+
 namespace BigMath
 {
   // Newton-Raphson division.
@@ -218,7 +229,7 @@ namespace BigMath
           ULong nCyc = std::bit_ceil((ULong)(Lmin + 1) * c);
           ULong nLin = std::bit_ceil(((ULong)D_new.size() + R_pad.size()) * c);
           SizeT L = (SizeT)(nCyc / c);
-          if (D_new.size() + R_pad.size() >= NTT_MULTIPLICATION_THRESHOLD &&
+          if (D_new.size() + R_pad.size() >= BIGMATH_CYCLIC_NTT_THRESHOLD &&
               nCyc < nLin && nCyc <= (1u << 22) &&
               D_new.size() <= L && R_pad.size() <= L)
           {
@@ -433,7 +444,7 @@ namespace BigMath
         ULong nCyc = std::bit_ceil((ULong)(n + 2) * c);
         ULong nLinear = std::bit_ceil(((ULong)Q.size() + n) * c);
         SizeT L = (SizeT)(nCyc / c);
-        if (Q.size() + n >= NTT_MULTIPLICATION_THRESHOLD &&
+        if (Q.size() + n >= BIGMATH_CYCLIC_NTT_THRESHOLD &&
             nCyc < nLinear && nCyc <= (1u << 22) &&
             Q.size() <= L)
           return WrappedRemainder(chunk, b_norm, L, Q, rem, fixupLimit);


### PR DESCRIPTION
Lever 2 of 3: the cold-ToString chain-build cost.

## Finding

Cold-path profile (fresh `topDigits` every call → chain cache never hits): ~100% of a cold 100k-digit `ToString` is `Divider` construction — `ApproxReciprocal` towers running pure Karatsuba, because every product is below the 5120-limb NTT threshold.

## Fix

The cyclic `mod (B^L−1)` products from the wraparound family (#85/#87) had inherited `NTT_MULTIPLICATION_THRESHOLD` as their gate. But cyclic products run at **half the transform length** the threshold was tuned for — their Karatsuba crossover is proportionally lower. New `BIGMATH_CYCLIC_NTT_THRESHOLD`, default **1280** total limbs (swept {640, 1280, 2560, 5120}).

## Results (paired same-run BM/GMP ratios; machine under ambient load, so ratios not absolutes)

| size | T=5120 (old) | T=1280 | 
|---|---:|---:|
| tostr 100k cold | 7.3–7.4× | **4.6–5.2×** |
| tostr 200k cold | 5.3× | 4.2–4.3× |
| tostr 500k+ | — | neutral |

Win applies to every Newton divide with sub-5120-limb internals, not just ToString. 640 regresses — documented in STRING_CONVERSION.md.

## Testing

246/246 unit tests, `div_correctness` (1024–4096-limb cases now exercise cyclic paths), wrap/pow10/thin-band stress suites, round-trips at 100k/1M/5M digits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)