### PR TITLE
perf: route squaring to CRT NTT (2.5-5.8x) with self-operand skip

### DIFF
--- a/include/biginteger/algorithms/Squaring.h
+++ b/include/biginteger/algorithms/Squaring.h
@@ -5,8 +5,8 @@
  * operand size. Mirrors Multiplication.h thresholds but uses operand size
  * directly (not the sum), since for a · a both sides are equal.
  *
- * NTT_SQUARE_THRESHOLD defaults to 512 limbs based on the square-specific
- * KaratsubaSquare vs NTTSquare crossover.
+ * NTT_SQUARE_THRESHOLD defaults to 640 limbs (LIMB_64) based on the
+ * KaratsubaSquare vs CRT-NTT self-multiply crossover.
  *
  * S. M. Mahbub Murshed (murshed@gmail.com)
  */
@@ -24,10 +24,11 @@
 namespace BigMath
 {
 #ifndef BIGMATH_NTT_SQUARE_THRESHOLD
-// dispatch_tuner LIMB_64=1: KaratsubaSquare wins through ~1536 limbs; NTT
-// takes over at 2048. Under LIMB_64=0 crossover stays at 512.
+// CRT-square crossover (2026-06-12): KaratsubaSquare ties the CRT+NEON
+// self-multiply at 512 limbs, loses 1.3x+ from 768. Under LIMB_64=0 the
+// crossover stays at 512. Canonical copy: build/DispatchThresholds.h.
 #if BIGMATH_LIMB_64
-#define BIGMATH_NTT_SQUARE_THRESHOLD 2048
+#define BIGMATH_NTT_SQUARE_THRESHOLD 640
 #else
 #define BIGMATH_NTT_SQUARE_THRESHOLD 512
 #endif

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -2264,6 +2264,13 @@ namespace BigMath
       if (a.size() == 1) return ClassicMultiplication::Multiply(b, a[0], base);
       if (b.size() == 1) return ClassicMultiplication::Multiply(a, b[0], base);
 
+      // Squaring: when both operands are the same vector, the b-side pack and
+      // forward transforms are byte-identical to the a-side — skip them and
+      // square fa pointwise. (The fused MFA window below packs straight from
+      // the limb arrays and fuses the pointwise into its stages, so it keeps
+      // the two-operand flow.)
+      const bool sameOperand = (&a == &b);
+
       // Split into 32-bit coefficients. Works for Base2_32 (1 coeff per limb)
       // and Base2_64 (2 coeffs per limb). Pre-CRT bounds: each coefficient is
       // < 2^32, convolution sum at length N is < N · 2^64.
@@ -2340,78 +2347,130 @@ namespace BigMath
           // where it (and ForwardMFA/InverseMFA's standalone Transpose
           // sweeps) is the intended fallback. Kept, not dead code.
           for (int i = 0; i < 6; ++i) mfaScratch[i].assign(n, 0);
-          fa1.assign(n, 0); fb1.assign(n, 0);
-          fa2.assign(n, 0); fb2.assign(n, 0);
-          fa3.assign(n, 0); fb3.assign(n, 0);
+          fa1.assign(n, 0);
+          fa2.assign(n, 0);
+          fa3.assign(n, 0);
           PackOperand(a, base, fa1, fa2, fa3);
-          PackOperand(b, base, fb1, fb2, fb3);
+          if (!sameOperand)
+          {
+            fb1.assign(n, 0); fb2.assign(n, 0); fb3.assign(n, 0);
+            PackOperand(b, base, fb1, fb2, fb3);
+          }
           UInt *bufs[6]   = {fa1.data(), fb1.data(), fa2.data(), fb2.data(), fa3.data(), fb3.data()};
           UInt *scrs[6]   = {mfaScratch[0].data(), mfaScratch[1].data(), mfaScratch[2].data(),
                              mfaScratch[3].data(), mfaScratch[4].data(), mfaScratch[5].data()};
-          // Multi-level MFA: original 6-unit forward batch; the pointwise
-          // sweep below handles the product.
-          auto fwdBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
-            for (Int idx = s; idx < e; ++idx)
-            {
-              switch (idx)
+          if (sameOperand)
+          {
+            // Squaring: only the three a-side forwards.
+            auto fwdBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
+              for (Int idx = s; idx < e; ++idx)
               {
-                case 0: ForwardMFA<F1>(bufs[0], n, scrs[0], /*parallel=*/false, tree1); break;
-                case 1: ForwardMFA<F1>(bufs[1], n, scrs[1], /*parallel=*/false, tree1); break;
-                case 2: ForwardMFA<F2>(bufs[2], n, scrs[2], /*parallel=*/false, tree2); break;
-                case 3: ForwardMFA<F2>(bufs[3], n, scrs[3], /*parallel=*/false, tree2); break;
-                case 4: ForwardMFA<F3>(bufs[4], n, scrs[4], /*parallel=*/false, tree3); break;
-                case 5: ForwardMFA<F3>(bufs[5], n, scrs[5], /*parallel=*/false, tree3); break;
+                switch (idx)
+                {
+                  case 0: ForwardMFA<F1>(bufs[0], n, scrs[0], /*parallel=*/false, tree1); break;
+                  case 1: ForwardMFA<F2>(bufs[2], n, scrs[1], /*parallel=*/false, tree2); break;
+                  case 2: ForwardMFA<F3>(bufs[4], n, scrs[2], /*parallel=*/false, tree3); break;
+                }
               }
-            }
-          };
-          ParallelDo(6, fwdBody);
+            };
+            ParallelDo(3, fwdBody);
+          }
+          else
+          {
+            // Multi-level MFA: original 6-unit forward batch; the pointwise
+            // sweep below handles the product.
+            auto fwdBody = [bufs, scrs, n, &tree1, &tree2, &tree3](Int s, Int e) {
+              for (Int idx = s; idx < e; ++idx)
+              {
+                switch (idx)
+                {
+                  case 0: ForwardMFA<F1>(bufs[0], n, scrs[0], /*parallel=*/false, tree1); break;
+                  case 1: ForwardMFA<F1>(bufs[1], n, scrs[1], /*parallel=*/false, tree1); break;
+                  case 2: ForwardMFA<F2>(bufs[2], n, scrs[2], /*parallel=*/false, tree2); break;
+                  case 3: ForwardMFA<F2>(bufs[3], n, scrs[3], /*parallel=*/false, tree2); break;
+                  case 4: ForwardMFA<F3>(bufs[4], n, scrs[4], /*parallel=*/false, tree3); break;
+                  case 5: ForwardMFA<F3>(bufs[5], n, scrs[5], /*parallel=*/false, tree3); break;
+                }
+              }
+            };
+            ParallelDo(6, fwdBody);
+          }
         }
       }
       else
 #endif
       {
-        fa1.assign(n, 0); fb1.assign(n, 0);
-        fa2.assign(n, 0); fb2.assign(n, 0);
-        fa3.assign(n, 0); fb3.assign(n, 0);
+        fa1.assign(n, 0);
+        fa2.assign(n, 0);
+        fa3.assign(n, 0);
         PackOperand(a, base, fa1, fa2, fa3);
-        PackOperand(b, base, fb1, fb2, fb3);
+        if (!sameOperand)
+        {
+          fb1.assign(n, 0); fb2.assign(n, 0); fb3.assign(n, 0);
+          PackOperand(b, base, fb1, fb2, fb3);
+        }
 #if BIGMATH_USE_THREADS
-        // Cross-prime parallelism: 6 forwards as one batch.
+        // Cross-prime parallelism: 6 forwards as one batch (3 when squaring).
         std::vector<UInt> *bufs[6] = {&fa1, &fb1, &fa2, &fb2, &fa3, &fb3};
         const Plan<F1> *p1 = &plan1;
         const Plan<F2> *p2 = &plan2;
         const Plan<F3> *p3 = &plan3;
-        auto body = [bufs, p1, p2, p3](Int s, Int e) {
-          for (Int idx = s; idx < e; ++idx)
-          {
-            switch (idx)
+        if (sameOperand)
+        {
+          auto body = [bufs, p1, p2, p3](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
             {
-              case 0: Forward<F1>(*bufs[0], *p1); break;
-              case 1: Forward<F1>(*bufs[1], *p1); break;
-              case 2: Forward<F2>(*bufs[2], *p2); break;
-              case 3: Forward<F2>(*bufs[3], *p2); break;
-              case 4: Forward<F3>(*bufs[4], *p3); break;
-              case 5: Forward<F3>(*bufs[5], *p3); break;
+              switch (idx)
+              {
+                case 0: Forward<F1>(*bufs[0], *p1); break;
+                case 1: Forward<F2>(*bufs[2], *p2); break;
+                case 2: Forward<F3>(*bufs[4], *p3); break;
+              }
             }
-          }
-        };
-        ParallelDo(6, body);
+          };
+          ParallelDo(3, body);
+        }
+        else
+        {
+          auto body = [bufs, p1, p2, p3](Int s, Int e) {
+            for (Int idx = s; idx < e; ++idx)
+            {
+              switch (idx)
+              {
+                case 0: Forward<F1>(*bufs[0], *p1); break;
+                case 1: Forward<F1>(*bufs[1], *p1); break;
+                case 2: Forward<F2>(*bufs[2], *p2); break;
+                case 3: Forward<F2>(*bufs[3], *p2); break;
+                case 4: Forward<F3>(*bufs[4], *p3); break;
+                case 5: Forward<F3>(*bufs[5], *p3); break;
+              }
+            }
+          };
+          ParallelDo(6, body);
+        }
 #else
-        Forward<F1>(fa1, plan1); Forward<F1>(fb1, plan1);
-        Forward<F2>(fa2, plan2); Forward<F2>(fb2, plan2);
-        Forward<F3>(fa3, plan3); Forward<F3>(fb3, plan3);
+        Forward<F1>(fa1, plan1);
+        Forward<F2>(fa2, plan2);
+        Forward<F3>(fa3, plan3);
+        if (!sameOperand)
+        {
+          Forward<F1>(fb1, plan1);
+          Forward<F2>(fb2, plan2);
+          Forward<F3>(fb3, plan3);
+        }
 #endif
       }
 
       // The fused MFA path already multiplied fb into fa during forward
       // stage B; the standalone pointwise sweep runs for every other path.
