### PR TITLE
perf: MFA pointwise fusion + row-chunked stage parallelism (F1) — 1.20× at 3M-10M limbs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,12 @@ if(BIGMATH_BUILD_TESTS)
         add_executable(mfa_vs_gmp_check tests/performance/mfa_vs_gmp_check.cpp)
         target_link_libraries(mfa_vs_gmp_check PRIVATE bigmath::bigmath ${GMP_LIBRARY})
         target_include_directories(mfa_vs_gmp_check PRIVATE ${GMP_INCLUDE_DIR})
+
+        # Raw-limb (mpz_import/export) MFA-band probe; pre-merge gate for any
+        # change touching the MFA pipeline (mem_pass_fusion.md protocol).
+        add_executable(mfa_mul_gmp_probe tests/performance/mfa_mul_gmp_probe.cpp)
+        target_link_libraries(mfa_mul_gmp_probe PRIVATE bigmath::bigmath ${GMP_LIBRARY})
+        target_include_directories(mfa_mul_gmp_probe PRIVATE ${GMP_INCLUDE_DIR})
         target_include_directories(bench_vs_gmp PRIVATE ${GMP_INCLUDE_DIR})
 
         add_executable(bench_run_gmp ${BENCHSUITE_DIR}/run_gmp.cpp)

--- a/docs/MULTIPLICATION.md
+++ b/docs/MULTIPLICATION.md
@@ -562,8 +562,17 @@ The win is **cache locality**. At 100M digits (n ≈ 33M per prime ≈ 134 MB pe
 The landed design separates the two:
 
 - Plans are pre-built in the main thread via `BuildMfaPlanTree<F, G>(n, tree)` for each prime before any dispatch. The tree is then passed by `const &` capture into the worker lambda. Workers never call `GetPlan` and therefore never reenter the pool.
-- The six forward transforms (and three inverses) dispatch as `ParallelDo(6)` / `ParallelDo(3)` with `parallel=false` passed to `ForwardMFA` / `InverseMFA` to suppress *internal* `ParallelFor` calls. Each task is one full per-prime MFA running serially in its own thread.
-- Six per-task scratch buffers are allocated on the caller stack (NOT `thread_local`) before dispatch so the capturing pointers cross threads safely.
+- In the single-level fused window (`n1, n2 ≤ LEAF` — every in-practice MFA length), the forward runs as two `ParallelDo(6)` phases: stage A for all six operand×prime planes (independent units), then stage B as `(prime, half-row-range)` units. The multi-level fallback and the three inverses keep the original whole-transform batching, with `parallel=false` suppressing *internal* `ParallelFor` calls.
+- Six per-task scratch buffers are sized before dispatch; the worker lambdas capture only the raw pointers so the buffers cross threads safely.
+
+**Pointwise fusion + row-chunked stages (F1, mem_pass_fusion.md, 2026-06-12).** In the single-level window, each forward stage-B unit runs `fa`'s stage B on its row range and then `fb`'s stage B on the same range with the pointwise multiply fused into the scatter: `FusedForwardBMul` performs the same gather + row-FFT as `FusedForwardB`, but multiplies each finished row into operand A's already-transformed plane (`fa[i] = fa[i] · f̂b[i]`) instead of writing `fb`'s plane. `fb`'s spectrum never reaches DRAM and the standalone pointwise sweep disappears. The inverse is likewise split into two `ParallelDo(6)` phases of `(prime, half-range)` units (the inter-stage barrier is load-bearing: stage B rows read scatter output from *every* stage A unit).
+
+Two failed shapes informed this design, both measured warm-state (first call discarded — plan build and first-touch faults otherwise mask everything):
+
+- Pairing `fa`/`fb` whole-prime in `ParallelDo(3)` lost **1.47×**: a single multiply only draws ~64% of the M1 Max's DRAM bandwidth (2-process probe: +28% per-process, 1.56× aggregate), so halving the concurrent work units is not free — the "fully bandwidth-bound" premise does not hold post-NEON.
+- Sequential primes with `parallel=true` inside the stages lost **2×**: MFA stage row counts (`n1, n2 ≤ 2^13`) sit below `ParallelMinSize()` = 65536, so the internal `ParallelFor` gate never fires and everything ran serial. `ParallelDo` bypasses MinSize; that is why the row chunking is expressed through it.
+
+Landed result (warm best-of-3 ×3 interleaved rounds vs pre-fusion baseline, M1 Max): **−16.2% / −17.1% / −17.0%** at 3M/5M/10M limbs (≈1.20× wall-clock) — most of it from the 6-unit inverse phases (the old inverse batched whole transforms in `ParallelDo(3)`, leaving cores idle for a third of the multiply), the remainder from the eliminated pointwise/`fb`-write passes.
 
 `mul_xl_bench` on M1 Max, Base2_64, CRT default, threaded, refreshed after the `2^24` threshold retune:
 

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -1507,6 +1507,10 @@ namespace BigMath
     inline void InverseMFA(UInt *a, Int n, UInt *scratch, bool parallel,
                            const MfaPlanTree<F> &tree);
 
+    template <typename F>
+    inline void ForwardMFAMul(UInt *b, Int n, UInt *scratch, bool parallel,
+                              const MfaPlanTree<F> &tree, UInt *acc);
+
     // Backward-compat wrappers that build a fresh plan tree per call. Safe
     // only when called from a context that is NOT already inside ParallelDo.
     template <typename F, UInt G>
@@ -1515,6 +1519,14 @@ namespace BigMath
       MfaPlanTree<F> tree;
       BuildMfaPlanTree<F, G>(n, tree);
       ForwardMFA<F>(a, n, scratch, parallel, tree);
+    }
+
+    template <typename F, UInt G>
+    inline void ForwardMFAMul(UInt *b, Int n, UInt *scratch, UInt *acc, bool parallel = true)
+    {
+      MfaPlanTree<F> tree;
+      BuildMfaPlanTree<F, G>(n, tree);
+      ForwardMFAMul<F>(b, n, scratch, parallel, tree, acc);
     }
 
     template <typename F, UInt G>
