### PR TITLE
perf: retune multiplication dispatch post-NEON (NTT entry 5120 → 1280)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,9 @@ CI (`.github/workflows/qa.yaml`) runs `nanoclaw-task qa-agent` on PRs against `o
 **Multiplication dispatch** (`algorithms/Multiplication.h`):
 - single-limb operand → `ClassicMultiplication::Multiply(vec, scalar, base)`
 - `a.size()+b.size() <= 96` or `min(a,b) <= 32` → classic schoolbook
-- below `NTT_MULTIPLICATION_THRESHOLD = 32768` → `KaratsubaMultiplication`
-- otherwise → `NTTMultiplication`
-- `ToomCookMultiplication` exists as an alternate exercised by tests but is not in the default dispatch path.
+- below `NTT_MULTIPLICATION_THRESHOLD = 1280` total limbs → `KaratsubaMultiplication` (dropped from 5120 on 2026-06-12 after the NEON Shoup butterflies made CRT NTT ~2.5× faster in the small-mid band)
+- otherwise → `NTTMultiplication` (3-prime CRT effectively always: `BIGMATH_NTT_CRT_THRESHOLD = 256`)
+- `ToomCookMultiplication` exists as an alternate exercised by tests; its dispatch window was retired 2026-06-12 (CRT+NEON beats it everywhere).
 
 **Why no Schönhage-Strassen.** NTT here uses the Goldilocks prime `P = 2^64 - 2^32 + 1` with 16-bit input split. Convolution-accumulation overflow only at ~2^31 limbs (≈ 8 GB operands), so NTT covers every practical size. SSA's asymptotic edge is `log log n`; at any size below ~2^40 limbs the constant-factor cost of mod-2^N+1 arithmetic loses to NTT. The ~700+ lines of SSA aren't justified for this codebase — if you need more big-int wins, look at block-recursive Mulders division or Schönhage's subquadratic GCD instead.
 

--- a/include/biginteger/algorithms/Multiplication.h
+++ b/include/biginteger/algorithms/Multiplication.h
@@ -48,14 +48,14 @@ namespace BigMath
 // Toom-3 wins over Karatsuba once the per-operand size grows past ~1280
 // limbs (total ≥ 2560). Measured 2026-05-27; see BENCHMARK.md "Toom-3
 // dispatch band" for the focused scan.
-#define BIGMATH_TOOM3_MULTIPLICATION_THRESHOLD 2560
+#define BIGMATH_TOOM3_MULTIPLICATION_THRESHOLD 1280
 #endif
 
 #ifndef BIGMATH_NTT_MULTIPLICATION_THRESHOLD
 // NTT crossover. Bumped from 4096 to 5120 (2026-05-27) after measurement
 // showed NTT regresses around total 4608 due to NTT-length boundary effect
 // (NTT 1.65 ms vs Toom3 1.10 ms); NTT becomes a clean win again at 5120+.
-#define BIGMATH_NTT_MULTIPLICATION_THRESHOLD 5120
+#define BIGMATH_NTT_MULTIPLICATION_THRESHOLD 1280
 #endif
 
 #ifndef BIGMATH_TOOM3_SKEW_RATIO

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -188,7 +188,7 @@ namespace BigMath
             // Threshold 5000 catches the 6000-8000 wins without admitting
             // the sum=4000 regression. Override via -DBIGMATH_NTT_CRT_THRESHOLD=N.
 #ifndef BIGMATH_NTT_CRT_THRESHOLD
-#define BIGMATH_NTT_CRT_THRESHOLD 5000
+#define BIGMATH_NTT_CRT_THRESHOLD 256
 #endif
             if (a.size() + b.size() >= BIGMATH_NTT_CRT_THRESHOLD)
                 return NttCrt::Multiply(a, b, base);

--- a/include/biginteger/build/DispatchThresholds.h
+++ b/include/biginteger/build/DispatchThresholds.h
@@ -29,8 +29,12 @@
 #define BIGMATH_CLASSIC_SKEW_RATIO 10
 #endif
 
+// Post-NEON (PR #96) retune: CRT NTT with NEON Shoup butterflies beats
+// Karatsuba from ~384 limbs per operand (sum 768) and Toom-3 everywhere,
+// so the Toom-3 window is retired from dispatch (kept as a cross-check
+// algorithm) and the NTT entry drops 5120 -> 1280 (sum 896-1024 also favors CRT but sits one bit_ceil tier below sum 1040-1250 where Karatsuba still edges it - 1280 keeps the dispatch cliff-free).
 #ifndef BIGMATH_TOOM3_MULTIPLICATION_THRESHOLD
-#define BIGMATH_TOOM3_MULTIPLICATION_THRESHOLD 2560
+#define BIGMATH_TOOM3_MULTIPLICATION_THRESHOLD 1280
 #endif
 
 #ifndef BIGMATH_TOOM3_SKEW_RATIO
@@ -38,11 +42,15 @@
 #endif
 
 #ifndef BIGMATH_NTT_MULTIPLICATION_THRESHOLD
-#define BIGMATH_NTT_MULTIPLICATION_THRESHOLD 5120
+#define BIGMATH_NTT_MULTIPLICATION_THRESHOLD 1280
 #endif
 
+// CRT+NEON beats single-prime Goldilocks at every measured size (512/op:
+// 0.106 vs 0.176 ms), so the CRT gate drops below the NTT entry point —
+// Goldilocks remains only as the non-aarch64-friendly fallback via
+// -DBIGMATH_NTT_CRT=0.
 #ifndef BIGMATH_NTT_CRT_THRESHOLD
-#define BIGMATH_NTT_CRT_THRESHOLD 5000
+#define BIGMATH_NTT_CRT_THRESHOLD 256
 #endif
 
 #ifndef BIGMATH_NTT_MFA_THRESHOLD


### PR DESCRIPTION
Item 2 of the batch: #96's NEON butterflies moved the multiplication crossovers.

- **NTT entry 5120 → 1280 total limbs** (Karatsuba/CRT crossover now ~896–1280; 1280 chosen to stay clear of the bit_ceil tier sliver at sum 1040–1250 where Karatsuba still edges).
- **Toom-3 dispatch window retired** — CRT+NEON beats it at every measured size; implementation stays as a test cross-check.
- **CRT gate 5000 → 256** — CRT+NEON beats Goldilocks everywhere measured (512 limbs/op: 0.10 vs 0.18 ms).

| case | before | after |
|---|---:|---:|
| mul 30k digits | 0.58 ms | **0.25 ms (2.3×)** |
| tostr 1M digits | 103 ms | **78 ms (−25%)** |
| div 1M×200k | 16.9 ms | 15.9 ms |
| mul 10k / 100k+ | unchanged | unchanged |

246/246 unit tests, mult_correctness, div_correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)