+      // When squaring, the b-side pointers alias fa and square it in place.
 #if BIGMATH_NTT_MFA
       if (!pointwiseFused)
 #endif
       {
-        UInt *p1a = fa1.data(), *p1b = fb1.data();
-        UInt *p2a = fa2.data(), *p2b = fb2.data();
-        UInt *p3a = fa3.data(), *p3b = fb3.data();
+        UInt *p1a = fa1.data(), *p1b = sameOperand ? fa1.data() : fb1.data();
+        UInt *p2a = fa2.data(), *p2b = sameOperand ? fa2.data() : fb2.data();
+        UInt *p3a = fa3.data(), *p3b = sameOperand ? fa3.data() : fb3.data();
         auto body = [p1a, p1b, p2a, p2b, p3a, p3b](Int s, Int e) {
           for (Int i = s; i < e; ++i)
           {

--- a/include/biginteger/build/DispatchThresholds.h
+++ b/include/biginteger/build/DispatchThresholds.h
@@ -64,9 +64,12 @@
 #define BIGMATH_NTT_MFA_THRESHOLD (1 << 20)
 #endif
 
+// Retuned 2048 -> 640 on 2026-06-12 when the square dispatch moved from the
+// single-prime Goldilocks NTTSquare to the CRT+NEON NttCrt self-multiply:
+// KaratsubaSquare ties CRT at 512 limbs and loses 1.3x+ from 768.
 #ifndef BIGMATH_NTT_SQUARE_THRESHOLD
 #if BIGMATH_LIMB_64
-#define BIGMATH_NTT_SQUARE_THRESHOLD 2048
+#define BIGMATH_NTT_SQUARE_THRESHOLD 640
 #else
 #define BIGMATH_NTT_SQUARE_THRESHOLD 512
 #endif

--- a/src/algorithms/Squaring.cpp
+++ b/src/algorithms/Squaring.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "biginteger/algorithms/Squaring.h"
+#include "biginteger/algorithms/multiplication/NTTMultiplicationCrt.h"
 
 namespace BigMath
 {
@@ -21,6 +22,16 @@ namespace BigMath
     if (a.size() < NTT_SQUARE_THRESHOLD)
       return KaratsubaSquare::Square(a, base);
 
+#if BIGMATH_NTT_CRT
+    // CRT NTT square: NttCrt::Multiply detects the self-operand and runs 3
+    // forward transforms instead of 6; NEON Shoup + MFA apply. Measured
+    // 1.6-6.4x over the single-prime Goldilocks NTTSquare at 2k-2M limbs
+    // even before the self-operand skip (NTTSquare uses the 16-bit split at
+    // 2x the transform length, no NEON, no MFA). NTTSquare remains the
+    // -DBIGMATH_NTT_CRT=0 fallback and a test-exercised alternate.
+    return NttCrt::Multiply(a, a, base);
+#else
     return NTTSquare::Square(a, base);
+#endif
   }
 }


### PR DESCRIPTION
## Summary

Stacked on #121. Fixes audit recommendation (a): squaring never used the CRT NTT — `Square()` at ≥2048 limbs ran the single-prime Goldilocks `NTTSquare` (16-bit split at 2× transform length, no NEON, no MFA), including in the hot parse `Pow10` chain.

- `Square()` NTT band now calls `NttCrt::Multiply(a, a)`; `NTTSquare` remains the `-DBIGMATH_NTT_CRT=0` fallback and test alternate.
- `NttCrt::Multiply` detects `&a == &b` and skips the b-side pack + 3 forward transforms (non-MFA and multi-level-MFA paths), squaring `fa` pointwise in place. Fused-MFA window (n ≥ 2^20 coeffs) keeps the two-operand flow — its stage fusion already dominates there.
- `NTT_SQUARE_THRESHOLD` retuned 2048 → 640 (LIMB_64): KaratsubaSquare ties CRT at 512 limbs, loses 1.3×+ from 768.

## Measurements (M1 Max, best-of-N)

| limbs | old NTTSquare | new Square | speedup |
|---|---|---|---|
| 2 048 | 0.559 ms | 0.221 ms | 2.5× |
| 8 192 | 2.53 ms | 0.717 ms | 3.5× |
| 32 768 | 10.9 ms | 2.33 ms | 4.7× |
| 524 288 | 275 ms | 49.2 ms | 5.6× |
| 2 097 152 | 1 643 ms | 285 ms | 5.8× |

Self-operand skip adds 1.02–1.14× over `Multiply(a, copy)` in the non-MFA band (threads soak most of the 6→3 forward saving). End-to-end `parse_cold`: −14% @ 500k digits, −25% @ 1M (A/B vs main); warm paths unchanged.

## Test plan

- ctest 4/4 green (unit_tests 280, mfa_roundtrip)
- `mult_correctness` full matrix incl. `csq/ksq/nsq/dsq` cross-checks
- Bench probes verify limb-exact match between Goldilocks square, CRT multiply, and dispatch square at every measured size

🤖 Generated with [Claude Code](https://claude.com/claude-code)