@@ -1683,6 +1695,43 @@ namespace BigMath
       }
     }
 
+    // Forward stage B with the pointwise product fused into the scatter
+    // (mem_pass_fusion.md F1). Row math is identical to FusedForwardB, but
+    // instead of writing operand B's spectrum to its own plane, each finished
+    // row is multiplied into the already-transformed operand-A plane:
+    // acc[i] = acc[i] * Bhat[i]. B's spectrum never reaches DRAM and the
+    // separate full-plane pointwise sweep disappears.
+    // Precondition: acc already holds A's COMPLETE forward transform — the
+    // caller must order A's forward before this stage (per-prime pairing in
+    // NttCrt::Multiply's fwdBody).
+    template <typename F>
+    inline void FusedForwardBMul(UInt *acc, const UInt *scratch, Int n1, Int n2,
+                                 const Plan<F> &planN1, Int r0s, Int r0e)
+    {
+      constexpr Int TILE = BIGMATH_NTT_MFA_FUSE_TILE;
+      static thread_local std::vector<UInt> tilebuf;
+      tilebuf.resize((SizeT)TILE * n1);
+      UInt *tile = tilebuf.data();
+      for (Int r0 = r0s; r0 < r0e; r0 += TILE)
+      {
+        Int tr = std::min<Int>(TILE, r0e - r0);
+        // Gather: tile[t*n1 + j] = scratch[j*n2 + (r0+t)], j in [0,n1).
+        for (Int j = 0; j < n1; ++j)
+        {
+          const UInt *s = scratch + (SizeT)j * n2 + r0;
+          UInt *d = tile + j;
+          for (Int t = 0; t < tr; ++t) d[(SizeT)t * n1] = s[t];
+        }
+        for (Int t = 0; t < tr; ++t)
+        {
+          UInt *row = tile + (SizeT)t * n1;
+          ForwardPtr<F>(row, n1, planN1);
+          UInt *d = acc + (SizeT)(r0 + t) * n1;
+          for (Int j = 0; j < n1; ++j) d[j] = F::Mul(d[j], row[j]);
+        }
+      }
+    }
+
     // Inverse stage A (invStep5+rev4): for input rows r in [r0s,r0e), inv-FFT
     // a row r (length n1), scatter to scratch[c*n2 + r]. Reads `a`, writes
     // `scratch`.
@@ -1838,6 +1887,49 @@ namespace BigMath
 #endif
     }
 
