### PR TITLE
fix: hard guard at the CRT NTT 2^26 ceiling; close F4 audit

### DIFF
--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -1279,6 +1279,11 @@ namespace BigMath
       ULong maxOtherCoeffSize = (ULong)maxOtherLimbs * prepared.coeffsPerLimb;
       ULong maxCoeffCount = prepared.operandCoeffSize + maxOtherCoeffSize - 1;
       prepared.n = (Int)std::max<ULong>(2, std::bit_ceil(maxCoeffCount));
+      if (prepared.n > (1 << 26))
+        throw std::invalid_argument(
+            "NttCrt: operands exceed the CRT NTT length ceiling (2^26 coefficients, "
+            "~640M decimal digits) — P2/P3 have 2-adic order 2^26, so longer "
+            "transforms would silently compute with invalid roots");
 
       prepared.f1.assign(prepared.n, 0);
       prepared.f2.assign(prepared.n, 0);
@@ -2278,6 +2283,14 @@ namespace BigMath
       ULong bCoeffSize = (ULong)b.size() * coeffsPerLimb;
       ULong coeffCount = aCoeffSize + bCoeffSize - 1;
       Int n = (Int)std::bit_ceil(coeffCount);
+      // CRT length ceiling: the primes' 2-adic order is 2^26 (see the prime
+      // table at the top of this file). Beyond it BuildRoots' (P-1)/n is no
+      // longer exact and the transform silently corrupts — fail loudly. The
+      // pre-guard behavior was undefined output at ≥ ~8 GB operand pairs.
+      if (n > (1 << 26))
+        throw std::invalid_argument(
+            "NttCrt: operands exceed the CRT NTT length ceiling (2^26 coefficients, "
+            "~640M decimal digits)");
 
       // Three parallel transforms. Buffer zero-fill + packing happen inside
       // the branch that needs them: the fused MFA path (F3) packs straight
@@ -2327,6 +2340,12 @@ namespace BigMath
         else
 #endif
         {
+          // F4 audit note (mem_pass_fusion.md): with LEAF = 2^13 the fused
+          // window covers every n ≤ 2^26 — the entire admissible CRT range
+          // under the ceiling guard above. This multi-level branch is
+          // therefore reachable ONLY in -DBIGMATH_NTT_MFA_FUSE=0 builds,
+          // where it (and ForwardMFA/InverseMFA's standalone Transpose
+          // sweeps) is the intended fallback. Kept, not dead code.
           for (int i = 0; i < 6; ++i) mfaScratch[i].assign(n, 0);
           fa1.assign(n, 0); fb1.assign(n, 0);
           fa2.assign(n, 0); fb2.assign(n, 0);
@@ -2336,9 +2355,8 @@ namespace BigMath
           UInt *bufs[6]   = {fa1.data(), fb1.data(), fa2.data(), fb2.data(), fa3.data(), fb3.data()};
           UInt *scrs[6]   = {mfaScratch[0].data(), mfaScratch[1].data(), mfaScratch[2].data(),
                              mfaScratch[3].data(), mfaScratch[4].data(), mfaScratch[5].data()};
-          // Multi-level MFA (above the single-level fused window): original
-          // 6-unit forward batch; the pointwise sweep below handles the
-          // product.
+          // Multi-level MFA: original 6-unit forward batch; the pointwise
+          // sweep below handles the product.
           auto fwdBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
             for (Int idx = s; idx < e; ++idx)
             {

--- a/mem_pass_fusion.md
+++ b/mem_pass_fusion.md
@@ -77,7 +77,14 @@ Warm-state raw-limb suite, best-of-3 × 3 interleaved rounds vs pre-#107
    2-5% across the band, 10.4M mul wash.
 3. F2 finalize chunking: FinalizeProduct serial but small (~0.4% in the
    old profile). Only if the probe shows saturation or its share grew.
-4. F4 transpose audit: unchanged.
+4. F4 transpose audit — **CLOSED (2026-06-12, accept-and-document)**:
+   with LEAF = 2^13 the single-level fused window covers every admissible
+   CRT length (n ≤ 2^26), so the multi-level/non-fused paths (standalone
+   Transpose sweeps, recursive ForwardMFA/InverseMFA) are reachable only
+   in -DBIGMATH_NTT_MFA_FUSE=0 builds — kept as that configuration's
+   fallback, marked in code. A hard guard now throws at n > 2^26 in
+   Multiply and PrepareOperand (previously: silent root corruption at
+   ~8 GB operand pairs; MultiplyMod2km1 already threw).
 Owner note: this is the last identified structural performance lever. Every
 band below 50M digits is at or better than GMP parity; the 50M–200M-digit
 band (balanced mul 1.28–1.33×, div 1.23–1.37× vs GMP) is


### PR DESCRIPTION
## What

- `NttCrt::Multiply` / `PrepareOperand` now throw `invalid_argument` when the transform length would exceed 2^26 — the CRT primes' 2-adic ceiling. Previously n = 2^27+ (operand pairs ≳33M limbs / ~640M total digits) silently computed with invalid roots: wrong products, no error — the PR #103 failure class, shape-triggered. (`MultiplyMod2km1` already threw.)
- Guard verified live: a 17M×17M-limb multiply (n = 2^27) throws with a clear message; all existing probe tiers unaffected.
- **F4 audit closed (accept-and-document):** with LEAF = 2^13, the single-level fused window covers every admissible length under the ceiling — the multi-level / non-fused MFA paths are reachable only in `-DBIGMATH_NTT_MFA_FUSE=0` builds. Marked in code as that configuration's intended fallback; FUSE=0 build probe-verified green. `mem_pass_fusion.md` updated — all four fusion items (F1–F4) now closed.

## Tests

- `unit_tests` 254/254, raw-limb GMP probe ALL OK (mul / cyclic / div tiers)
- FUSE=0 configuration: compiles, probe OK at n=2^21 and 2^24
- New guard exercised positively (throws) and negatively (existing sizes pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)