### PR TITLE
perf: parallel ToString subtree fan-out (T1) + reentrant-safe ParallelDo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ if(BIGMATH_BUILD_TESTS)
     add_executable(division_floor_probe tests/performance/division_floor_probe.cpp)
     target_link_libraries(division_floor_probe PRIVATE bigmath::bigmath)
 
+    add_executable(tostring_bench tests/performance/tostring_bench.cpp)
+    target_link_libraries(tostring_bench PRIVATE bigmath::bigmath)
+
     add_executable(mfa_correctness tests/performance/mfa_correctness.cpp)
     target_link_libraries(mfa_correctness PRIVATE bigmath::bigmath)
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ BigMath vs GMP 6.3, Apple M1 Max, paired same-run measurements (2026-06-12). Bel
 
 - **Multiplication beats GMP at every balanced size from 500k digits up** — peaking at 3.2× faster (10M×10M: 65 vs 206 ms) and staying at or below GMP through 200M digits (warm steady state) — and at **every measured skewed shape ≥500k×50k** (0.40–0.77×).
 - **Division beats GMP from 20M-digit dividends (0.45–0.82×)** and reaches parity from 5M (200M÷40M: 3.0 s vs GMP's 4.5 s).
-- **Decimal I/O at parity at scale**: parse 20M digits 1.01×, 50M 1.04×; to-string 10M digits 1.17× warm.
-- Sub-NTT sizes (≲ 13k digits) remain 2–3× behind GMP's hand-tuned basecase, and ToString below ~2M digits is the largest remaining gap (1.9–4×; see `tostring_chain_plan.md`).
+- **ToString beats GMP from 500k digits up** (0.50–0.69× warm; 1M digits: 28 vs 49 ms) after the parallel subtree fan-out (PR #118); 100k digits at 1.25×. Parse at parity at scale: 20M digits 1.01×, 50M 1.04×.
+- Sub-NTT sizes (≲ 13k digits) remain 2–3× behind GMP's hand-tuned basecase — the documented portable-C++ wall.
 
 Two 2026-06 optimization runs produced the current margins — PRs #82–#99 (wraparound Newton division, dispatch band retunes, quotient-sized division, NEON Shoup NTT butterflies) and PRs #107–#112 (fused-MFA pass fusion, row-chunked stage parallelism, MFA gate 2^24→2^20, cyclic products on the fused pipeline, on-the-fly operand packing). PR #116 then fixed a long-standing Burnikel–Ziegler blind spot: odd divisor limb counts silently fell back to quadratic Knuth D, costing 1.3–10× on ~half of real division shapes in the 1k–25k-limb band (12289-limb divisor at ratio 1.5: 95 → 8 ms) — the prior benchmark tables, whose digit-derived shapes mostly landed on even sizes, never sampled it.
 
@@ -157,11 +157,11 @@ Apple M1 Max, vs GMP 6.3.0, `-O3 -march=native`, full default stack (`BIGMATH_LI
 | div (skewed) | **200 000 000 / 40 000 000** | **3 010 ms** | **4 492 ms** | **0.67×** ← BigMath faster |
 | parse | 1 000 000 digits | 32 ms | 21 ms | 1.58× |
 | parse | **20 000 000 digits** | **814 ms** | **804 ms** | **1.01×** ← parity |
-| ToString | 100 000 digits | 9.7 ms | 2.4 ms | 4.01× |
-| ToString | 1 000 000 digits | 106 ms | 49 ms | 2.16× |
-| ToString | 10 000 000 digits | 1 062 ms (warm) | 908 ms | **1.17×** ← near parity |
+| ToString | 100 000 digits | 3.0 ms | 2.4 ms | 1.25× |
+| ToString | **1 000 000 digits** | **28 ms** | **49 ms** | **0.57×** ← BigMath faster |
+| ToString | **10 000 000 digits** | **481 ms (warm)** | **908 ms** | **0.53×** ← BigMath faster |
 
-**BigMath beats GMP on balanced multiplication at every size from 500k digits up** — the former ≥50M-digit losses ("GMP SSA recovers") closed once the fused-MFA pipeline landed: 50M–200M digits run at 0.90–0.97× warm. **Skewed division flipped from a 1.9–2.8× loss to a 0.45–0.67× win at ≥20M-digit dividends** as Newton inherits the fused multiplies and runs its wrap-around products on the same pipeline. ToString narrows from 8.35× (session start) to 4.0× at 100k and near-parity at 10M+ digits; the sub-2M-digit ToString band is the largest remaining gap, with an implementation plan in `tostring_chain_plan.md`. The 10k–2M-digit division plan (`smallskew_div_plan.md`) is executed: its sweep surfaced the Burnikel–Ziegler odd-size fallback fixed in PR #116, and what remains of the sub-50k-digit division gap is the documented portable-C++ basecase wall, accepted there. See [BENCHMARK.md](BENCHMARK.md) for full tables, warm/cold methodology, and per-PR history.
+**BigMath beats GMP on balanced multiplication at every size from 500k digits up** — the former ≥50M-digit losses ("GMP SSA recovers") closed once the fused-MFA pipeline landed: 50M–200M digits run at 0.90–0.97× warm. **Skewed division flipped from a 1.9–2.8× loss to a 0.45–0.67× win at ≥20M-digit dividends** as Newton inherits the fused multiplies and runs its wrap-around products on the same pipeline. **ToString flipped from the largest remaining gap to a 0.50–0.69× win at ≥500k digits** (PR #118: the D&C formatter's subtrees are fixed-width fields at precomputable offsets — one ParallelDo over 8 of them; `tostring_chain_plan.md` records the outcome and the deferred cold-chain lever). The 10k–2M-digit division plan (`smallskew_div_plan.md`) is executed: its sweep surfaced the Burnikel–Ziegler odd-size fallback fixed in PR #116, and what remains of the sub-50k-digit division gap is the documented portable-C++ basecase wall, accepted there. See [BENCHMARK.md](BENCHMARK.md) for full tables, warm/cold methodology, and per-PR history.
 
 Opt-out flags (`-DBIGMATH_USE_THREADS=0` / `-DBIGMATH_NTT_CRT=0` / `-DBIGMATH_LIMB_64=0`) revert any subset of the defaults — useful for embedded targets, header-only-strict consumers, or A/B comparison.
 

--- a/include/biginteger/common/Parser.h
+++ b/include/biginteger/common/Parser.h
@@ -39,7 +39,10 @@ namespace BigMath
   // multiplication has broad carry headroom across both limb modes.
   inline constexpr ULong Base10_19 = 10000000000000000000ULL;
   inline constexpr SizeT Base10_19_Zeroes = 19;
-  inline constexpr SizeT DecimalDcThreshold = 2048;
+#ifndef BIGMATH_PARSE_DC_THRESHOLD
+#define BIGMATH_PARSE_DC_THRESHOLD 2048
+#endif
+  inline constexpr SizeT DecimalDcThreshold = BIGMATH_PARSE_DC_THRESHOLD;
 
 #ifndef BIGMATH_TOSTR_DC_THRESHOLD
 #define BIGMATH_TOSTR_DC_THRESHOLD 1024

--- a/src/common/Parallel.cpp
+++ b/src/common/Parallel.cpp
@@ -23,6 +23,15 @@ namespace BigMath
 {
   namespace
   {
+    // Nesting guard: the pool has a single work slot (curBody/remaining), so a
+    // ParallelDo issued from inside a chunk body — worker thread or the caller
+    // thread running chunk 0 — would overwrite in-flight work and corrupt the
+    // outer dispatch's completion count. Any nested call runs inline serially
+    // instead. This makes ParallelDo safely reentrant, which top-level
+    // orchestration (e.g. the ToString subtree fan-out) relies on: subtree
+    // workers call Newton/NTT code that itself uses ParallelDo.
+    thread_local int tl_chunkDepth = 0;
+
     class ThreadPool
     {
     public:
@@ -60,7 +69,7 @@ namespace BigMath
       // until all chunks complete.
       void RunChunks(Int numChunks, Int total, void (*body)(Int, Int, void *), void *ctx)
       {
-        if (numChunks <= 1)
+        if (numChunks <= 1 || tl_chunkDepth > 0)
         {
           body(0, total, ctx);
           return;
@@ -83,7 +92,9 @@ namespace BigMath
         Int chunkSize = (total + numChunks - 1) / numChunks;
         Int s0 = 0;
         Int e0 = std::min(total, chunkSize);
+        ++tl_chunkDepth;
         body(s0, e0, ctx);
+        --tl_chunkDepth;
 
         // Wait for workers.
         std::unique_lock<std::mutex> lk(m);
@@ -116,7 +127,12 @@ namespace BigMath
             Int chunkSize = (total + chunks - 1) / chunks;
             Int s = workerId * chunkSize;
             Int e = std::min(total, s + chunkSize);
-            if (s < e) body(s, e, ctx);
+            if (s < e)
+            {
+              ++tl_chunkDepth;
+              body(s, e, ctx);
+              --tl_chunkDepth;
+            }
           }
 
           {

--- a/src/common/Parser.cpp
+++ b/src/common/Parser.cpp
@@ -343,6 +343,10 @@ namespace BigMath
         DecimalDcEntry e;
         e.digits = d;
         e.value = Pow10(d);
+        // NOTE: building the dividers in a ParallelDo over levels was tried
+        // (2026-06-12) and REGRESSES cold ToString 10-55%: the level-1/2
+        // reciprocal builds lose their internal threaded NTT when run
+        // serial-inline on a worker, which costs more than the fan-out wins.
         e.divider = std::make_shared<NewtonDivision::Divider>(e.value, CurrentBase);
         chain.push_back(std::move(e));
       }

--- a/src/common/Parser.cpp
+++ b/src/common/Parser.cpp
@@ -15,6 +15,9 @@
 #include "biginteger/algorithms/division/ClassicDivision.h"
 #include "biginteger/algorithms/division/NewtonDivision.h"
 
+#include "biginteger/common/Parallel.h"
+
+#include <cstring>
 #include <memory>
 #include <bit>
 #include <cmath>
@@ -296,10 +299,22 @@ namespace BigMath
       AppendPaddedUnsignedDecimal(*it, Base10_19_Zeroes, out);
   }
 
+// Parallel ToString fan-out (T1): depth of serial descent before the one
+// ParallelDo dispatch (2^splits subtrees), and the digit count below which
+// the fan-out isn't worth the extra copy + dispatch.
+#ifndef BIGMATH_TOSTR_PARALLEL_SPLITS
+#define BIGMATH_TOSTR_PARALLEL_SPLITS 3
+#endif
+#ifndef BIGMATH_TOSTR_PARALLEL_THRESHOLD
+#define BIGMATH_TOSTR_PARALLEL_THRESHOLD 100000
+#endif
+
   // Chain entry: 10^digits + its precomputed Newton-reciprocal divider.
   // Built top-down so each level splits its parent in half — balanced T(N) = 2T(N/2) + M(N).
   namespace
   {
+    constexpr int ToStringParallelSplits = BIGMATH_TOSTR_PARALLEL_SPLITS;
+    constexpr SizeT ToStringParallelThreshold = BIGMATH_TOSTR_PARALLEL_THRESHOLD;
     SizeT EstimateDecimalDigits(std::vector<DataT> const &r)
     {
 #if BIGMATH_LIMB_64
@@ -382,6 +397,93 @@ namespace BigMath
       ToStringDivConquer(std::move(q), chain, level + 1, topPad, out);
       ToStringDivConquer(std::move(r), chain, level + 1, half, out);
     }
+
+#if BIGMATH_USE_THREADS
+    // T1 (tostring_chain_plan.md): the D&C recursion is embarrassingly
+    // parallel below the first few divmods — every subtree's output is a
+    // fixed-width field (value < 10^padTo by construction), so the substrings
+    // land at disjoint, precomputable offsets. Descend serially through the
+    // top `splits` levels (those divmods are the big O(M(L)) ones and thread
+    // internally via NTT), collect the subtrees, then convert them with ONE
+    // ParallelDo dispatch — the pool is non-reentrant by design and nested
+    // dispatches run inline (Parallel.cpp tl_chunkDepth guard).
+    struct ToStringSubtree
+    {
+      std::vector<DataT> n;
+      SizeT level;
+      SizeT padTo;
+    };
+
+    void CollectToStringSubtrees(
+        std::vector<DataT> n,
+        std::vector<DecimalDcEntry> const &chain,
+        SizeT level,
+        SizeT padTo,
+        int splits,
+        std::vector<ToStringSubtree> &items)
+    {
+      if (splits == 0 || level >= chain.size() || IsZero(n))
+      {
+        items.push_back({std::move(n), level, padTo});
+        return;
+      }
+      // n smaller than this level's divisor → top half empty; descend without
+      // consuming a split (no fan-out happened).
+      if (Compare(n, chain[level].value) < 0)
+      {
+        CollectToStringSubtrees(std::move(n), chain, level + 1, padTo, splits, items);
+        return;
+      }
+      std::vector<DataT> q;
+      std::vector<DataT> r;
+      chain[level].divider->DivideAndRemainderInto(n, q, r);
+      SizeT half = chain[level].digits;
+      SizeT topPad = (padTo > half) ? padTo - half : 0;
+      CollectToStringSubtrees(std::move(q), chain, level + 1, topPad, splits - 1, items);
+      CollectToStringSubtrees(std::move(r), chain, level + 1, half, splits - 1, items);
+    }
+
+    void ToStringDivConquerParallel(
+        std::vector<DataT> n,
+        std::vector<DecimalDcEntry> const &chain,
+        std::string &out)
+    {
+      std::vector<ToStringSubtree> items;
+      items.reserve((SizeT)1 << ToStringParallelSplits);
+      CollectToStringSubtrees(std::move(n), chain, 0, 0, ToStringParallelSplits, items);
+
+      // Head subtree carries padTo = 0 (variable width — no leading zeros) so
+      // its length is unknown until converted; do it serially. Everything
+      // after it is fixed-width.
+      ToStringDivConquer(std::move(items[0].n), chain, items[0].level, items[0].padTo, out);
+
+      SizeT m = (SizeT)items.size();
+      if (m <= 1)
+        return;
+
+      std::vector<SizeT> offset(m);
+      SizeT pos = out.size();
+      for (SizeT i = 1; i < m; ++i)
+      {
+        offset[i] = pos;
+        pos += items[i].padTo;
+      }
+      out.resize(pos);
+
+      ParallelDo((Int)(m - 1), [&](Int start, Int end) {
+        for (Int t = start; t < end; ++t)
+        {
+          SizeT i = (SizeT)t + 1;
+          std::string part;
+          part.reserve(items[i].padTo);
+          ToStringDivConquer(std::move(items[i].n), chain, items[i].level, items[i].padTo, part);
+          if (part.size() != items[i].padTo)
+            std::abort(); // fixed-width invariant broken — corrupt output otherwise
+          std::memcpy(&out[offset[i]], part.data(), part.size());
+        }
+      });
+    }
+#endif
   } // namespace
 
   std::string ToString(std::vector<DataT> const &bigInt, SizeT start, SizeT end, bool isNeg)
@@ -417,6 +519,14 @@ namespace BigMath
     SizeT rounded = ((approxDigits + grid - 1) / grid) * grid;
 
     auto const &chain = GetDecimalDcChain(rounded / 2);
+#if BIGMATH_USE_THREADS
+    if (approxDigits >= ToStringParallelThreshold && ParallelNumThreads() > 1 &&
+        chain.size() >= (SizeT)ToStringParallelSplits)
+    {
+      ToStringDivConquerParallel(std::move(r), chain, s);
+      return s;
+    }
+#endif
     ToStringDivConquer(std::move(r), chain, 0, 0, s);
     return s;
   }

--- a/tests/performance/tostring_bench.cpp
+++ b/tests/performance/tostring_bench.cpp
@@ -1,13 +1,19 @@
 // Focused ToString benchmark for decimal conversion experiments.
+// Reports cold (first call at a size — includes the divider-chain build)
+// and warm (best-of-3 with the chain cached) separately; single-iteration
+// chain rows vary ±20-60% with process state, so the split is mandatory
+// (PR #112 lesson, tostring_chain_plan.md methodology).
 
 #include "biginteger/BigInteger.h"
 #include "biginteger/common/Parser.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <string>
 #include <vector>
@@ -28,63 +34,70 @@ static std::string GenerateDigits(int digits, std::uint64_t seed)
 }
 
 template <class F>
-static double TimeMs(F &&fn, int iters)
+static double OnceMs(F &&fn)
 {
   auto start = std::chrono::steady_clock::now();
-  for (int i = 0; i < iters; ++i)
-    fn();
+  fn();
   auto end = std::chrono::steady_clock::now();
-  return std::chrono::duration<double, std::milli>(end - start).count() / iters;
+  return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+template <class F>
+static double BestMs(F &&fn, int iters)
+{
+  double best = std::numeric_limits<double>::max();
+  for (int i = 0; i < iters; ++i)
+    best = std::min(best, OnceMs(fn));
+  return best;
 }
 
 static int Iterations(int digits)
 {
-  if (digits <= 1000) return 80;
   if (digits <= 10000) return 20;
-  if (digits <= 50000) return 6;
-  if (digits <= 100000) return 3;
-  return 1;
+  if (digits <= 100000) return 7;
+  if (digits <= 1000000) return 5;
+  return 3;
 }
 
 int main(int argc, char **argv)
 {
   std::vector<int> sizes;
-  if (argc > 1)
-  {
-    for (int i = 1; i < argc; ++i)
-      sizes.push_back(std::atoi(argv[i]));
-  }
-  else
-  {
-    sizes = {1000, 10000, 50000, 100000, 200000};
-  }
+  for (int i = 1; i < argc; ++i)
+    sizes.push_back(std::atoi(argv[i]));
+  if (sizes.empty())
+    sizes = {100000, 500000, 1000000, 2000000};
 
-  std::cout << "digits,iters,parse_ms,tostring_ms\n";
+  std::cout << "digits,tostring_cold_ms,tostring_warm_ms,parse_cold_ms,parse_warm_ms\n";
   for (int digits : sizes)
   {
     std::string input = GenerateDigits(digits, 0xB16B00B5ULL ^ (std::uint64_t)digits);
-    BigInteger value = Parse(input.c_str());
-    std::string warm = ToString(value);
-    if (warm != input)
+
+    BigInteger value;
+    double parseCold = OnceMs([&]() { value = Parse(input.c_str()); });
+
+    std::string out;
+    double toStringCold = OnceMs([&]() { out = ToString(value); });
+    if (out != input)
     {
       std::cerr << "round trip failed at " << digits << " digits\n";
       return 1;
     }
 
     int iters = Iterations(digits);
-    double parseMs = TimeMs([&]() {
+    double parseWarm = BestMs([&]() {
       BigInteger parsed = Parse(input.c_str());
       if (parsed.size() == 0) std::abort();
     }, iters);
-
-    double toStringMs = TimeMs([&]() {
-      std::string out = ToString(value);
-      if (out.size() != input.size()) std::abort();
+    double toStringWarm = BestMs([&]() {
+      std::string s = ToString(value);
+      if (s.size() != input.size()) std::abort();
     }, iters);
 
-    std::cout << digits << ',' << iters << ','
-              << std::fixed << std::setprecision(4)
-              << parseMs << ',' << toStringMs << '\n';
+    std::cout << digits << ','
+              << std::fixed << std::setprecision(3)
+              << toStringCold << ',' << toStringWarm << ','
+              << parseCold << ',' << parseWarm << '\n'
+              << std::flush;
   }
   return 0;
 }

--- a/tests/unit/test_string_conversion.cpp
+++ b/tests/unit/test_string_conversion.cpp
@@ -28,6 +28,34 @@ static std::string RandomDigits(int digits, std::mt19937 &gen)
   return v;
 }
 
+// ─── parallel ToString fan-out band (≥ BIGMATH_TOSTR_PARALLEL_THRESHOLD) ────
+
+// Byte equality of the round trip is the oracle — any offset-math error in
+// the parallel subtree fan-out corrupts the string. All-9s exercises the
+// carry boundary in every subtree; a power of 10 exercises the IsZero/padTo
+// zero-fill paths.
+static void CheckRoundTrip(std::string const &s)
+{
+  BigInteger v = Parse(s.c_str());
+  ASSERT_EQ(ToString(v), s);
+}
+
+REGISTER_TEST(ToStringParallel, RandomLarge)
+{
+  std::mt19937 gen(0x7051);
+  CheckRoundTrip(RandomDigits(250000, gen));
+}
+
+REGISTER_TEST(ToStringParallel, AllNines)
+{
+  CheckRoundTrip(std::string(150000, '9'));
+}
+
+REGISTER_TEST(ToStringParallel, PowerOfTen)
+{
+  CheckRoundTrip("1" + std::string(150000, '0'));
+}
+
 // ─── parse basics ────────────────────────────────────────────────────────────
 
 REGISTER_TEST(Parse, EmptyAndNullSafe)

--- a/tostring_chain_plan.md
+++ b/tostring_chain_plan.md
@@ -1,6 +1,6 @@
 # ToString Chain Optimization Plan
 
-Status: PLANNED (written 2026-06-12, post PR #107–#112 MFA run).
+Status: DONE (T1 executed 2026-06-12, PR #118; see outcome at bottom).
 This is the largest user-visible gap left vs GMP: ToString at 100k–2M
 digits runs 1.85–4.0× GMP's time; at ≥5M digits the warm steady state is
 already 1.17–1.28× (near parity) and the residual is cold chain build.
@@ -142,3 +142,41 @@ ToString output is end-to-end checkable — byte equality vs
 
 Target: 100k digits 4.0× → ≤2×; 1M 2.16× → ≤1.3×; warm 5M–20M from
 1.17–1.28× → parity or better.
+
+## Outcome (2026-06-12, executed)
+
+Cold/warm split (new `tostring_bench` columns) attributed the time
+exactly as hypothesized: chain build ≈ 40-60% of cold, serial divmod
+tree the rest. T1 alone beat every target (PR #118):
+
+| digits | warm before | after | GMP | ratio |
+|---|---:|---:|---:|---|
+| 100k | 5.4 ms | 3.0 | 2.4 | 1.25× (target ≤2×) |
+| 500k | 31.6 | 14.4 | 20.8 | **0.69×** |
+| 1M | 67.5 | 28.1 | 49.0 | **0.57×** (target ≤1.3×) |
+| 2M | 144.0 | 59.0 | 119.1 | **0.50×** |
+| 10M | 1062 | 481 | 908 | **0.53×** |
+
+ToString beats GMP from 500k digits up. Shape: serial descent through
+the top 3 divmod levels (threaded NTT inside), 8 fixed-width subtrees,
+one ParallelDo, memcpy at precomputed offsets. Prerequisite: ParallelDo
+made safely reentrant (thread_local depth guard runs nested dispatches
+inline) — the pool's single work slot was a latent corruption hazard
+for ANY nested use. Splits=4 measured equal-or-worse than 3.
+
+- **T2: deferred.** Feasible (ApproxReciprocal's doubling loop has clean
+  (R, cur_n) warm-start state; seed = square of the half-level
+  reciprocal with normalization-shift bookkeeping) but cold-only,
+  ~30-40% of chain build ≈ 13 ms at 1M, with fiddly ±1-limb alignment
+  edge cases — worst ROI of the plan now that warm beats GMP. Revisit
+  only if one-shot conversions show up in a real workload.
+- **T3: skipped** — no mixed-size workload; grid-rounded cache (PR #102)
+  already covers nearby sizes.
+- **T4: swept, defaults confirmed.** ToStringDcThreshold 256-4096 and
+  parse DecimalDcThreshold 1024-8192 vs defaults 1024/2048: differences
+  at/below the ~5-10% run-noise floor except parse ≥4096 (clearly
+  worse, 1M parse 31.7→36.8 ms). `BIGMATH_PARSE_DC_THRESHOLD` is now an
+  override hook like the ToString one.
+- **Dead end (documented in code):** ParallelDo over the chain's divider
+  builds regresses cold 10-55% — level-1/2 reciprocal builds lose their
+  internal threaded NTT when run serial-inline on a worker.


### PR DESCRIPTION
## What

First lever of `tostring_chain_plan.md` (T1): the D&C formatter recursion ran serially on the caller's thread while the pool idled. Subtrees below the top divmods are independent fixed-width fields (`value < 10^padTo` by construction) → disjoint, precomputable output offsets.

**Shape:** descend serially through the top 3 levels (the big O(M(L)) divmods, which thread internally via NTT), collect 8 subtrees, ONE `ParallelDo` dispatch, each worker converts into a local string and memcpys to its offset. Head subtree (padTo=0, variable width) converts serially first.

**Prerequisite fix:** the pool has a single work slot — a nested `ParallelDo` from inside a chunk body overwrote in-flight work and corrupted the completion count (latent deadlock/corruption hazard). A `thread_local` depth guard now runs nested dispatches inline serially, making `ParallelDo` safely reentrant. Subtree workers rely on this (their divmods → Newton → NTT → ParallelDo).

## Results (warm, M1 Max, vs GMP `mpz_get_str`)

| digits | before | after | speedup | GMP | ratio before → after |
|---|---:|---:|---|---:|---|
| 100k | 5.4 ms | 3.0 | 1.8× | 2.4 | 2.2× → **1.25×** |
| 500k | 31.6 | 14.4 | 2.2× | 20.8 | 1.5× → **0.69×** |
| 1M | 67.5 | 28.1 | 2.4× | 49.0 | 1.4× → **0.57×** |
| 2M | 144.0 | 59.0 | 2.4× | 119.1 | 1.2× → **0.50×** |
| 10M | 1062 | 481 | 2.2× | 908 | 1.17× → **0.53×** |

**ToString now beats GMP from 500k digits up.** Plan targets (100k ≤2×, 1M ≤1.3×, 5M+ parity) all exceeded. Cold improves too (1M: 109 → 71 ms); the remaining cold gap is the chain build — that's T2 (bottom-up reciprocals), next PR.

Splits=4 A/B: equal ≥500k, worse at 100k — kept 3. Threshold 100k digits (`BIGMATH_TOSTR_PARALLEL_THRESHOLD`), tunable.

## Correctness

- Byte-compare vs `mpz_get_str` at 10k/100k/1M/10M × {random, all-9s, power-of-10} — all pass
- 3 new unit tests in the parallel band (random 250k, all-9s 150k, 10^150000 — carry + zero-fill `padTo` edges)
- Transient-break protocol: corrupted one subtree offset → exactly the 3 new tests failed → restored
- unit_tests 262/262, ctest 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)