+    // Forward-transform `b` and multiply its spectrum into `acc` (operand A's
+    // already-transformed plane) in one pass — mem_pass_fusion.md F1. When the
+    // single-level fused path doesn't apply (n at/below the leaf, a recursive
+    // split, or FUSE disabled), falls back to the plain forward followed by a
+    // pointwise loop; the MFA gate keeps every in-practice length (2^24..2^26)
+    // on the fused branch.
+    template <typename F>
+    inline void ForwardMFAMul(UInt *b, Int n, UInt *scratch, bool parallel,
+                              const MfaPlanTree<F> &tree, UInt *acc)
+    {
+#if BIGMATH_NTT_MFA_FUSE
+      if (n > BIGMATH_NTT_MFA_LEAF)
+      {
+        Int n1, n2;
+        MFAFactor(n, n1, n2);
+        if (n1 <= BIGMATH_NTT_MFA_LEAF && n2 <= BIGMATH_NTT_MFA_LEAF)
+        {
+          const Plan<F> &planN_f = tree.Get(n);
+          const Plan<F> &planN2_f = tree.Get(n2);
+          const Plan<F> &planN1_f = tree.Get(n1);
+          const UInt *fwdRoots_f = planN_f.forwardRoots.data();
+          const Int *br_f = GetBitReverseTable(n2).data();
+          auto fa = [b, scratch, n, n1, n2, &planN2_f, fwdRoots_f, br_f](Int s, Int e) {
+            FusedForwardA<F>(b, scratch, n, n1, n2, planN2_f, fwdRoots_f, br_f, s, e);
+          };
+          auto fb = [acc, scratch, n1, n2, &planN1_f](Int s, Int e) {
+            FusedForwardBMul<F>(acc, scratch, n1, n2, planN1_f, s, e);
+          };
+#if BIGMATH_USE_THREADS
+          if (parallel && (SizeT)n1 >= ParallelMinSize()) ParallelFor(n1, fa); else fa(0, n1);
+          if (parallel && (SizeT)n2 >= ParallelMinSize()) ParallelFor(n2, fb); else fb(0, n2);
+#else
+          fa(0, n1);
+          fb(0, n2);
+#endif
+          return;
+        }
+      }
+#endif
+      ForwardMFA<F>(b, n, scratch, parallel, tree);
+      for (Int i = 0; i < n; ++i) acc[i] = F::Mul(acc[i], b[i]);
+    }
+
     template <typename F>
     inline void InverseMFA(UInt *a, Int n, UInt *scratch, bool parallel,
                            const MfaPlanTree<F> &tree)
@@ -1975,6 +2067,7 @@ namespace BigMath
       MfaPlanTree<F1> tree1;
       MfaPlanTree<F2> tree2;
       MfaPlanTree<F3> tree3;
