### PR TITLE
perf: BZ basecase 512→128 + Newton frontier re-sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,15 +42,16 @@ CI (`.github/workflows/qa.yaml`) runs `nanoclaw-task qa-agent` on PRs against `o
 
 **Division dispatch** (`algorithms/Division.h`, thresholds defined in `src/algorithms/Division.cpp`):
 - `NewtonDivision` (Newton-Raphson reciprocal, O(M(n)); handles arbitrary `na/nb` via blockwise mode — top chunk in [n+1, 2n], slide down by n, thread the remainder) when any skew band holds:
-  - `b ≥ 640` at ratio ≥ 8 (`NEWTON_HIGH_SKEW` 8/1), or
-  - `b ≥ 1024` at ratio ≥ 7/2 (`NEWTON_RATIO35`), or
-  - `b ≥ 1280` at ratio ≥ 14/5 (`NEWTON_SKEW` — 2.8 keeps the ratio-3.0000±1-limb knife on the Newton side), or
-  - `b ≥ 1792` at ratio ≥ 5/2 (`NEWTON_MID`), or
-  - `b ≥ 4096` at ratio ≥ 8/5 (`NEWTON_RATIO2`), or
-  - `b ≥ 24576` at ratio ≥ 4/3 (`NEWTON_BALANCED` — near-balanced band; ratio lowered from 2/1 and floor from 98304 on 2026-06-11).
-  (Frontier re-swept 2026-06-12 after the BZ odd-size padding fix — see below — changed every Newton/BZ crossover; `include/biginteger/build/DispatchThresholds.h` is the canonical place these live — its `#define`s win over the `#ifndef` fallbacks in `algorithms/*.h`.)
-- `QuotientSizedDivision` when (`b ≥ 24576`, `a ≥ b + 64`, ratio < 4/3) OR (thin-quotient: `b ≥ 8192`, `64 ≤ Δ ≤ b/8`): divides the operand TOPS (`t = Δ+4` limbs of b, `Δ+t` of a) for the (Δ+1)-limb quotient, then one Δ×nb back-multiply for the remainder — cost scales with the quotient, not the divisor.
-- else `BurnikelZieglerDivision` for power-of-two base when `b > 512` and the BZ band fits (near-balanced `b ≥ 1024, b+32 ≤ a ≤ 3b`, or big-and-skewed `a > 2048 && a > 3b`). BZ pads both operands with bottom zero limbs so the divisor size divides by 2 at every recursion level (quotient unchanged, remainder's bottom pad limbs are zero); before 2026-06-12 any odd size on the way down fell back to FastDivision at full size — the root cause of the "2^k+1 family" pathology and 1.3-10× losses on odd-limb-count divisors at ratio < 2.8.
+  - `b ≥ 896` at ratio ≥ 8 (`NEWTON_HIGH_SKEW` 8/1), or
+  - `b ≥ 1280` at ratio ≥ 7/2 (`NEWTON_RATIO35` — 7/2 keeps the ratio-4.0000±1-limb knife on the Newton side), or
+  - `b ≥ 1792` at ratio ≥ 14/5 (`NEWTON_SKEW` — 2.8 likewise for ratio 3.0000), or
+  - `b ≥ 2560` at ratio ≥ 5/2 (`NEWTON_MID`), or
+  - `b ≥ 4096` at ratio ≥ 2 (`NEWTON_RATIO20`), or
+  - `b ≥ 8192` at ratio ≥ 8/5 (`NEWTON_RATIO2`), or
+  - `b ≥ 131072` at ratio ≥ 4/3 (`NEWTON_BALANCED` — floor raised from 24576 on 2026-06-12: padded BZ with the 128-limb basecase wins ratio 1.4-1.5 through ~98k limbs).
+  (Frontier re-swept twice 2026-06-12: once after the BZ odd-size padding fix, again after the BZ basecase retune 512→128 — both changed every Newton/BZ crossover; `include/biginteger/build/DispatchThresholds.h` is the canonical place these live — its `#define`s win over the `#ifndef` fallbacks in `algorithms/*.h`.)
+- `QuotientSizedDivision` when (`b ≥ 24576` (`QSIZED_MAIN_B`, decoupled from the balanced floor), `a ≥ b + 64`, ratio < 4/3) OR (thin-quotient: `b ≥ 8192`, `64 ≤ Δ ≤ b/8`): divides the operand TOPS (`t = Δ+4` limbs of b, `Δ+t` of a) for the (Δ+1)-limb quotient, then one Δ×nb back-multiply for the remainder — cost scales with the quotient, not the divisor.
+- else `BurnikelZieglerDivision` for power-of-two base when `b > 512` and the BZ band fits (near-balanced `b ≥ 1024, b+32 ≤ a ≤ 3b`, or big-and-skewed `a > 2048 && a > 3b`). BZ pads both operands with bottom zero limbs so the divisor size divides by 2 at every recursion level (quotient unchanged, remainder's bottom pad limbs are zero); before 2026-06-12 any odd size on the way down fell back to FastDivision at full size — the root cause of the "2^k+1 family" pathology and 1.3-10× losses on odd-limb-count divisors at ratio < 2.8. Recursion basecase `BIGMATH_BZ_RECURSION_THRESHOLD = 128` (was 512; the retune is worth another 1.2-1.5× across the BZ band — Karatsuba-backed multiplies beat 512-limb Knuth-D basecase calls).
 - otherwise multi-limb → `FastDivision` (Knuth Algorithm D variant)
 - single-limb divisor → `ClassicDivision`
 - `KnuthDivision` and `ReciprocalDivision` are alternates used by correctness tests for cross-checking.

--- a/include/biginteger/algorithms/Division.h
+++ b/include/biginteger/algorithms/Division.h
@@ -4,16 +4,17 @@
  * Dispatch order:
  *   1. NewtonDivision (blockwise handles arbitrary ratio via reciprocal cache),
  *      when any of these skew bands hold:
+ *        - b ≥ NEWTON_HIGH_SKEW_B AND  a ≥ NEWTON_HIGH_SKEW (8/1)     · b
  *        - b ≥ NEWTON_RATIO35_B   AND  a ≥ NEWTON_RATIO35 (7/2)       · b
  *        - b ≥ NEWTON_MEDIUM_B    AND  a ≥ NEWTON_SKEW (14/5)         · b
  *        - b ≥ NEWTON_MID_B       AND  a ≥ NEWTON_MID (5/2)           · b
+ *        - b ≥ NEWTON_RATIO20_B   AND  a ≥ NEWTON_RATIO20 (2/1)       · b
  *        - b ≥ NEWTON_RATIO2_B    AND  a ≥ NEWTON_RATIO2 (8/5)        · b
  *        - b ≥ NEWTON_BALANCED_B  AND  a ≥ NEWTON_BALANCED (4/3)      · b
- *        - b ≥ NEWTON_HIGH_SKEW_B AND  a ≥ NEWTON_HIGH_SKEW (8/1)     · b
  *      The balanced (ratio ≥ 4/3) band starts at 24k limbs — the generic
  *      Newton/BZ crossover measured after the wraparound-Newton PRs (#85-#87);
  *      below it BZ wins near-balanced, above it BZ degrades erratically.
- *   2. QuotientSizedDivision when b ≥ NEWTON_BALANCED_B, a ≥ b + 64, and
+ *   2. QuotientSizedDivision when b ≥ QSIZED_MAIN_B, a ≥ b + 64, and
  *      ratio < 4/3 — short-quotient shapes where cost should scale with the
  *      quotient, not the divisor (and where BZ blows up 7-128× on
  *      2^k+1-family divisor sizes).
@@ -44,7 +45,7 @@
 namespace BigMath
 {
 #ifndef BIGMATH_NEWTON_MEDIUM_B
-#define BIGMATH_NEWTON_MEDIUM_B 1280
+#define BIGMATH_NEWTON_MEDIUM_B 1792
 #endif
 
 // Ratio-≥8/5 band. Sits between the medium (3/1) and balanced (4/3) bands:
@@ -53,8 +54,18 @@ namespace BigMath
 // ratio ~1.6. 8/5 rather than 2/1 because digit-derived operands sit at limb
 // ratios like 2.0000 ± 1 limb and BZ blows up 8-12× on non-pow2 divisor
 // sizes right across that edge.
+#ifndef BIGMATH_NEWTON_RATIO20_B
+#define BIGMATH_NEWTON_RATIO20_B 4096
+#endif
+#ifndef BIGMATH_NEWTON_RATIO20_NUMERATOR
+#define BIGMATH_NEWTON_RATIO20_NUMERATOR 2
+#endif
+#ifndef BIGMATH_NEWTON_RATIO20_DENOMINATOR
+#define BIGMATH_NEWTON_RATIO20_DENOMINATOR 1
+#endif
+
 #ifndef BIGMATH_NEWTON_RATIO2_B
-#define BIGMATH_NEWTON_RATIO2_B 4096
+#define BIGMATH_NEWTON_RATIO2_B 8192
 #endif
 #ifndef BIGMATH_NEWTON_RATIO2_NUMERATOR
 #define BIGMATH_NEWTON_RATIO2_NUMERATOR 8
@@ -75,10 +86,10 @@ namespace BigMath
 #define BIGMATH_NEWTON_SKEW_DENOMINATOR 5
 #endif
 
-// Ratio ≥ 7/2 band: Newton wins ratio ≥ 4 across [1024, 1280); 7/2 keeps
-// the ratio-4.0000 ± 1 limb knife-edge on the Newton side.
+// Ratio ≥ 7/2 band: 7/2 keeps the ratio-4.0000 ± 1 limb knife-edge on the
+// Newton side.
 #ifndef BIGMATH_NEWTON_RATIO35_B
-#define BIGMATH_NEWTON_RATIO35_B 1024
+#define BIGMATH_NEWTON_RATIO35_B 1280
 #endif
 
 #ifndef BIGMATH_NEWTON_RATIO35_NUMERATOR
@@ -89,9 +100,9 @@ namespace BigMath
 #define BIGMATH_NEWTON_RATIO35_DENOMINATOR 2
 #endif
 
-// Exactly-2.5 band: Newton wins from b ≈ 1792; below, padded BZ.
+// Exactly-2.5 band: Newton wins from b ≈ 2560; below, padded BZ.
 #ifndef BIGMATH_NEWTON_MID_B
-#define BIGMATH_NEWTON_MID_B 1792
+#define BIGMATH_NEWTON_MID_B 2560
 #endif
 
 #ifndef BIGMATH_NEWTON_MID_NUMERATOR
@@ -102,8 +113,19 @@ namespace BigMath
 #define BIGMATH_NEWTON_MID_DENOMINATOR 2
 #endif
 
+// Near-balanced (ratio ≥ 4/3) Newton floor. Raised 24576 -> 131072 on
+// 2026-06-12: padded BZ with the 128-limb basecase wins ratio 1.4-1.5
+// through 98304 limbs (16-35%); Newton edges it from ~131072. The old
+// 24576 floor was insurance against BZ's odd-size collapse, now fixed.
 #ifndef BIGMATH_NEWTON_BALANCED_B
-#define BIGMATH_NEWTON_BALANCED_B 24576
+#define BIGMATH_NEWTON_BALANCED_B 131072
+#endif
+
+// Quotient-sized main band floor — decoupled from NEWTON_BALANCED_B
+// (2026-06-12): QSized keeps beating padded BZ at ratio < 4/3 from 24576
+// (24576×1.3: 6.4 vs BZ 10.3 ms; 32768×1.25: 8.5 vs 10.8).
+#ifndef BIGMATH_QSIZED_MAIN_B
+#define BIGMATH_QSIZED_MAIN_B 24576
 #endif
 
 #ifndef BIGMATH_NEWTON_BALANCED_NUMERATOR
@@ -126,7 +148,7 @@ namespace BigMath
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_B
-#define BIGMATH_NEWTON_HIGH_SKEW_B 640
+#define BIGMATH_NEWTON_HIGH_SKEW_B 896
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR
@@ -138,6 +160,9 @@ namespace BigMath
 #endif
 
   extern const SizeT NEWTON_MEDIUM_B;
+  extern const SizeT NEWTON_RATIO20_B;
+  extern const SizeT NEWTON_RATIO20_NUMERATOR;
+  extern const SizeT NEWTON_RATIO20_DENOMINATOR;
   extern const SizeT NEWTON_RATIO2_B;
   extern const SizeT NEWTON_RATIO2_NUMERATOR;
   extern const SizeT NEWTON_RATIO2_DENOMINATOR;
@@ -153,6 +178,7 @@ namespace BigMath
   extern const SizeT NEWTON_BALANCED_B;
   extern const SizeT NEWTON_BALANCED_NUMERATOR;
   extern const SizeT NEWTON_BALANCED_DENOMINATOR;
+  extern const SizeT QSIZED_MAIN_B;
   extern const SizeT QSIZED_MIN_DELTA;
   extern const SizeT QSIZED_SMALL_B;
   extern const SizeT QSIZED_SMALL_DELTA_DIV;

--- a/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
+++ b/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
@@ -17,8 +17,13 @@ using namespace std;
 
 namespace BigMath
 {
+// Basecase floor for the 2n-by-n recursion. Swept 2026-06-12 after the
+// odd-size padding fix made recursion depth size-independent: 128 beats the
+// old 512 by 1.2-1.5× across the whole BZ band (the 512-limb Knuth-D
+// basecase calls were the bottleneck — Karatsuba-backed multiplies win the
+// 128-512 range). Flat 64-128, worse at 48 and above 128.
 #ifndef BIGMATH_BZ_RECURSION_THRESHOLD
-#define BIGMATH_BZ_RECURSION_THRESHOLD 512
+#define BIGMATH_BZ_RECURSION_THRESHOLD 128
 #endif
 
   class BurnikelZieglerDivision

--- a/include/biginteger/build/DispatchThresholds.h
+++ b/include/biginteger/build/DispatchThresholds.h
@@ -76,24 +76,34 @@
 #define BIGMATH_BZ_DIVISOR_THRESHOLD 512
 #endif
 
+// Newton frontier re-swept 2026-06-12 a second time after the BZ basecase
+// retune (BIGMATH_BZ_RECURSION_THRESHOLD 512 -> 128) made BZ another
+// 1.2-1.5× faster across its whole band: every Newton floor moves up.
+// Frontier (floor, min ratio): (896, 8/1), (1280, 7/2), (1792, 14/5),
+// (2560, 5/2), (4096, 2/1), (8192, 8/5). The old exact-ratio knife-edge
+// hazard (BZ collapsing on the wrong side of 2.0000/3.0000 ± 1 limb) died
+// with the odd-size padding fix — both sides of every knife are now
+// well-behaved, so the cuts below track measured crossovers only.
 #ifndef BIGMATH_NEWTON_MEDIUM_B
-#define BIGMATH_NEWTON_MEDIUM_B 1280
+#define BIGMATH_NEWTON_MEDIUM_B 1792
 #endif
 
-// Newton floors re-swept 2026-06-12 (smallskew_div_plan.md S1) AFTER fixing
-// the BZ odd-size FastDivision fallback (operand padding in
-// BurnikelZieglerDivision.h). That fix changed every crossover: BZ used to
-// collapse to O(n·Δ) on odd divisor sizes (1.3-10× losses), which had pushed
-// the Newton floors artificially low as insurance. With padded BZ
-// well-behaved on all sizes the floors are data-driven again — the Newton
-// frontier is now (640, 8/1), (1024, 7/2), (1280, 14/5), (1792, 5/2),
-// (4096, 8/5), (24576, 4/3); ratio-8/5@4096 re-confirmed unchanged.
-// Ratio-≥8/5 Newton band between the mid (5/2) and balanced (4/3) bands.
-// 8/5 instead of a knife-edge 2/1: digit-derived operands land at limb ratios
-// like 2.0000 ± 1 limb; Newton near-ties padded BZ from ratio ~1.6 at 4096
-// (at ratio 1.6 BZ wins 18-22% at b=2048-3072, Newton from 4096).
+// Ratio ≥ 2 from 4096: Newton edges BZ at 3584 (tie) and wins 8-14% from
+// 4096-6144. Below, BZ.
+#ifndef BIGMATH_NEWTON_RATIO20_B
+#define BIGMATH_NEWTON_RATIO20_B 4096
+#endif
+#ifndef BIGMATH_NEWTON_RATIO20_NUMERATOR
+#define BIGMATH_NEWTON_RATIO20_NUMERATOR 2
+#endif
+#ifndef BIGMATH_NEWTON_RATIO20_DENOMINATOR
+#define BIGMATH_NEWTON_RATIO20_DENOMINATOR 1
+#endif
+
+// Ratio ≥ 8/5 from 8192: BZ wins 1.6-band shapes at 4096-7168 (7-19%),
+// Newton from ~8192-9216.
 #ifndef BIGMATH_NEWTON_RATIO2_B
-#define BIGMATH_NEWTON_RATIO2_B 4096
+#define BIGMATH_NEWTON_RATIO2_B 8192
 #endif
 #ifndef BIGMATH_NEWTON_RATIO2_NUMERATOR
 #define BIGMATH_NEWTON_RATIO2_NUMERATOR 8
@@ -102,12 +112,9 @@
 #define BIGMATH_NEWTON_RATIO2_DENOMINATOR 5
 #endif
 
-// 14/5 rather than 3/1: digit-derived operands land at limb ratios like
-// 3.0000 ± 1 limb; 2.8 keeps that edge on the Newton side (Newton is still
-// 2.3× better than even padded BZ at 15579×5193). Not 5/2: at exactly
-// ratio 2.5, padded BZ beats Newton up to b≈1792 (06-12 probe: 7-34% at
-// 1024-1543), so 2.5 has its own band below with a higher floor. Floor
-// 1280: BZ wins ratio 2.8-3.0 at 1037-1163, Newton from 1291.
+// 14/5 keeps the ratio-3.0000 ± 1 limb digit-derived edge inside one band
+// (both sides Newton at the floor). Newton from 1792 at ratio 2.8-3.0
+// (17-21%); 1543 is a tie, below BZ wins.
 #ifndef BIGMATH_NEWTON_SKEW_NUMERATOR
 #define BIGMATH_NEWTON_SKEW_NUMERATOR 14
 #endif
@@ -116,13 +123,10 @@
 #define BIGMATH_NEWTON_SKEW_DENOMINATOR 5
 #endif
 
-// Ratio ≥ 7/2 from 1024: Newton wins ratio 4-6 across all of [1024, 1280)
-// (3-45%, growing with ratio); 7/2 rather than 4/1 keeps the ratio-4.0000
-// ± 1 limb knife-edge (40k÷10k-digit class) on the Newton side, and 3.5
-// itself is a measured tie. Below 3.2, BZ wins — that segment belongs to
-// the 14/5@1280 band above.
+// Ratio ≥ 7/2 from 1280: Newton wins ratio 4-5 at 1280-1408 (15-41%);
+// 1024 is BZ. 7/2 keeps the ratio-4.0000 ± 1 limb class on the Newton side.
 #ifndef BIGMATH_NEWTON_RATIO35_B
-#define BIGMATH_NEWTON_RATIO35_B 1024
+#define BIGMATH_NEWTON_RATIO35_B 1280
 #endif
 #ifndef BIGMATH_NEWTON_RATIO35_NUMERATOR
 #define BIGMATH_NEWTON_RATIO35_NUMERATOR 7
@@ -131,10 +135,10 @@
 #define BIGMATH_NEWTON_RATIO35_DENOMINATOR 2
 #endif
 
-// Exactly-2.5 shapes (digit-derived 2.5000 ± 1 limb): Newton from 1792
-// (14% win at 1791, 6% at 2049, 29% at 2600); below, padded BZ wins.
+// Exactly-2.5 shapes (digit-derived 2.5000 ± 1 limb): Newton from ~2560
+// (2816: 18%); 2304 and below, BZ.
 #ifndef BIGMATH_NEWTON_MID_B
-#define BIGMATH_NEWTON_MID_B 1792
+#define BIGMATH_NEWTON_MID_B 2560
 #endif
 #ifndef BIGMATH_NEWTON_MID_NUMERATOR
 #define BIGMATH_NEWTON_MID_NUMERATOR 5
@@ -154,11 +158,11 @@
 #define BIGMATH_QSIZED_SMALL_DELTA_DIV 8
 #endif
 
-// 640 (06-12 probe): ratio 8 ties BZ at 640 and wins 16% at 704; ratio 10
-// wins 12% at 640. 576 stays BZ (16% better) and Newton degrades sharply
-// at b ≈ 520, so the floor must not go below 640.
+// 896 (06-12 post-basecase-retune probe): Newton wins ratio 8 from 896
+// (12%) and 1024 (21%); 768 stays BZ (7%) and Newton degrades sharply at
+// b ≈ 520, so the floor must not go below ~832.
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_B
-#define BIGMATH_NEWTON_HIGH_SKEW_B 640
+#define BIGMATH_NEWTON_HIGH_SKEW_B 896
 #endif
 
 #ifndef BIGMATH_NEWTON_HIGH_SKEW_NUMERATOR

--- a/smallskew_div_plan.md
+++ b/smallskew_div_plan.md
@@ -132,3 +132,13 @@ here). The MFA-staleness premise (hypothesis 1) was wrong for this
 band: the MFA gate is 2^20 transform length, far above these sizes.
 S2 is moot: blockwise Newton with a cached reciprocal IS the chunking
 pattern, and it loses below 640 limbs.
+
+Follow-up (same day, second PR): with padding making recursion depth
+size-independent, the BZ basecase `BIGMATH_BZ_RECURSION_THRESHOLD`
+swept 512 → 128 — another 1.2-1.5× across the whole BZ band (flat
+64-128, worse at 48), which moved every Newton floor up again and
+raised the balanced floor 24576 → 131072 (padded BZ wins ratio 1.4-1.5
+through ~98k limbs; QSized main floor decoupled at 24576). Even the
+"basecase wall" rows improved: 5200÷520 limbs 2.5 → 1.7 ms. Frontier:
+(896, 8/1), (1280, 7/2), (1792, 14/5), (2560, 5/2), (4096, 2/1),
+(8192, 8/5), (131072, 4/3).

--- a/src/algorithms/Division.cpp
+++ b/src/algorithms/Division.cpp
@@ -12,6 +12,9 @@
 namespace BigMath
 {
   const SizeT NEWTON_MEDIUM_B = BIGMATH_NEWTON_MEDIUM_B;
+  const SizeT NEWTON_RATIO20_B = BIGMATH_NEWTON_RATIO20_B;
+  const SizeT NEWTON_RATIO20_NUMERATOR = BIGMATH_NEWTON_RATIO20_NUMERATOR;
+  const SizeT NEWTON_RATIO20_DENOMINATOR = BIGMATH_NEWTON_RATIO20_DENOMINATOR;
   const SizeT NEWTON_RATIO2_B = BIGMATH_NEWTON_RATIO2_B;
   const SizeT NEWTON_RATIO2_NUMERATOR = BIGMATH_NEWTON_RATIO2_NUMERATOR;
   const SizeT NEWTON_RATIO2_DENOMINATOR = BIGMATH_NEWTON_RATIO2_DENOMINATOR;
@@ -27,6 +30,7 @@ namespace BigMath
   const SizeT NEWTON_BALANCED_B = BIGMATH_NEWTON_BALANCED_B;
   const SizeT NEWTON_BALANCED_NUMERATOR = BIGMATH_NEWTON_BALANCED_NUMERATOR;
   const SizeT NEWTON_BALANCED_DENOMINATOR = BIGMATH_NEWTON_BALANCED_DENOMINATOR;
+  const SizeT QSIZED_MAIN_B = BIGMATH_QSIZED_MAIN_B;
   const SizeT QSIZED_MIN_DELTA = BIGMATH_QSIZED_MIN_DELTA;
   const SizeT QSIZED_SMALL_B = BIGMATH_QSIZED_SMALL_B;
   const SizeT QSIZED_SMALL_DELTA_DIV = BIGMATH_QSIZED_SMALL_DELTA_DIV;
@@ -78,11 +82,15 @@ namespace BigMath
     bool newton_high_skew =
         b.size() >= NEWTON_HIGH_SKEW_B &&
         NEWTON_HIGH_SKEW_DENOMINATOR * a.size() >= NEWTON_HIGH_SKEW_NUMERATOR * b.size();
-    // Ratio-≥8/5 band between medium (3/1 @ 2560) and balanced (4/3 @ 24576).
+    // Ratio-≥2 band between the mid (5/2) and ratio-8/5 bands.
+    bool newton_ratio20 =
+        b.size() >= NEWTON_RATIO20_B &&
+        NEWTON_RATIO20_DENOMINATOR * a.size() >= NEWTON_RATIO20_NUMERATOR * b.size();
+    // Ratio-≥8/5 band between the ratio-2 and balanced (4/3) bands.
     bool newton_ratio2 =
         b.size() >= NEWTON_RATIO2_B &&
         NEWTON_RATIO2_DENOMINATOR * a.size() >= NEWTON_RATIO2_NUMERATOR * b.size();
-    bool newton_eligible = newton_medium_skew || newton_ratio35 || newton_mid_skew || newton_balanced || newton_high_skew || newton_ratio2;
+    bool newton_eligible = newton_medium_skew || newton_ratio35 || newton_mid_skew || newton_balanced || newton_high_skew || newton_ratio20 || newton_ratio2;
     if (newton_eligible)
       return NewtonDivision::DivideAndRemainder(a, b, base, computeRemainder);
 
@@ -91,7 +99,7 @@ namespace BigMath
     // loses. BZ's near-balanced path blows up 7-128x on 2^k+1-family divisor
     // sizes here; quotient-sized division scales with the quotient instead.
     bool qsized_main =
-        b.size() >= NEWTON_BALANCED_B &&
+        b.size() >= QSIZED_MAIN_B &&
         a.size() >= b.size() + QSIZED_MIN_DELTA &&
         NEWTON_BALANCED_DENOMINATOR * a.size() < NEWTON_BALANCED_NUMERATOR * b.size();
     // Thin-quotient extension below the balanced floor: delta <= b/8. Generic


### PR DESCRIPTION
## What

Warm-up follow-on to #116. With odd-size padding making BZ recursion depth size-independent, the basecase threshold (`BIGMATH_BZ_RECURSION_THRESHOLD`) was the next stale knob.

### Basecase 512 → 128

128 beats 512 by **1.2-1.5× across the whole BZ band** (flat 64-128, worse at 48 and above 128). The 512-limb Knuth-D basecase calls were the bottleneck — Karatsuba-backed multiplies win the 128-512 range.

### Newton frontier re-sweep (third time's the charm)

Faster BZ moves every crossover up again. New frontier (floor, min ratio), knife-edge validated at band±1 limbs:

`(896, 8/1), (1280, 7/2), (1792, 14/5), (2560, 5/2), (4096, 2/1 — new band), (8192, 8/5), (131072, 4/3)`

- **Balanced floor 24576 → 131072**: padded BZ wins ratio 1.4-1.5 through ~98k limbs (49152×1.4: BZ 28 vs Newton 38 ms; 98304×1.4: 62 vs 78); Newton edges it from ~131k. The old 24576 floor was insurance against BZ's odd-size collapse — gone since #116.
- **QSized main floor decoupled** (`QSIZED_MAIN_B = 24576`): QSized keeps beating BZ at ratio < 4/3 (24576×1.3: 6.4 vs 10.3 ms; 32768×1.25: 8.5 vs 10.8).
- Old exact-ratio knife-edge hazard is dead (both sides of every knife now well-behaved); cuts track measured crossovers only.

### Results (dispatch, vs #116)

| shape (limbs) | #116 | new | |
|---|---:|---:|---|
| 2048÷1024 | 1.02 ms | 0.74 | 1.39× |
| 3840÷768 (r5) | 2.22 | 1.64 | 1.35× |
| 2560÷1024 (r2.5) | 1.54 | 1.13 | 1.36× |
| 4096÷2048 | 2.41 | 1.87 | 1.29× |
| 24576÷16384 (r1.5) | 12.99 | 10.87 | 1.19× |
| 5200÷520 (r10, "basecase wall" row) | 2.51 | 2.04 | 1.23× |

Full 96-shape sweep: 1.1-1.4× across the band, no regressions beyond noise (one apparent 0.86× outlier re-measured as variance).

## Tests

unit_tests 259/259 (incl. #116's odd-size BZ pins), div_correctness + mult_correctness, ctest 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)