### PR TITLE
docs: ToString + small-skew division implementation plans; README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ BigMath vs GMP 6.3, Apple M1 Max, paired same-run measurements (2026-06-12). Bel
 
 ![BigMath vs GMP ratio by operand size](docs/images/bigmath_vs_gmp.png)
 
-- **Multiplication beats GMP by 1.5–2.4× across 500k–10M digits** (5M×5M: 26.2 vs 63.4 ms) and at skewed shapes 500k×50k – 5M×500k.
-- **Division reaches GMP parity from 5M digits** (10M×2M: 0.94× — BigMath faster).
-- **Decimal I/O near parity at scale**: parse 20M digits 1.09×, to-string 20M digits 1.16×.
-- Sub-NTT sizes (≲ 13k digits) remain 2–3× behind GMP's hand-tuned basecase.
+- **Multiplication beats GMP at every balanced size from 500k digits up** — peaking at 3.2× faster (10M×10M: 65 vs 206 ms) and staying at or below GMP through 200M digits (warm steady state) — and at **every measured skewed shape ≥500k×50k** (0.40–0.77×).
+- **Division beats GMP from 20M-digit dividends (0.45–0.82×)** and reaches parity from 5M (200M÷40M: 3.0 s vs GMP's 4.5 s).
+- **Decimal I/O at parity at scale**: parse 20M digits 1.01×, 50M 1.04×; to-string 10M digits 1.17× warm.
+- Sub-NTT sizes (≲ 13k digits) remain 2–3× behind GMP's hand-tuned basecase, and ToString below ~2M digits is the largest remaining gap (1.9–4×; see `tostring_chain_plan.md`).
 
-The 2026-06-11/12 optimization run (PRs #82–#99: wraparound Newton division, dispatch band retunes, quotient-sized division, NEON Shoup NTT butterflies) produced most of the current margins:
+Two 2026-06 optimization runs produced the current margins — PRs #82–#99 (wraparound Newton division, dispatch band retunes, quotient-sized division, NEON Shoup NTT butterflies) and PRs #107–#112 (fused-MFA pass fusion, row-chunked stage parallelism, MFA gate 2^24→2^20, cyclic products on the fused pipeline, on-the-fly operand packing):
 
 ![Session before/after](docs/images/session_2026_06_11.png)
 
@@ -29,8 +29,8 @@ Full tables, methodology, and per-PR history: [BENCHMARK.md](BENCHMARK.md).
 - **Multiplication:** Classic schoolbook → Karatsuba (64-bit-hybrid leaf) → 3-prime CRT NTT (2013265921 / 469762049 / 1811939329, 32-bit coefficient splitting) from 1280 total limbs (~13k digits). Toom-3 and the single-prime Goldilocks NTT remain as cross-check alternates; the NEON-accelerated CRT path beats both at every measured size.
 - **Radix-4 + radix-8 fused NTT butterflies** (PRs #59, #60): 3× fewer memory passes vs radix-2; ~1.6× wall-clock at ≥2M limbs.
 - **NEON Shoup butterflies on aarch64** (PRs #96–#99, `BIGMATH_NEON=1` default on Apple Silicon): the radix-8/4/2 layers and 1/n scaling run 4 lanes wide using Shoup's precomputed-reciprocal multiplication — `(w·x) mod P` from one widening multiply, one low multiply, one conditional subtract, with interleaved `(twiddle, w′)` tables keeping the strided gathers at one cache line per pair. Bit-exact with the scalar path; ~4× per butterfly pass, −26…40% end-to-end on NTT-bound ops. Scalar fallback everywhere else.
-- **MFA / Bailey 6-step CRT NTT** (`BIGMATH_NTT_MFA_THRESHOLD=2^24`, default). Very large CRT transforms switch to a cache-friendly matrix Fourier layout. The threshold was retuned upward from `2^21` to avoid regressions in the 300k-2M limb band while keeping wins at `2^24+` transform sizes.
-- **Multithreaded NTT** (`BIGMATH_USE_THREADS=1`, default). Small thread pool (size `min(hw_concurrency, BIGMATH_MAX_THREADS=8)`) parallelizes the CRT path: 6 forwards + 3 inverses as batched work units, one `ParallelDo` dispatch per phase. 2.3-3.4× speedup on large mul / skewed div / parse. Opt out via `-DBIGMATH_USE_THREADS=0` to drop pthread linkage.
+- **MFA / Bailey 6-step CRT NTT** (`BIGMATH_NTT_MFA_THRESHOLD=2^20`, default). Large CRT transforms switch to a cache-friendly matrix Fourier layout with fully fused stages: the transpose, the operand packing (straight from the limb arrays), and the pointwise product all ride the tiled stage passes, and the forward/inverse stages run as row-chunked `ParallelDo(6)` work units. The gate sat at `2^24` until the fused stages flipped the break-even (PR #109); cyclic wrap-around products use the same pipeline up to the CRT ceiling `2^26` (PR #110).
+- **Multithreaded NTT** (`BIGMATH_USE_THREADS=1`, default). Small thread pool (size `min(hw_concurrency, BIGMATH_MAX_THREADS=8)`) parallelizes the CRT path: in the fused MFA window each transform stage runs as six (operand×prime or prime×row-range) work units; the non-MFA path batches 6 forwards + 3 inverses. 2.3-3.4× speedup on large mul / skewed div / parse. Opt out via `-DBIGMATH_USE_THREADS=0` to drop pthread linkage.
 - **Division:** Classic short division → Knuth Algorithm D (`FastDivision`, Möller-Granlund qhat, bit-shift normalization) → Burnikel–Ziegler (small near-balanced) → Newton–Raphson with cached reciprocals and wrap-around cyclic products (half-length transforms for the remainder, quotient-estimate, and reciprocal-iteration steps — GMP `mu_div`/`invertappr` style) → quotient-sized division for short-quotient shapes (cost scales with the quotient, not the divisor). Dispatch bands use fractional ratios (5/2, 8/5, 4/3) to avoid one-limb knife-edge cliffs. Identity `q·b + r == a` is cross-checked in `tests/div_correctness.cpp`.
 - **Squaring:** Specialized Classic / Karatsuba / NTT squarers (1.4–1.6× over `Multiply(a,a)`).
 - **String I/O:** Linear chunked parser/formatter for small inputs, divide-and-conquer with cached Newton reciprocals at scale. Asymptotic `O(M(L) · log L)` both directions.
@@ -138,32 +138,30 @@ Each doc covers algorithms, dispatch, benchmark numbers vs GMP, optimizations th
 
 ## Performance
 
-Apple M1 Max, vs GMP 6.3.0, `-O3 -march=native`, full default stack (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool). Min of 5 runs:
+Apple M1 Max, vs GMP 6.3.0, `-O3 -march=native`, full default stack (`BIGMATH_LIMB_64=1` + `BIGMATH_NTT_CRT=1` + `BIGMATH_USE_THREADS=1`, 8-thread pool). Canonical `bench_vs_gmp` run, 2026-06-12 evening (post PR #107–#112):
 
 | operation | size | BigMath | GMP | ratio |
 |---|---|---:|---:|---:|
-| mul | 100 000 × 100 000 | 1.35 ms | 0.78 ms | 1.72× |
-| mul | 1 000 000 × 1 000 000 | 10.5 ms | 9.06 ms | 1.16× |
-| mul | 2 000 000 × 2 000 000 | 21.9 ms | 20.6 ms | 1.07× |
-| mul | **5 000 000 × 5 000 000** | **46.5 ms** | **63.5 ms** | **0.73×** ← BigMath faster |
-| mul | **10 000 000 × 10 000 000** | **105 ms** | **212 ms** | **0.50×** ← BigMath 2.01× faster |
-| mul | 20 000 000 × 20 000 000 | 279 ms | 278 ms | 1.00× ← parity |
-| mul | 50 000 000 × 50 000 000 | 1 231 ms | 660 ms | 1.86× ← GMP SSA recovers |
-| mul | 100 000 000 × 100 000 000 | 2 832 ms | 1 391 ms | 2.04× |
-| mul (skewed) | **1 000 000 / 100 000** | **4.47 ms** | **4.79 ms** | **0.93×** ← BigMath faster |
-| mul (skewed) | 2 000 000 / 200 000 | 9.43 ms | 9.45 ms | 1.00× ← parity |
-| mul (skewed) | 10 000 000 / 1 000 000 | 88.4 ms | 70.5 ms | 1.25× |
-| mul (skewed) | 50 000 000 / 5 000 000 | 667 ms | 666 ms | 1.00× ← parity |
-| div (skewed) | 500 000 / 100 000 | 18.0 ms | 4.63 ms | 3.89× |
-| div (skewed) | 10 000 000 / 2 000 000 | 427 ms | 154 ms | 2.78× |
-| div (skewed) | 50 000 000 / 10 000 000 | 2 500 ms | 1 299 ms | **1.92×** |
-| parse | 1 000 000 digits | 48.7 ms | 20.3 ms | 2.40× |
-| parse | 20 000 000 digits | 1 252 ms | 803 ms | **1.56×** |
-| ToString | 100 000 digits | 19.5 ms | 2.33 ms | 8.35× |
-| ToString | 1 000 000 digits | 224 ms | 49.8 ms | 4.50× |
-| ToString | 20 000 000 digits | 5 437 ms | 2 116 ms | **2.57×** |
+| mul | 100 000 × 100 000 | 0.66 ms | 0.61 ms | 1.08× |
+| mul | **1 000 000 × 1 000 000** | **7.8 ms** | **9.6 ms** | **0.81×** ← BigMath faster |
+| mul | **5 000 000 × 5 000 000** | **32.6 ms** | **64.4 ms** | **0.51×** ← BigMath 2× faster |
+| mul | **10 000 000 × 10 000 000** | **65 ms** | **206 ms** | **0.32×** ← BigMath 3.2× faster |
+| mul | **20 000 000 × 20 000 000** | **129 ms** | **276 ms** | **0.47×** ← BigMath 2.1× faster |
+| mul | **200 000 000 × 200 000 000** | **3 453 ms** | **3 307 ms** | **1.04×** ← 0.97× warm |
+| mul (skewed) | **1 000 000 / 100 000** | **2.5 ms** | **4.6 ms** | **0.54×** ← BigMath faster |
+| mul (skewed) | **20 000 000 / 2 000 000** | **94 ms** | **162 ms** | **0.58×** ← BigMath faster |
+| mul (skewed) | **50 000 000 / 5 000 000** | **267 ms** | **671 ms** | **0.40×** ← BigMath 2.5× faster |
+| div (skewed) | 500 000 / 100 000 | 7.6 ms | 4.6 ms | 1.65× |
+| div (skewed) | **5 000 000 / 1 000 000** | **70 ms** | **70 ms** | **1.01×** ← parity |
+| div (skewed) | **50 000 000 / 10 000 000** | **587 ms** | **1 307 ms** | **0.45×** ← BigMath 2.2× faster |
+| div (skewed) | **200 000 000 / 40 000 000** | **3 010 ms** | **4 492 ms** | **0.67×** ← BigMath faster |
+| parse | 1 000 000 digits | 32 ms | 21 ms | 1.58× |
+| parse | **20 000 000 digits** | **814 ms** | **804 ms** | **1.01×** ← parity |
+| ToString | 100 000 digits | 9.7 ms | 2.4 ms | 4.01× |
+| ToString | 1 000 000 digits | 106 ms | 49 ms | 2.16× |
+| ToString | 10 000 000 digits | 1 062 ms (warm) | 908 ms | **1.17×** ← near parity |
 
-**BigMath beats GMP on balanced multiplication across the 5M–10M digit band** and is roughly parity at 20M. The current peak is **10M balanced at 2.01× faster than GMP** (105 ms vs 212 ms). The MFA threshold retune improved that row by avoiding early MFA; at ≥50M GMP's Schönhage-Strassen still recovers. Skewed multiplication is a BigMath win around 1M×100k and parity at 2M×200k and 50M×5M, with the dispatcher now avoiding Toom-3 on 2:1+ skewed inputs in the pre-NTT band. Skewed division at 50M×10M is **1.92×** as Newton inherits the large-multiplication speedups. ToString narrows from 8.35× at 100k to 2.57× at 20M; parse to 1.56× at 20M. See [BENCHMARK.md](BENCHMARK.md) for the full table or the per-doc ratio tables for the breakdown.
+**BigMath beats GMP on balanced multiplication at every size from 500k digits up** — the former ≥50M-digit losses ("GMP SSA recovers") closed once the fused-MFA pipeline landed: 50M–200M digits run at 0.90–0.97× warm. **Skewed division flipped from a 1.9–2.8× loss to a 0.45–0.67× win at ≥20M-digit dividends** as Newton inherits the fused multiplies and runs its wrap-around products on the same pipeline. ToString narrows from 8.35× (session start) to 4.0× at 100k and near-parity at 10M+ digits; the sub-2M-digit ToString band is the largest remaining gap, with an implementation plan in `tostring_chain_plan.md` (and `smallskew_div_plan.md` for the 10k–2M-digit division band). See [BENCHMARK.md](BENCHMARK.md) for full tables, warm/cold methodology, and per-PR history.
 
 Opt-out flags (`-DBIGMATH_USE_THREADS=0` / `-DBIGMATH_NTT_CRT=0` / `-DBIGMATH_LIMB_64=0`) revert any subset of the defaults — useful for embedded targets, header-only-strict consumers, or A/B comparison.
 

--- a/smallskew_div_plan.md
+++ b/smallskew_div_plan.md
@@ -1,0 +1,103 @@
+# Small-Skew Division Plan (10k–2M-digit dividends)
+
+Status: PLANNED (written 2026-06-12, post PR #107–#112 MFA run).
+Honest expectations up front: this band is adjacent to documented dead
+ends (sub-50k mul vs GMP's hand-tuned basecase), and GMP's lead here is
+basecase quality, not algorithm choice. The realistic goal is to halve
+the gap, not flip it. Read the cost/benefit note at the bottom before
+starting.
+
+## Current state (canonical run, PR #112)
+
+| shape (digits) | limbs (÷19.27) | BigMath | GMP | ratio |
+|---|---|---:|---:|---|
+| 40k ÷ 10k | 2.1k ÷ 520 | 0.74 ms | 0.22 | 3.35× |
+| 100k ÷ 10k | 5.2k ÷ 520 | 2.16 | 0.45 | 4.84× ← worst |
+| 200k ÷ 50k | 10.4k ÷ 2.6k | 3.83 | 1.69 | 2.26× |
+| 500k ÷ 100k | 26k ÷ 5.2k | 7.65 | 4.63 | 1.65× |
+| 1M ÷ 200k | 52k ÷ 10.4k | 14.6 | 10.0 | 1.46× |
+| 2M ÷ 500k | 104k ÷ 26k | 28.4 | 24.6 | 1.15× |
+| 5M ÷ 1M | 260k ÷ 52k | 70.5 | 69.8 | 1.01× (parity from here up) |
+
+Divisors in the losing rows are 520–26k limbs. Dispatch context
+(DispatchThresholds.h): BZ from divisor 512; Newton bands from divisor
+1024 (5/2), 4096 (8/5), 768 (8/1 high-skew); below those, FastDivision
+(Knuth D with Möller-Granlund 3/2). The 520-limb divisor of the two
+worst rows sits at the BZ floor and below every Newton band.
+
+## Why the gap exists (hypotheses — profile FIRST, same rule as always)
+
+1. **Stale floors.** Every Newton/BZ floor was tuned 2026-06-11/12
+   BEFORE the MFA run made Newton's internal multiplies and cyclic
+   products 1.2–3× cheaper (PRs #107–#111). The same staleness that hid
+   the 2^24→2^20 MFA gate win (PR #109 — floors tuned against a slower
+   engine) almost certainly affects `BIGMATH_NEWTON_MEDIUM_B = 1024`,
+   `BIGMATH_NEWTON_RATIO2_B = 4096`, `BZ_DIVISOR_THRESHOLD = 512`, and
+   `BIGMATH_CYCLIC_NTT_THRESHOLD = 1280`. A floor re-sweep is the
+   cheapest possible experiment and has paid out twice already
+   (PRs #92, #101).
+2. **10:1 shape runs quotient-sized work in the wrong place.** 100k÷10k
+   has a 4.7k-limb quotient against a 520-limb divisor; the
+   QuotientSizedDivision band starts at b ≥ 8192 (thin-quotient) /
+   24576. A small-divisor high-skew path that chunks the dividend
+   against a cached divisor reciprocal (the ToString chain pattern —
+   `NewtonDivision::Divider` reuse across chunks) may beat FastDivision
+   well below the current floors now that reciprocal builds are
+   cheaper.
+3. **FastDivision basecase itself.** GMP's `mpn_sbpi1_div_qr` /
+   divide-and-conquer ladder is hand-tuned assembly territory. If the
+   profile says the time is in the 3/2 GM inner loop rather than in
+   dispatch-band misses, stop — that is the documented-dead-end wall,
+   and the remaining ratio is the price of portable C++.
+
+## Levers, ordered
+
+### S1. Post-MFA-run floor re-sweep (cheap, do first, likely the whole win)
+
+Re-run `dispatch_tuner` / `division_shape_bench` across divisor sizes
+256–8192 × ratios {2, 4, 8, 10, 16} against the current engine. Sweep
+`NEWTON_MEDIUM_B`, `NEWTON_RATIO2_B`, `BZ_DIVISOR_THRESHOLD`,
+`NEWTON_HIGH_SKEW` floor (768), and `CYCLIC_NTT_THRESHOLD` (1280)
+downward. Warm-state, interleaved, quiet machine — the PR #107–#112
+methodology. Expected from history: each prior re-sweep moved its band
+1.5–2.5×; even half of that closes 200k÷50k to ~1.5× and 1M÷200k to
+near parity.
+
+### S2. Small-divisor high-skew Divider path (medium effort)
+
+For `b < NEWTON floors` and `a ≥ 8b`: build one cached
+`NewtonDivision::Divider` for the divisor (cost amortizes over a/b
+chunks), then chunk the dividend top-down — the ToString-chain
+consumption pattern, which the formatter already proves out at
+520–5 200-limb divisor sizes. Prototype = wire
+`Divider::DivideAndRemainderInto` into a loop in Division.h dispatch
+under a new band; measure before any polish. If S1 already moved the
+floors below 520 limbs, skip — S1 subsumes this.
+
+### S3. Accept and document (the likely end state for ≤100k÷10k)
+
+If the profile shows GM 3/2 inner-loop dominance after S1/S2, record
+the residual as the portable-C++ basecase price next to the sub-50k
+mul dead-end note, with the profile attached, and stop. Do NOT reach
+for assembly or SIMD here without a separate cost/benefit discussion —
+the band's absolute times are 0.7–15 ms.
+
+## Measurement + correctness
+
+- `division_shape_bench` + the raw-limb probe pattern: extend
+  `mfa_mul_gmp_probe` CheckDiv with the band's shapes (520–26k-limb
+  divisors) — quotient limb-compare vs `mpz_tdiv_q` is the oracle.
+- `div_correctness` (identity q·b + r = a, r < b) stays the canonical
+  harness; any new dispatch band must appear in its cross-check matrix.
+- Floors changed by S1 get the knife-edge treatment from PR #92's
+  lesson: test divisor sizes at band±1 limb and 2^k±1 around each new
+  floor (the BZ non-pow2 pathology lives exactly there).
+
+## Cost/benefit note (read before starting)
+
+The whole band is single-digit milliseconds. ToString
+(tostring_chain_plan.md) repays effort better: its worst row is 4× at
+a user-facing operation, and its T1/T2 levers are structural rather
+than tuning. Do S1 here (it is a half-day sweep with proven odds),
+then decide between S2 and the ToString plan with the numbers in hand
+— do not run both speculative tracks at once.

--- a/tostring_chain_plan.md
+++ b/tostring_chain_plan.md
@@ -1,0 +1,144 @@
+# ToString Chain Optimization Plan
+
+Status: PLANNED (written 2026-06-12, post PR #107–#112 MFA run).
+This is the largest user-visible gap left vs GMP: ToString at 100k–2M
+digits runs 1.85–4.0× GMP's time; at ≥5M digits the warm steady state is
+already 1.17–1.28× (near parity) and the residual is cold chain build.
+
+## Current state (post-#112 canonical run + A/B verification)
+
+| digits | BigMath | GMP | ratio | note |
+|---|---:|---:|---|---|
+| 100k | 9.7 ms | 2.4 | 4.0× | worst point |
+| 500k | 53.4 | 20.8 | 2.57× | |
+| 1M | 105.6 | 49.0 | 2.16× | |
+| 2M | 220.4 | 119.1 | 1.85× | |
+| 5M | 510 warm / 879 cold | 398.6 | 1.28× / 2.2× | cold = first call at a size |
+| 10M | 1 062 warm / 1 699 cold | 908.3 | 1.17× / 1.87× | |
+
+Architecture (docs/STRING_CONVERSION.md): D&C formatter over a
+`DecimalDcChain` — entries at `d = L/2, L/4, …` down to ~512 digits, each
+holding `Pow10(d)` and a precomputed `NewtonDivision::Divider`
+reciprocal. Chain is cached `thread_local` keyed by `topDigits`
+(src/common/Parser.cpp:339), so repeat calls at the same size are warm;
+the cold cost is one `Pow10` + one full Newton reciprocal build per
+level. Per-level divmods then cost O(M(n)).
+
+## Where the time goes (to be confirmed by profile — do this FIRST)
+
+Hypothesized split, cold call at 1M digits:
+1. Chain build: log₂(L/512) ≈ 11 Divider setups, each a full Newton
+   reciprocal at its level's size. Dominant cold cost.
+2. Recursive divmods: 2^k divmods at level k, each O(M(L/2^k)) — the
+   steady-state cost, entirely SERIAL today (zero ParallelDo/ParallelFor
+   in Parser.cpp).
+3. Leaf linear formatting (Möller-Granlund div2by1 loop): already tight.
+
+Profile protocol: `sample` on a cold 1M-digit ToString and a warm one;
+attribute to BuildDecimalDcChain vs ToStringDivConquer vs leaf. The
+levers below are ordered by expected (win ÷ risk) — re-order after the
+profile.
+
+## Levers
+
+### T1. Parallelize the D&C recursion (high win at ≥500k digits, low risk)
+
+After each divmod, the (q, r) subtrees are fully independent and their
+output substrings land at disjoint, precomputed offsets (`padTo`
+arithmetic already determines exact digit positions). Today the
+recursion is serial on the caller's thread while the pool sits idle.
+
+Constraint: the pool is non-reentrant (single work slot — see
+docs/MULTIPLICATION.md threading notes), so nested ParallelDo from
+inside a worker deadlocks. Shape the parallelism as ONE dispatch:
+descend serially to depth k (2^k subtrees, k ≈ 3–4 → 8–16 subtrees of
+similar size), collect them in a work list, `ParallelDo(2^k)` over the
+list with each worker running its subtree serially into its own output
+range, then the already-written shared `out` buffer needs no stitch.
+The top-of-tree divmods before depth k stay serial — they are the big
+O(M(L)) ones and can themselves use threaded multiplies internally
+(they already do: Newton divmod → NTT → ParallelDo inside), so the
+machine is busy throughout.
+
+Expected: divmod tree below depth k is ~half the total divmod work;
+8-way parallel ⇒ 1.3–1.7× on the warm path at ≥500k digits. This is
+also the only lever that helps the WARM 5M–20M rows (1.17–1.28× → at or
+below GMP).
+
+Risk: low — output ranges are disjoint by construction; the workers
+call Divider::DivideAndRemainderInto which must be checked for hidden
+shared state (the chain entries are read-only after build; verify the
+Divider is const-callable / has no internal scratch races — if it has
+thread_local scratch, that is per-worker and safe).
+
+### T2. Bottom-up reciprocal chain (kills most of the cold cost, medium risk)
+
+Chain entries are exact halvings and `Pow10` is already built by
+squaring (`Pow10(d) = Pow10(d/2)²`). Reciprocals compose the same way:
+`1/10^d = (1/10^(d/2))² · 10^... ` — i.e. the level-d reciprocal is the
+square of the level-d/2 reciprocal up to scaling, correct to the
+smaller precision; ONE Newton refinement step lifts it to full
+precision at level d. So build dividers bottom-up: full Newton build
+only at the smallest level (~512 digits, trivial), then each larger
+level costs one squaring + one refinement multiply instead of a full
+reciprocal build. Halves-to-thirds the chain-build cost; the cold 100k
+(4.0×) and 500k (2.57×) rows are mostly this.
+
+Requires a `NewtonDivision::Divider` constructor that accepts a seed
+reciprocal at half precision — check whether the invertappr-style
+internal loop already supports a warm start (it iterates from a seed
+anyway; expose the entry point).
+
+### T3. Persist the chain across sizes (small win, trivial)
+
+The cache is keyed by exact `topDigits`; a 1M-digit call then a
+999 873-digit call builds two chains, though all lower levels could be
+shared. Key the cache by level value (`d`) instead of by top size:
+each `(d, value, divider)` triple is independent of the top. Saves
+rebuilds in mixed-size workloads (calculator REPL, BigDecimal toString).
+No effect on single-size benches — do not expect bench movement; this
+is API-hygiene-level.
+
+### T4. Leaf threshold re-sweep (cheap, do alongside T1/T2)
+
+`BIGMATH_TOSTR_DC_THRESHOLD = 1024` and the chain floor (~512 digits)
+were tuned before the MFA run cheapened every multiply ≥2^20
+coefficients and before cyclic products reached the fused pipeline. The
+leaf/linear crossover and `DecimalDcThreshold = 2048` (parse) deserve a
+re-sweep — same playbook as the division-floor re-sweeps (PRs #92/#101,
+and the #109 gate retune that this run showed pays compounding
+dividends).
+
+## Measurement methodology
+
+- Warm/cold split is mandatory (PR #112 lesson: single-iter chain rows
+  vary ±20–60% with process state). Per size: 1 cold call (fresh
+  process), then best-of-3 warm — report both.
+- Sizes: 100k / 500k / 1M / 2M / 5M / 10M / 20M digits, interleaved
+  baseline-vs-change, quiet machine.
+- GMP reference: `mpz_get_str` timed in-process (bench_vs_gmp rows).
+- Verify output identity: byte-compare BigMath vs GMP strings at every
+  measured size, every change (cheap, total).
+
+## Correctness protocol
+
+ToString output is end-to-end checkable — byte equality vs
+`mpz_get_str` IS the oracle. Every lever change must:
+1. Byte-compare vs GMP at 10k / 100k / 1M / 10M digits, random inputs,
+   plus all-9s and power-of-10 boundary values (carry/pad edge cases —
+   the `padTo` zero-padding logic is where T1's offset math can break).
+2. Keep the existing parse/ToString round-trip tests green.
+3. T1 gets a transient-break: shuffle the work-list order and confirm
+   output corrupts (proves offsets, not luck, give the ordering); then
+   restore.
+
+## Sequencing
+
+1. Profile (half a day) — confirms the T1/T2 split before any code.
+2. T1 (parallel subtrees) — single PR, biggest steady-state lever.
+3. T2 (bottom-up reciprocals) — single PR, biggest cold lever.
+4. T4 threshold re-sweep — fold into whichever of T1/T2 lands last.
+5. T3 only if a real mixed-size workload shows up.
+
+Target: 100k digits 4.0× → ≤2×; 1M 2.16× → ≤1.3×; warm 5M–20M from
+1.17–1.28× → parity or better.


### PR DESCRIPTION
Follow-up plans for the two remaining performance gaps, plus README sync.

- **`tostring_chain_plan.md`** — ToString 100k–2M digits (1.85–4.0× vs GMP, largest user-visible gap). T1: parallelize the D&C recursion (independent subtrees, disjoint output offsets, one `ParallelDo` dispatch — pool is non-reentrant); T2: bottom-up reciprocal chain (each divider from the squared half-precision seed + one Newton refinement); T3/T4 minor. Profile-first; byte-equality vs `mpz_get_str` is the oracle.
- **`smallskew_div_plan.md`** — division with 520–26k-limb divisors (1.15–4.84×). S1: re-sweep all Newton/BZ/cyclic floors against the post-#107–#111 engine (same staleness that hid the MFA gate win — proven playbook); S2: cached-Divider chunking for small high-skew divisors; S3: accept-and-document if the profile lands in the GM 3/2 basecase wall. Includes an honest cost/benefit note.
- **README** — both performance sections were stale (one pre-dated the entire 2026-06-12 run). Refreshed to post-#112 canonical numbers; feature bullets now describe the fused-MFA pipeline, gate 2^20, cyclic 2^26 cap, and row-chunked threading.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)