+      bool pointwiseFused = false;
       if (useMfa)
       {
         for (int i = 0; i < 6; ++i) mfaScratch[i].assign(n, 0);
@@ -1986,21 +2079,103 @@ namespace BigMath
         UInt *bufs[6]   = {fa1.data(), fb1.data(), fa2.data(), fb2.data(), fa3.data(), fb3.data()};
         UInt *scrs[6]   = {mfaScratch[0].data(), mfaScratch[1].data(), mfaScratch[2].data(),
                            mfaScratch[3].data(), mfaScratch[4].data(), mfaScratch[5].data()};
-        auto fwdBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
-          for (Int idx = s; idx < e; ++idx)
-          {
-            switch (idx)
+
+        Int n1 = 0, n2 = 0;
+        MFAFactor(n, n1, n2);
+#if BIGMATH_NTT_MFA_FUSE
+        if (n1 <= BIGMATH_NTT_MFA_LEAF && n2 <= BIGMATH_NTT_MFA_LEAF)
+        {
+          // Pass fusion F1 (mem_pass_fusion.md), parallelism-preserving form.
+          //   P1 — ParallelDo(6): stage A (gather + row FFT(n2) + cross-
+          //        twiddle) for all six operand×prime planes; independent.
+          //   P2 — ParallelDo(6): unit = (prime, half of the n2 output
+          //        rows). Each unit runs fa's stage B on its row range, then
+          //        fb's stage B over the same range with the pointwise
+          //        multiply fused into the scatter (FusedForwardBMul):
+          //        fa[i] = fa[i] · fb^[i]. fb's spectrum never reaches DRAM
+          //        and the standalone pointwise sweep below is skipped,
+          //        while the forward keeps six concurrent work units
+          //        throughout.
+          // A first cut paired fa/fb whole-prime in ParallelDo(3); warm-
+          // state benches showed a 1.47× regression — this band does NOT
+          // saturate bandwidth from 3 cores. Row-level ParallelFor inside
+          // the stages can't restore the parallelism either: MFA stage row
+          // counts (n1, n2 ≤ 2^13) sit below ParallelMinSize() = 65536, so
+          // the internal gate never fires. ParallelDo bypasses MinSize.
+          const UInt *fwd1 = tree1.Get(n).forwardRoots.data();
+          const UInt *fwd2 = tree2.Get(n).forwardRoots.data();
+          const UInt *fwd3 = tree3.Get(n).forwardRoots.data();
+          const Plan<F1> *pn2_1 = &tree1.Get(n2), *pn1_1 = &tree1.Get(n1);
+          const Plan<F2> *pn2_2 = &tree2.Get(n2), *pn1_2 = &tree2.Get(n1);
+          const Plan<F3> *pn2_3 = &tree3.Get(n2), *pn1_3 = &tree3.Get(n1);
+          const Int *br = GetBitReverseTable(n2).data();
+
+          auto stageA = [bufs, scrs, n, n1, n2, fwd1, fwd2, fwd3,
+                         pn2_1, pn2_2, pn2_3, br](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
             {
-              case 0: ForwardMFA<F1>(bufs[0], n, scrs[0], /*parallel=*/false, tree1); break;
-              case 1: ForwardMFA<F1>(bufs[1], n, scrs[1], /*parallel=*/false, tree1); break;
-              case 2: ForwardMFA<F2>(bufs[2], n, scrs[2], /*parallel=*/false, tree2); break;
-              case 3: ForwardMFA<F2>(bufs[3], n, scrs[3], /*parallel=*/false, tree2); break;
-              case 4: ForwardMFA<F3>(bufs[4], n, scrs[4], /*parallel=*/false, tree3); break;
-              case 5: ForwardMFA<F3>(bufs[5], n, scrs[5], /*parallel=*/false, tree3); break;
+              switch (idx)
+              {
+                case 0: FusedForwardA<F1>(bufs[0], scrs[0], n, n1, n2, *pn2_1, fwd1, br, 0, n1); break;
+                case 1: FusedForwardA<F1>(bufs[1], scrs[1], n, n1, n2, *pn2_1, fwd1, br, 0, n1); break;
+                case 2: FusedForwardA<F2>(bufs[2], scrs[2], n, n1, n2, *pn2_2, fwd2, br, 0, n1); break;
+                case 3: FusedForwardA<F2>(bufs[3], scrs[3], n, n1, n2, *pn2_2, fwd2, br, 0, n1); break;
+                case 4: FusedForwardA<F3>(bufs[4], scrs[4], n, n1, n2, *pn2_3, fwd3, br, 0, n1); break;
+                case 5: FusedForwardA<F3>(bufs[5], scrs[5], n, n1, n2, *pn2_3, fwd3, br, 0, n1); break;
+              }
             }
-          }
-        };
-        ParallelDo(6, fwdBody);
+          };
+          ParallelDo(6, stageA);
+
+          const Int half = n2 >> 1;
+          auto stageB = [bufs, scrs, n1, n2, half,
+                         pn1_1, pn1_2, pn1_3](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
+            {
+              Int r0s = (idx & 1) ? half : 0;
+              Int r0e = (idx & 1) ? n2 : half;
+              switch (idx >> 1)
+              {
+                case 0:
+                  FusedForwardB<F1>(bufs[0], scrs[0], n1, n2, *pn1_1, r0s, r0e);
+                  FusedForwardBMul<F1>(bufs[0], scrs[1], n1, n2, *pn1_1, r0s, r0e);
+                  break;
+                case 1:
+                  FusedForwardB<F2>(bufs[2], scrs[2], n1, n2, *pn1_2, r0s, r0e);
+                  FusedForwardBMul<F2>(bufs[2], scrs[3], n1, n2, *pn1_2, r0s, r0e);
+                  break;
+                case 2:
+                  FusedForwardB<F3>(bufs[4], scrs[4], n1, n2, *pn1_3, r0s, r0e);
+                  FusedForwardBMul<F3>(bufs[4], scrs[5], n1, n2, *pn1_3, r0s, r0e);
+                  break;
+              }
+            }
+          };
+          ParallelDo(6, stageB);
+          pointwiseFused = true;
+        }
+        else
+#endif
+        {
+          // Multi-level MFA (above the single-level fused window): original
+          // 6-unit forward batch; the pointwise sweep below handles the
+          // product.
+          auto fwdBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
+            {
+              switch (idx)
+              {
+                case 0: ForwardMFA<F1>(bufs[0], n, scrs[0], /*parallel=*/false, tree1); break;
+                case 1: ForwardMFA<F1>(bufs[1], n, scrs[1], /*parallel=*/false, tree1); break;
+                case 2: ForwardMFA<F2>(bufs[2], n, scrs[2], /*parallel=*/false, tree2); break;
+                case 3: ForwardMFA<F2>(bufs[3], n, scrs[3], /*parallel=*/false, tree2); break;
+                case 4: ForwardMFA<F3>(bufs[4], n, scrs[4], /*parallel=*/false, tree3); break;
+                case 5: ForwardMFA<F3>(bufs[5], n, scrs[5], /*parallel=*/false, tree3); break;
+              }
+            }
+          };
+          ParallelDo(6, fwdBody);
+        }
       }
       else
 #endif
@@ -2033,6 +2208,11 @@ namespace BigMath
 #endif
       }
 
