### PR TITLE
perf: retune MFA gate 2^24 → 2^20 — division beats GMP at 50-100M digits

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -98,7 +98,26 @@ Warm-state methodology (NOT comparable to the cold single-iter rows above): raw-
 Two structural findings from this work:
 
 - **The band is no longer purely memory-bandwidth-bound post-NEON.** A 2-concurrent-process probe shows one multiply draws ~64–69% of the M1 Max's DRAM bandwidth; pure pass-cutting that sacrificed work-unit concurrency regressed 1.47×. Parallelism is the current lever (mem_pass_fusion.md carries the revised analysis).
-- **Division did not inherit the win** (~1% movement): Newton's inner products route through the cyclic `MultiplyMod2km1` path (capped at `n ≤ 2^22`, below the MFA gate by design) and the prepared-operand path (`PrepareOperand`/`Multiply(prepared, other)`), which has no MFA at all. Large division (1.37–1.44× vs GMP) is now the widest remaining gap.
+- **Division did not inherit the win** (~1% movement): Newton's inner products route through the cyclic `MultiplyMod2km1` path (capped at `n ≤ 2^22`, below the MFA gate by design) and transforms at `n = 2^22–2^23` — below the 2^24 MFA gate. Addressed by the gate retune below.
+
+### MFA gate retune 2^24 → 2^20 (2026-06-12, post-#107)
+
+A `sample` profile of 200M÷40M-digit division showed ~88% of active compute in plain (whole-transform) radix-8 NTT layers with half of all thread-time in `psynch_cvwait` — Newton's transforms sit at `n = 2^22–2^23`, below the MFA gate, on the non-MFA path whose `ParallelDo(6)`/`ParallelDo(3)` whole-transform units idle cores. The 2^24 break-even was measured before PR #107's row-chunked stages existed; re-sweeping the gate (warm-state, quiet machine, best-of-2×2–3 interleaved rounds) flipped it decisively:
+
+| op | size (limbs) | n | gate 2^24 | gate 2^20 | BM/GMP was → now |
+|---|---|---|---:|---:|---|
+| mul | 1M × 1M | 2^22 | 299.1 | **100.7** | 1.12× → **0.38×** |
+| mul | 2M × 2M | 2^23 | 621.5 | **278.9** | 1.15× → **0.52×** |
+| mul | 500k × 500k | 2^21 | 102.5 | **50.4** | 1.06× → **0.51×** |
+| mul | 250k × 250k | 2^20 | 25.9 | 25.5 | 0.59× (wash) |
+| div | 1M ÷ 200k | — | 358.6 | **288.5** | 1.26× → **1.01×** |
+| div | 2.6M ÷ 520k | — | 904.0 | **626.8** | 1.03× → **0.71×** |
+| div | 5.2M ÷ 1.04M | — | 3 166.0 | **1 700.9** | 1.37× → **0.74×** |
+| div | 10.4M ÷ 2.08M | — | 6 492.4 | **4 426.9** | 1.47× → **1.00×** |
+
+**Division now beats GMP at ≈50–100M-digit dividends (0.71–0.74×) and reaches parity at 200M÷40M digits.** Lower gates (2^18) measured ≈ wash vs 2^20 (≤4% div); 2^20 keeps the gate out of the latency-sensitive sub-ms band. The remaining 200M÷40M gap is the cyclic `MultiplyMod2km1` transforms (always plain, `n ≤ 2^22` cap) — next candidate is routing those through the fused-stage machinery.
+
+Correctness: raw-limb GMP probe OK at every newly-MFA size (n=2^20–2^23 balanced + 8:1 skew at n=2^19 high-skew gate); full unit/roundtrip/mult/div correctness batteries green.
 
 ### MFA focused threshold check
 

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -74,14 +74,16 @@
 #define BIGMATH_NTT_MFA_LEAF (1 << 13)
 #endif
 
-// MFA fires when transform length n reaches this. Default 2^24 = 16,777,216
-// coeffs ≈ 64 MB per-prime buffer. For balanced Base2_64 multiplication this
-// starts around 2M limbs per operand (≈40M decimal digits), because each limb
-// contributes two CRT coefficients and the convolution length is about 4L.
-// Fresh M1 Max measurements showed the previous 2^21 gate was too early: MFA
-// lost through ~2^23 and won around 2^24+ transform lengths.
+// MFA fires when transform length n reaches this. Canonical value lives in
+// build/DispatchThresholds.h (2^20 since the 2026-06-12 post-PR-#107
+// retune); this fallback only applies if that header isn't in the TU.
+// History: 2^21 (too early pre-NEON) -> 2^24 (MFA lost through ~2^23 with
+// whole-transform ParallelDo batching) -> 2^20: the row-chunked
+// ParallelDo(6) fused stages from PR #107 keep 6-12 work units busy where
+// the non-MFA path idles cores, flipping the break-even (warm-state
+// n=2^22 mul 3.0x, n=2^23 2.2x vs non-MFA).
 #ifndef BIGMATH_NTT_MFA_THRESHOLD
-#define BIGMATH_NTT_MFA_THRESHOLD (1 << 24)
+#define BIGMATH_NTT_MFA_THRESHOLD (1 << 20)
 #endif
 
 // Fuse the MFA transpose into the adjacent row-FFT pass. The plain MFA writes a

--- a/include/biginteger/build/DispatchThresholds.h
+++ b/include/biginteger/build/DispatchThresholds.h
@@ -53,8 +53,15 @@
 #define BIGMATH_NTT_CRT_THRESHOLD 256
 #endif
 
