### PR TITLE
fix: MFA inverse cross-twiddle applied after the inverse row FFT (silent wrong results since 05-31)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,11 @@ if(BIGMATH_BUILD_TESTS)
 
     add_executable(mfa_roundtrip tests/performance/mfa_roundtrip.cpp)
     target_link_libraries(mfa_roundtrip PRIVATE bigmath::bigmath)
+    # Registered as a test: the MFA band sits above every other correctness
+    # harness's sizes, so an MFA-only bug is invisible without this (the
+    # daaf3f4 inverse-twiddle ordering bug shipped and stayed latent for 12
+    # days exactly this way).
+    add_test(NAME mfa_roundtrip COMMAND mfa_roundtrip)
 
     add_executable(mfa_dft_check tests/performance/mfa_dft_check.cpp)
     target_link_libraries(mfa_dft_check PRIVATE bigmath::bigmath)

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -1728,8 +1728,12 @@ namespace BigMath
         {
           UInt *row = tile + (SizeT)t * n2;
           std::copy(scratch + (SizeT)(r0 + t) * n2, scratch + (SizeT)(r0 + t) * n2 + n2, row);
-          InversePtr<F>(row, n2, planN2, /*scale=*/ true);
+          // Inverse cross-twiddle must precede the inverse row FFT (adjoint
+          // of the forward fusion order; the bit-reversed addressing refers
+          // to the pre-DIT layout). Same daaf3f4 ordering bug as the
+          // non-tiled inverse step.
           MfaTwiddleApplyRow<F>(row, r0 + t, n2, n, invRoots, br);
+          InversePtr<F>(row, n2, planN2, /*scale=*/ true);
         }
         // Scatter: a[c*n1 + (r0+t)] = tile[t*n2 + c], c in [0,n2).
         for (Int c = 0; c < n2; ++c)
@@ -1899,11 +1903,18 @@ namespace BigMath
         for (Int r = rStart; r < rEnd; ++r)
         {
           UInt *row = scratch + (SizeT)r * n2;
+          // The inverse cross-twiddle must PRECEDE the inverse row FFT: it is
+          // the adjoint of the forward order (row FFT, then twiddle), and
+          // MfaTwiddleApplyRow's bit-reversed addressing refers to the
+          // pre-DIT layout. The fusion commit (daaf3f4, PR #72) applied it
+          // after the row inverse, breaking forward·inverse identity at every
+          // MFA size — latent because the 2^24 gate sits above all routine
+          // correctness tests.
+          MfaTwiddleApplyRow<F>(row, r, n2, n, planN.inverseRoots.data(), br);
           if (n2 <= BIGMATH_NTT_MFA_LEAF)
             InversePtr<F>(row, n2, planN2, /*scale=*/ true);
           else
             InverseMFA<F>(row, n2, a + (SizeT)r * n2, parallel, tree);
-          MfaTwiddleApplyRow<F>(row, r, n2, n, planN.inverseRoots.data(), br);
         }
       };
 #if BIGMATH_USE_THREADS


### PR DESCRIPTION
## Severity

**Correctness.** Every product whose transform reaches the MFA gate (n ≥ 2^24 coefficients ≈ ≥40M-digit balanced multiplies) has returned silently wrong results since the twiddle-fusion commit `daaf3f4` (PR #72, 2026-05-31). Division at those sizes survived only because Newton's fixup cap detected the corruption and fell back to quadratic FastDivision — which is what tonight's "stuck" 200M×40M runs actually were.

## Root cause

The fusion moved the MFA cross-twiddle into the row-FFT passes. Forward order stayed correct (row FFT → twiddle), but **both** inverse variants (plain `invStep2` and the transpose-fused `FusedInverseB`) applied the inverse twiddle **after** the inverse row FFT. The inverse twiddle is the adjoint of the forward order and must come first; its bit-reversed addressing also refers to the pre-DIT layout.

## Diagnosis trail

stalled 200M×40M div (100% single-core = FastDivision-fallback signature) → raw-limb GMP probe: FAIL at exactly tier 2^24+, OK below → NEON off: still FAIL → pre-session commits: still FAIL → `BIGMATH_NTT_MFA=0`: ALL OK → `mfa_roundtrip` FAIL at n=2^23 → bisect of PR #72's commits: `51e62c2` OK, `1fa4525` OK, **`daaf3f4` FAIL**.

## Fix + guard

Twiddle moved before the inverse row FFT at both sites. `mfa_roundtrip` (which catches this in 1.2 s) is now **registered with ctest** — the MFA band sits above every other harness's sizes, which is exactly how this stayed latent 12 days.

## Verification

- `mfa_roundtrip`: was FAIL at n=2^23 → ALL PASS
- raw-limb GMP cross-check (no decimal I/O): OK at tiers 2^22, 2^23, 2^24, 2^25 (incl. off-power sizes)
- 246/246 unit tests, `mult_correctness`, `div_correctness`, ToString round-trips

## Note

Tonight's earlier 50M+ XL benchmark rows were measured on the broken path and are invalid (wrong-result timings); they were not yet published. Re-measure follows in a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)