+      // The fused MFA path already multiplied fb into fa during forward
+      // stage B; the standalone pointwise sweep runs for every other path.
+#if BIGMATH_NTT_MFA
+      if (!pointwiseFused)
+#endif
       {
         UInt *p1a = fa1.data(), *p1b = fb1.data();
         UInt *p2a = fa2.data(), *p2b = fb2.data();
@@ -2052,22 +2232,80 @@ namespace BigMath
 #if BIGMATH_NTT_MFA
       if (useMfa)
       {
-        // Reuse the first three forward scratches; the other three are freed
-        // implicitly when the function returns. Each task gets its own.
+        // Reuse the per-prime forward scratches. Each task gets its own.
         UInt *bufs[3] = {fa1.data(), fa2.data(), fa3.data()};
         UInt *scrs[3] = {mfaScratch[0].data(), mfaScratch[1].data(), mfaScratch[2].data()};
-        auto invBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
-          for (Int idx = s; idx < e; ++idx)
-          {
-            switch (idx)
+
+        Int n1 = 0, n2 = 0;
+        MFAFactor(n, n1, n2);
+#if BIGMATH_NTT_MFA_FUSE
+        if (n1 <= BIGMATH_NTT_MFA_LEAF && n2 <= BIGMATH_NTT_MFA_LEAF)
+        {
+          // Row-chunked inverse: the 2-concurrent-process probe showed a
+          // single multiply uses only ~64% of DRAM bandwidth, so the old
+          // ParallelDo(3) (one whole per-prime inverse per unit, 3 cores
+          // busy) leaves wall-clock on the table. Split each fused inverse
+          // stage into (prime, half-row-range) units — 6 concurrent units
+          // per phase, same math, barrier between stages preserved (stage B
+          // row j reads scratch elements written by every stage A unit).
+          const UInt *inv1 = tree1.Get(n).inverseRoots.data();
+          const UInt *inv2 = tree2.Get(n).inverseRoots.data();
+          const UInt *inv3 = tree3.Get(n).inverseRoots.data();
+          const Plan<F1> *pn2_1 = &tree1.Get(n2), *pn1_1 = &tree1.Get(n1);
+          const Plan<F2> *pn2_2 = &tree2.Get(n2), *pn1_2 = &tree2.Get(n1);
+          const Plan<F3> *pn2_3 = &tree3.Get(n2), *pn1_3 = &tree3.Get(n1);
+          const Int *br = GetBitReverseTable(n2).data();
+
+          const Int halfA = n2 >> 1; // stage A iterates n2 rows of length n1
+          auto invStageA = [bufs, scrs, n1, n2, halfA,
+                            pn1_1, pn1_2, pn1_3](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
             {
-              case 0: InverseMFA<F1>(bufs[0], n, scrs[0], /*parallel=*/false, tree1); break;
-              case 1: InverseMFA<F2>(bufs[1], n, scrs[1], /*parallel=*/false, tree2); break;
-              case 2: InverseMFA<F3>(bufs[2], n, scrs[2], /*parallel=*/false, tree3); break;
+              Int r0s = (idx & 1) ? halfA : 0;
+              Int r0e = (idx & 1) ? n2 : halfA;
+              switch (idx >> 1)
+              {
+                case 0: FusedInverseA<F1>(bufs[0], scrs[0], n1, n2, *pn1_1, r0s, r0e); break;
+                case 1: FusedInverseA<F2>(bufs[1], scrs[1], n1, n2, *pn1_2, r0s, r0e); break;
+                case 2: FusedInverseA<F3>(bufs[2], scrs[2], n1, n2, *pn1_3, r0s, r0e); break;
+              }
             }
-          }
-        };
-        ParallelDo(3, invBody);
+          };
+          ParallelDo(6, invStageA);
+
+          const Int halfB = n1 >> 1; // stage B iterates n1 rows of length n2
+          auto invStageB = [bufs, scrs, n, n1, n2, halfB, inv1, inv2, inv3,
+                            pn2_1, pn2_2, pn2_3, br](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
+            {
+              Int r0s = (idx & 1) ? halfB : 0;
+              Int r0e = (idx & 1) ? n1 : halfB;
+              switch (idx >> 1)
+              {
+                case 0: FusedInverseB<F1>(bufs[0], scrs[0], n, n1, n2, *pn2_1, inv1, br, r0s, r0e); break;
+                case 1: FusedInverseB<F2>(bufs[1], scrs[1], n, n1, n2, *pn2_2, inv2, br, r0s, r0e); break;
+                case 2: FusedInverseB<F3>(bufs[2], scrs[2], n, n1, n2, *pn2_3, inv3, br, r0s, r0e); break;
+              }
+            }
+          };
+          ParallelDo(6, invStageB);
+        }
+        else
+#endif
+        {
+          auto invBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
+            {
+              switch (idx)
+              {
+                case 0: InverseMFA<F1>(bufs[0], n, scrs[0], /*parallel=*/false, tree1); break;
+                case 1: InverseMFA<F2>(bufs[1], n, scrs[1], /*parallel=*/false, tree2); break;
+                case 2: InverseMFA<F3>(bufs[2], n, scrs[2], /*parallel=*/false, tree3); break;
+              }
+            }
+          };
+          ParallelDo(3, invBody);
+        }
       }
       else
 #endif