+// Post-PR-#107 retune (2026-06-12): the row-chunked ParallelDo(6) fused MFA
+// stages flipped the old 2^24 break-even — the whole-transform non-MFA path
+// idles cores (6-unit forward, 3-unit inverse) while the fused path keeps
+// 6-12 units busy. Warm-state sweep (quiet M1 Max, best-of-3 interleaved):
+// n=2^22 mul 3.0× faster, n=2^23 2.2×, div 100M÷20M digits 1.37→0.74× vs
+// GMP, 200M÷40M 1.47→1.01×. 2^18 measured ≈ wash vs 2^20 (≤4% div); 2^20
+// keeps the gate out of the latency-sensitive sub-ms band.
 #ifndef BIGMATH_NTT_MFA_THRESHOLD
-#define BIGMATH_NTT_MFA_THRESHOLD (1 << 24)
+#define BIGMATH_NTT_MFA_THRESHOLD (1 << 20)
 #endif
 
 #ifndef BIGMATH_NTT_SQUARE_THRESHOLD

--- a/mem_pass_fusion.md
+++ b/mem_pass_fusion.md
@@ -48,11 +48,17 @@ Warm-state raw-limb suite, best-of-3 × 3 interleaved rounds vs pre-#107
 
 ## Next-lever ranking (revised after validation)
 
-1. **Division MFA routing** — the widest gap left (1.37–1.44× vs GMP).
-   Add MFA to the prepared-operand transform path (its forward/inverse are
-   plain Forward/Inverse), and/or raise the cyclic cap with an MFA-aware
-   MultiplyMod2km1. Newton's big linear multiplies then inherit #107's
-   1.20× automatically.
+1. **Division MFA routing — DONE via gate retune (2026-06-12)**. Profile
+   showed div's transforms at n=2^22–2^23, below the 2^24 gate, with half
+   of thread-time in psynch_cvwait. The 2^24 break-even predated #107's
+   row-chunked stages; re-sweep flipped it. Gate now **2^20**
+   (DispatchThresholds.h): mul n=2^22 3.0×, n=2^23 2.2×, n=2^21 2.0×;
+   div 50–100M digits 0.71–0.74× vs GMP (beats), 200M÷40M 1.47→1.00×
+   (parity). 2^18 ≈ wash (≤4% div) — left on the table for tune.yml.
+   Remaining 200M÷40M residual: cyclic MultiplyMod2km1 transforms (always
+   plain Forward/Inverse, n ≤ 2^22 cap) — route through fused stages
+   and/or raise the cap; also the prepared-operand path still has no MFA
+   (matters for ops/Multiplication.h repeated-multiply users, not Newton).
 2. F3 pack fusion (parallelism-first): PackOperand is a serial sweep
    writing 6 planes, plus 12 serial plane zero-fills (assign(n,0)) —
    ~1.6 GB serial at 10M limbs. Fold into stage A's ParallelDo(6) gather.


### PR DESCRIPTION
## Why

`sample` profile of 200M÷40M-digit division: ~88% of active compute in plain whole-transform radix-8 NTT layers, half of all thread-time in `psynch_cvwait`. Newton's transforms sit at n=2^22–2^23 — below the 2^24 MFA gate — on the non-MFA path whose whole-transform `ParallelDo(6)`/`ParallelDo(3)` units idle cores. That's why division didn't inherit #107.

The 2^24 break-even predates #107's row-chunked fused stages. Re-swept warm-state on a quiet machine:

## Measured (interleaved best-of-3, M1 Max)

| op | size | n | gate 2^24 | gate 2^20 | vs GMP was → now |
|---|---|---|---:|---:|---|
| mul | 1M limbs | 2^22 | 299 ms | **101 ms** | 1.12× → **0.38×** |
| mul | 2M limbs | 2^23 | 621 ms | **279 ms** | 1.15× → **0.52×** |
| mul | 500k limbs | 2^21 | 103 ms | **50 ms** | 1.06× → **0.51×** |
| mul | 250k limbs | 2^20 | wash | wash | 0.59× |
| div | 1M÷200k | | 359 ms | **289 ms** | 1.26× → **1.01×** |
| div | 2.6M÷520k | | 904 ms | **627 ms** | 1.03× → **0.71×** |
| div | 5.2M÷1.04M | | 3166 ms | **1701 ms** | 1.37× → **0.74×** |
| div | 10.4M÷2.08M | | 6492 ms | **4427 ms** | 1.47× → **1.00×** |

**Division now beats GMP at 50–100M-digit dividends (0.71–0.74×) and reaches parity at 200M÷40M.** Mul gains 2-3× in the 2^21–2^23 band on top of #107.

Gate 2^18 ≈ wash vs 2^20 (≤4% div) — left for a tune.yml sweep. Remaining 200M÷40M residual = cyclic `MultiplyMod2km1` transforms (always plain, n ≤ 2^22 cap); noted in `mem_pass_fusion.md` as next candidate.

## Correctness

- Raw-limb GMP probe (`mfa_mul_gmp_probe`) OK at every newly-MFA size: n=2^20–2^23 balanced, 8:1 skew at the n=2^19 high-skew gate, plus existing 2^24/2^25 tiers
- `unit_tests` 254/254, `mfa_roundtrip`, `mult_correctness`, `div_correctness` all green
- Default-build spot-check matches the `-D` sweep numbers (include-order sanity for the `#ifndef` fallback, which is also updated to 2^20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)