### PR TITLE
perf: lower Newton division band floors post-NEON (768/1024/4096)

### DIFF
--- a/include/biginteger/algorithms/Division.h
+++ b/include/biginteger/algorithms/Division.h
@@ -42,7 +42,7 @@
 namespace BigMath
 {
 #ifndef BIGMATH_NEWTON_MEDIUM_B
-#define BIGMATH_NEWTON_MEDIUM_B 2560
+#define BIGMATH_NEWTON_MEDIUM_B 1024
 #endif
 
 // Ratio-≥8/5 band. Sits between the medium (3/1) and balanced (4/3) bands:
@@ -52,7 +52,7 @@ namespace BigMath
 // ratios like 2.0000 ± 1 limb and BZ blows up 8-12× on non-pow2 divisor
 // sizes right across that edge.
 #ifndef BIGMATH_NEWTON_RATIO2_B
-#define BIGMATH_NEWTON_RATIO2_B 6144
+#define BIGMATH_NEWTON_RATIO2_B 4096
 #endif
 #ifndef BIGMATH_NEWTON_RATIO2_NUMERATOR
 #define BIGMATH_NEWTON_RATIO2_NUMERATOR 8
@@ -97,7 +97,7 @@ namespace BigMath
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_B
-#define BIGMATH_NEWTON_HIGH_SKEW_B 2048
+#define BIGMATH_NEWTON_HIGH_SKEW_B 768
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR

--- a/include/biginteger/build/DispatchThresholds.h
+++ b/include/biginteger/build/DispatchThresholds.h
@@ -70,15 +70,18 @@
 #endif
 
 #ifndef BIGMATH_NEWTON_MEDIUM_B
-#define BIGMATH_NEWTON_MEDIUM_B 2560
+#define BIGMATH_NEWTON_MEDIUM_B 1024
 #endif
 
-// Ratio-≥8/5 Newton band between the medium (3/1) and balanced (4/3) bands.
+// Floors re-swept 2026-06-12 after the NEON NTT pass made Newton's internal
+// multiplies ~40% faster: high-skew (8/1) 2048 -> 768, medium (5/2)
+// 2560 -> 1024, ratio-8/5 6144 -> 4096. Below those, BZ/FastDivision win.
+// Ratio-≥8/5 Newton band between the medium (5/2) and balanced (4/3) bands.
 // 8/5 instead of a knife-edge 2/1: digit-derived operands land at limb ratios
 // like 2.0000 ± 1 limb, and the BZ side of the edge blows up 8-12× on
 // non-power-of-2 divisor sizes; Newton generic-ties BZ from ratio ~1.6 here.
 #ifndef BIGMATH_NEWTON_RATIO2_B
-#define BIGMATH_NEWTON_RATIO2_B 6144
+#define BIGMATH_NEWTON_RATIO2_B 4096
 #endif
 #ifndef BIGMATH_NEWTON_RATIO2_NUMERATOR
 #define BIGMATH_NEWTON_RATIO2_NUMERATOR 8
@@ -111,7 +114,7 @@
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_B
-#define BIGMATH_NEWTON_HIGH_SKEW_B 2048
+#define BIGMATH_NEWTON_HIGH_SKEW_B 768
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR


### PR DESCRIPTION
Item 2: third band re-sweep of the run, this time because NEON made Newton's internal NTTs ~40% faster at small sizes.

| band | old floor | new floor |
|---|---:|---:|
| high-skew (ratio ≥ 8) | 2048 | **768** |
| medium (ratio ≥ 5/2) | 2560 | **1024** |
| ratio-8/5 | 6144 | **4096** |

| shape (limbs) | before (BZ) | after (Newton) |
|---|---:|---:|
| 1536 ÷, ratio 10 | 12.0 ms | **4.9 ms** |
| 2048 ÷, ratio 5 | 8.3 ms | **3.8 ms** |
| 1024 ÷, ratio 3 | 1.72 ms | 1.39 ms |

≤ ~520-limb divisors keep BZ/FastDivision (measured still faster; the 100k×10k row's 4.9× is structural BZ-vs-GMP at that size, documented).

246/246 unit tests, div_correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)