--- a/mem_pass_fusion.md
+++ b/mem_pass_fusion.md
@@ -1,6 +1,34 @@
 # MFA Memory-Pass Fusion Plan
 
-Status: PLANNED (written 2026-06-12, post PR #82–#105 optimization run).
+Status: F1 IMPLEMENTED (2026-06-12, `FusedForwardBMul` + row-chunked
+ParallelDo(6) stage phases in NTTMultiplicationCrt.h). Measured 1.20×
+warm-state at 3M–10M limbs — but read the revised analysis below before
+starting F2/F3.
+
+## REVISED PREMISE (2026-06-12, post-F1 measurement)
+
+The "fully memory-bandwidth-bound" premise below is WRONG post-NEON
+(PRs #96–#99 shifted the balance). Direct probe on M1 Max: two concurrent
+multiplies run at +28% per-process (1.56× aggregate) — a single multiply
+draws only ~64% of DRAM bandwidth. Consequences, measured warm-state
+(first call discarded; cold-inclusive runs mask everything under plan
+build + page faults):
+
+- Pure pass-cutting (F1 fusion alone, with forward work units dropping
+  6→3): **1.47× regression**. Concurrency loss outweighs byte savings.
+- Pass-cutting with concurrency preserved (row-chunked ParallelDo(6)
+  phases): parity only.
+- Concurrency raised on the inverse too (old code: ParallelDo(3) whole
+  transforms — 3 cores busy for a third of the multiply): **1.20× win**.
+  This is where the F1 PR's gain actually comes from.
+
+F2 (Garner fusion) re-scoped: its single-threaded-stitch prototype would
+repeat the F1 mistake. The winning direction is the opposite — chunk
+FinalizeProduct (serial today!) into per-range Garner with carry fix-up,
+i.e. F2's tiling for PARALLELISM first, byte savings second. F3 likewise:
+fold pack into stage A only if it keeps ≥6 concurrent units.
+Re-run the 2-process probe after each step; once a single multiply
+saturates bandwidth, byte-cutting resumes being the lever.
 Owner note: this is the last identified structural performance lever. Every
 band below 50M digits is at or better than GMP parity; the 50M–200M-digit
 band (balanced mul 1.28–1.33×, div 1.23–1.37× vs GMP) is

--- a/tests/performance/mfa_mul_gmp_probe.cpp
+++ b/tests/performance/mfa_mul_gmp_probe.cpp
@@ -1,0 +1,89 @@
+// Raw-limb GMP probe for the MFA multiplication band (mem_pass_fusion.md
+// correctness protocol, step 3).
+//
+// Drives NttCrt::Multiply directly on random Base2_64 limb vectors and
+// compares against GMP via mpz_import/mpz_export. Deliberately NEVER uses
+// Parse/ToString: those route through the very multiplication band under
+// test, so a corrupt MFA layer could cancel itself out and the comparison
+// would prove nothing (the PR #103 lesson).
+//
+// Default tiers put the transform length at 2^24 and 2^25 — at and above the
+// MFA gate — plus one 8:1 skewed shape for the lowered high-skew cutover.
+// Runtime is minutes and memory is several GB; this is a pre-merge probe,
+// not a ctest.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include <gmp.h>
+
+#include "biginteger/common/Constants.h"
+#include "biginteger/algorithms/multiplication/NTTMultiplicationCrt.h"
+
+using namespace BigMath;
+
+static std::vector<DataT> RandLimbs(SizeT n, uint64_t seed)
+{
+    std::mt19937_64 g(seed);
+    std::vector<DataT> v(n);
+    for (SizeT i = 0; i < n; ++i) v[i] = g();
+    if (v.back() == 0) v.back() = 1; // keep the top limb significant
+    return v;
+}
+
+static bool Check(SizeT la, SizeT lb, uint64_t seed)
+{
+    std::vector<DataT> a = RandLimbs(la, seed);
+    std::vector<DataT> b = RandLimbs(lb, seed ^ 0x9E3779B97F4A7C15ULL);
+
+    std::vector<DataT> c = NttCrt::Multiply(a, b, Base2_64);
+
+    mpz_t ga, gb, gc;
+    mpz_init(ga); mpz_init(gb); mpz_init(gc);
+    mpz_import(ga, la, -1, sizeof(DataT), 0, 0, a.data());
+    mpz_import(gb, lb, -1, sizeof(DataT), 0, 0, b.data());
+    mpz_mul(gc, ga, gb);
+
+    size_t gn = 0;
+    std::vector<DataT> g(la + lb, 0);
+    mpz_export(g.data(), &gn, -1, sizeof(DataT), 0, 0, gc);
+    mpz_clear(ga); mpz_clear(gb); mpz_clear(gc);
+
+    bool ok = (c.size() == gn) && (memcmp(c.data(), g.data(), gn * sizeof(DataT)) == 0);
+    printf("mul %zu x %zu limbs : %s  (bm_limbs=%zu, gmp_limbs=%zu)\n",
+           (size_t)la, (size_t)lb, ok ? "OK" : "FAIL", c.size(), gn);
+    if (!ok)
+    {
+        size_t lim = std::min(c.size(), gn);
+        for (size_t i = 0; i < lim; ++i)
+            if (c[i] != g[i])
+            {
+                printf("  first diff at limb %zu: bm=%016llx gmp=%016llx\n",
+                       i, (unsigned long long)c[i], (unsigned long long)g[i]);
+                break;
+            }
+    }
+    return ok;
+}
+
+int main(int argc, char **argv)
+{
+    bool ok = true;
+    if (argc > 1)
+    {
+        for (int k = 1; k + 1 < argc; k += 2)
+            ok &= Check((SizeT)atoll(argv[k]), (SizeT)atoll(argv[k + 1]), 0xC0FFEE ^ k);
+    }
+    else
+    {
+        // 2 coeffs/limb: la+lb limbs → ~2(la+lb) coeffs → n = bit_ceil.
+        ok &= Check(1u << 22, 1u << 22, 0xC0FFEE01); // n = 2^24 (MFA gate)
+        ok &= Check(1u << 23, 1u << 23, 0xC0FFEE02); // n = 2^25
+        ok &= Check(1u << 23, 1u << 20, 0xC0FFEE03); // 8:1 skew, n = 2^25
+    }
+    printf("%s\n", ok ? "ALL OK" : "FAILURES");
+    return ok ? 0 : 1;
+}

--- a/tests/unit/test_mfa.cpp
+++ b/tests/unit/test_mfa.cpp
@@ -86,6 +86,41 @@ namespace
 
     return fa == ga;
   }
+
+  // The F1 pass fusion (ForwardMFAMul, mem_pass_fusion.md) must produce the
+  // exact spectrum product the unfused pipeline does: forward A, then
+  // forward B with the pointwise multiply fused into B's scatter, must equal
+  // forward A + forward B + separate pointwise sweep. Verified through the
+  // full inverse so a fused-path bug can't hide in the MFA permutation.
+  template <typename F, UInt G>
+  bool FusedPointwiseMatchesUnfusedOk(Int n, uint64_t seed)
+  {
+    std::mt19937_64 gen(seed);
+    std::uniform_int_distribution<uint32_t> dis(0, F::Prime - 1);
+
+    std::vector<UInt> a(n), b(n);
+    for (Int i = 0; i < n; ++i)
+    {
+      a[i] = dis(gen);
+      b[i] = dis(gen);
+    }
+
+    // Unfused reference pipeline.
+    std::vector<UInt> ra = a, rb = b, scratch(n);
+    ForwardMFA<F, G>(ra.data(), n, scratch.data(), /*parallel=*/false);
+    ForwardMFA<F, G>(rb.data(), n, scratch.data(), /*parallel=*/false);
+    for (Int i = 0; i < n; ++i)
+      ra[i] = F::Mul(ra[i], rb[i]);
+    InverseMFA<F, G>(ra.data(), n, scratch.data(), /*parallel=*/false);
+
+    // Fused pipeline: B's forward multiplies into A's plane at scatter time.
+    std::vector<UInt> fa = a, fb = b;
+    ForwardMFA<F, G>(fa.data(), n, scratch.data(), /*parallel=*/false);
+    ForwardMFAMul<F, G>(fb.data(), n, scratch.data(), fa.data(), /*parallel=*/false);
+    InverseMFA<F, G>(fa.data(), n, scratch.data(), /*parallel=*/false);
+
+    return fa == ra;
+  }
 }
 
 // n must exceed BIGMATH_NTT_MFA_LEAF (2^13) for the MFA decomposition (and
@@ -120,4 +155,25 @@ REGISTER_TEST(MfaTransform, ConvolutionMatchesPlainP1)
 REGISTER_TEST(MfaTransform, ConvolutionMatchesPlainP2)
 {
   ASSERT_TRUE((ConvolutionMatchesPlainOk<F2, G2>(1 << 14, 0xEE1)));
+}
+
+// 2^14/2^15/2^17 hit the single-level fused-mul scatter (even and uneven
+// n1/n2 factorizations); 2^12 sits at/below the leaf, exercising
+// ForwardMFAMul's plain-forward + pointwise fallback branch.
+REGISTER_TEST(MfaTransform, FusedPointwiseMatchesUnfusedP1)
+{
+  ASSERT_TRUE((FusedPointwiseMatchesUnfusedOk<F1, G1>(1 << 12, 0xFF0)));
+  ASSERT_TRUE((FusedPointwiseMatchesUnfusedOk<F1, G1>(1 << 14, 0xFF1)));
+  ASSERT_TRUE((FusedPointwiseMatchesUnfusedOk<F1, G1>(1 << 15, 0xFF2)));
+  ASSERT_TRUE((FusedPointwiseMatchesUnfusedOk<F1, G1>(1 << 17, 0xFF3)));
+}
+
+REGISTER_TEST(MfaTransform, FusedPointwiseMatchesUnfusedP2)
+{
+  ASSERT_TRUE((FusedPointwiseMatchesUnfusedOk<F2, G2>(1 << 14, 0xFF4)));
+}
+
+REGISTER_TEST(MfaTransform, FusedPointwiseMatchesUnfusedP3)
+{
+  ASSERT_TRUE((FusedPointwiseMatchesUnfusedOk<F3, G3>(1 << 14, 0xFF5)));
 }


### PR DESCRIPTION
## What

Implements **F1 from `mem_pass_fusion.md`** (pointwise multiply fused into operand B's last forward MFA stage), reshaped by measurement into a parallelism-first design:

- **`FusedForwardBMul`**: operand B's stage B multiplies its spectrum into operand A's already-transformed plane at scatter time (`fa[i] = fa[i] · f̂b[i]`). fb's spectrum never reaches DRAM; the standalone pointwise sweep disappears.
- **Forward** in the single-level MFA window: two `ParallelDo(6)` phases — stage A for all six operand×prime planes, then stage B as (prime, half-row-range) units.
- **Inverse**: two `ParallelDo(6)` half-range phases instead of `ParallelDo(3)` whole transforms — this is where most of the win comes from (the old inverse left cores idle for a third of the multiply).
- Multi-level MFA lengths and the non-MFA path are unchanged (original 6-unit batch + pointwise sweep).

## Measured (M1 Max, warm-state, best-of-3 × 3 interleaved rounds vs main)

| limbs | base | this PR | Δ |
|---|---:|---:|---|
| 3M | 752 ms | 630 ms | **−16.2%** |
| 5M | 1571 ms | 1303 ms | **−17.1%** |
| 10M | 3347 ms | 2778 ms | **−17.0%** |

Warm-state = first call discarded; cold-inclusive timings bury the effect under plan build + first-touch page faults. Ambient load was 3–4 during runs (spotlight/mediaanalysisd); relative deltas were consistent to <1% across rounds. Worth re-confirming on a quiet machine before reading absolute numbers into BENCHMARK.md.

## Premise correction (plan doc updated)

The plan's "fully memory-bandwidth-bound" premise is **wrong post-NEON**: a 2-concurrent-process probe shows one multiply draws only ~64% of DRAM bandwidth (1.56× aggregate). Two rejected shapes documented in `docs/MULTIPLICATION.md`:

- whole-prime fa/fb pairing in `ParallelDo(3)`: **1.47× regression** (concurrency loss > byte savings)
- sequential primes with internal `ParallelFor`: **2× regression** — MFA stage row counts (≤2^13) sit below `ParallelMinSize()` = 65536, the internal gate never fires; `ParallelDo` bypasses it

`mem_pass_fusion.md` now carries the revised analysis; F2/F3 re-scoped parallelism-first (FinalizeProduct is serial today — same idle-core shape the inverse had).

## Correctness (protocol per `mem_pass_fusion.md`, learned from PR #103)

1. `unit_tests` MfaTransform green, incl. new `FusedPointwiseMatchesUnfused` tests for all three CRT primes — fused scatter at 2^14/2^15/2^17, fallback branch at 2^12
2. `mfa_roundtrip` (n=2^23) ctest green; `mult_correctness` / `div_correctness` green
3. New **raw-limb GMP probe** (`tests/performance/mfa_mul_gmp_probe`, mpz_import/export — never ToString): OK at n=2^24, 2^25, and 8:1 skew
4. Transient-break validated twice: (a) swapped fused stage-B order, (b) removed the inverse inter-stage barrier — each makes the probe FAIL at limb 0; restored code passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)