### PR TITLE
refactor: dedup division bit-shifts, NTT finalize, CRT batch orchestration

### DIFF
--- a/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
+++ b/include/biginteger/algorithms/division/BurnikelZieglerDivision.h
@@ -8,6 +8,7 @@
 #include <vector>
 using namespace std;
 
+#include "../../common/BitShifts.h"
 #include "../../common/Comparator.h"
 #include "../../common/Util.h"
 #include "../Addition.h"
@@ -66,52 +67,6 @@ namespace BigMath
         v.clear();
       while (v.size() < limbs)
         v.push_back(0);
-    }
-
-    // Bit-shift left by [1..LimbBits] bits. Caller ensures shift ∈ [0,LimbBits].
-    static vector<DataT> ShiftLeftBits(vector<DataT> const &v, Int shift)
-    {
-      if (shift == 0 || IsZero(v))
-        return v;
-      vector<DataT> out(v.size() + 1, 0);
-      for (SizeT i = 0; i < v.size(); ++i)
-      {
-#if BIGMATH_LIMB_64
-        ULong128 cur = (ULong128)v[i] << shift;
-        out[i] |= (DataT)(cur & 0xFFFFFFFFFFFFFFFFULL);
-        out[i + 1] |= (DataT)(cur >> 64);
-#else
-        ULong cur = (ULong)v[i] << shift;
-        out[i] |= (DataT)(cur & 0xFFFFFFFFULL);
-        out[i + 1] |= (DataT)(cur >> 32);
-#endif
-      }
-      TrimZerosToOne(out);
-      return out;
-    }
-
-    // Bit-shift right by [0..LimbBits] bits.
-    static vector<DataT> ShiftRightBits(vector<DataT> const &v, Int shift)
-    {
-      if (shift == 0 || IsZero(v))
-        return v;
-      vector<DataT> out(v.size(), 0);
-      for (Int i = 0; i < (Int)v.size(); ++i)
-      {
-#if BIGMATH_LIMB_64
-        ULong128 cur = (ULong128)v[i];
-        if (i + 1 < (Int)v.size())
-          cur |= ((ULong128)v[i + 1]) << 64;
-        out[i] = (DataT)((cur >> shift) & 0xFFFFFFFFFFFFFFFFULL);
-#else
-        ULong cur = v[i];
-        if (i + 1 < (Int)v.size())
-          cur |= ((ULong)v[i + 1]) << 32;
-        out[i] = (DataT)((cur >> shift) & 0xFFFFFFFFULL);
-#endif
-      }
-      TrimZerosToOne(out);
-      return out;
     }
 
     static void Decrement(vector<DataT> &v, BaseT base)
@@ -360,25 +315,11 @@ namespace BigMath
       // 3n/2n correction-loop bound of 2 iterations; without it the loop runs O(B)
       // times when the recursive q-estimate is wildly off (PR #30 LIMB_64 sparse-input
       // hang was here — divisor.back() = 1 forced ~2^64 correction iters).
-      DataT b_top = b[b.size() - 1];
-      Int shift = 0;
-#if BIGMATH_LIMB_64
-      const DataT topBitMask = 0x8000000000000000ULL;
-#else
-      const DataT topBitMask = 0x80000000U;
-#endif
-      while ((b_top & topBitMask) == 0)
-      {
-        b_top <<= 1;
-        ++shift;
-      }
+      const int limbBits = LimbBitsFor(base);
+      Int shift = NormalizationShiftBits(b[b.size() - 1], limbBits);
 
-      vector<DataT> aNorm = (shift > 0)
-                                ? ShiftLeftBits(vector<DataT>(a.begin(), a.end()), shift)
-                                : vector<DataT>(a.begin(), a.end());
-      vector<DataT> bNorm = (shift > 0)
-                                ? ShiftLeftBits(vector<DataT>(b.begin(), b.end()), shift)
-                                : vector<DataT>(b.begin(), b.end());
+      vector<DataT> aNorm = ShiftLeftBits(a, shift, limbBits);
+      vector<DataT> bNorm = ShiftLeftBits(b, shift, limbBits);
 
       // BZ recursion needs the divisor size divisible by 2 at every level of
       // the 2n-by-n split until the basecase; any odd size on the way down
@@ -415,7 +356,7 @@ namespace BigMath
           qr.second.assign(1, 0);
       }
       if (computeRemainder && shift > 0)
-        qr.second = ShiftRightBits(qr.second, shift);
+        qr.second = ShiftRightBits(qr.second, shift, limbBits);
       return qr;
     }
 

--- a/include/biginteger/algorithms/division/FastDivision.h
+++ b/include/biginteger/algorithms/division/FastDivision.h
@@ -8,6 +8,7 @@
 #include <vector>
 using namespace std;
 
+#include "../../common/BitShifts.h"
 #include "../../common/Comparator.h"
 #include "../../common/Util.h"
 #include "../multiplication/ClassicMultiplication.h"
@@ -241,42 +242,6 @@ namespace BigMath
         ++q1;
 
       return q1;
-    }
-
-    // Bit-shift normalization for power-of-two bases. Shifting left by s
-    // (s < limbBits) sets the divisor's top bit; denormalizing the remainder
-    // is a right shift — no per-limb 128/64 division like the scalar-d path.
-    static vector<DataT> ShiftLeftBits(span<const DataT> a, int s, int limbBits)
-    {
-      vector<DataT> out(a.size() + 1, 0);
-      if (s == 0)
-      {
-        std::copy(a.begin(), a.end(), out.begin());
-        return out;
-      }
-      DataT mask = limbBits == 64 ? (DataT)~0ULL : (DataT)0xFFFFFFFFULL;
-      DataT carry = 0;
-      for (SizeT i = 0; i < a.size(); ++i)
-      {
-        DataT cur = a[i];
-        out[i] = ((cur << s) | carry) & mask;
-        carry = cur >> (limbBits - s);
-      }
-      out[a.size()] = carry;
-      return out;
-    }
-
-    static void ShiftRightBitsInPlace(vector<DataT> &r, int s, int limbBits)
-    {
-      if (s == 0)
-        return;
-      DataT mask = limbBits == 64 ? (DataT)~0ULL : (DataT)0xFFFFFFFFULL;
-      SizeT n = (SizeT)r.size();
-      for (SizeT i = 0; i < n; ++i)
-      {
-        DataT hi = (i + 1 < n) ? r[i + 1] : 0;
-        r[i] = ((r[i] >> s) | (hi << (limbBits - s))) & mask;
-      }
     }
 
     static vector<DataT> MultiplyByScalar(span<const DataT> a, DataT d, BaseT base)

--- a/include/biginteger/algorithms/division/NewtonDivision.h
+++ b/include/biginteger/algorithms/division/NewtonDivision.h
@@ -9,6 +9,7 @@
 #include <vector>
 using namespace std;
 
+#include "../../common/BitShifts.h"
 #include "../../common/Comparator.h"
 #include "../../common/Util.h"
 #include "../Addition.h"
@@ -55,52 +56,6 @@ namespace BigMath
     {
       static thread_local ScratchBuffers scratch;
       return scratch;
-    }
-
-    // Bit-shift left by `bits` in [0, LimbBits-1].
-    static vector<DataT> ShiftLeftBits(vector<DataT> const &v, Int bits)
-    {
-      if (bits == 0 || IsZero(v))
-        return v;
-      vector<DataT> out(v.size() + 1, 0);
-      for (SizeT i = 0; i < v.size(); ++i)
-      {
-#if BIGMATH_LIMB_64
-        ULong128 cur = (ULong128)v[i] << bits;
-        out[i] |= (DataT)(cur & 0xFFFFFFFFFFFFFFFFULL);
-        out[i + 1] |= (DataT)(cur >> 64);
-#else
-        ULong cur = (ULong)v[i] << bits;
-        out[i] |= (DataT)(cur & 0xFFFFFFFFULL);
-        out[i + 1] |= (DataT)(cur >> 32);
-#endif
-      }
-      TrimZerosToOne(out);
-      return out;
-    }
-
-    // Bit-shift right by `bits` in [0, LimbBits-1].
-    static vector<DataT> ShiftRightBits(vector<DataT> const &v, Int bits)
-    {
-      if (bits == 0 || IsZero(v))
-        return v;
-      vector<DataT> out(v.size(), 0);
-      for (Int i = 0; i < (Int)v.size(); ++i)
-      {
-#if BIGMATH_LIMB_64
-        ULong128 cur = (ULong128)v[i];
-        if (i + 1 < (Int)v.size())
-          cur |= ((ULong128)v[i + 1]) << 64;
-        out[i] = (DataT)((cur >> bits) & 0xFFFFFFFFFFFFFFFFULL);
-#else
-        ULong cur = v[i];
-        if (i + 1 < (Int)v.size())
-          cur |= ((ULong)v[i + 1]) << 32;
-        out[i] = (DataT)((cur >> bits) & 0xFFFFFFFFULL);
-#endif
-      }
-      TrimZerosToOne(out);
-      return out;
     }
 
     // ApproxReciprocal: given n-limb normalized D (top bit of D[n-1] set),
@@ -580,7 +535,7 @@ namespace BigMath
         vector<DataT> rem_final;
         if (computeRemainder)
         {
-          rem_final = (shift > 0) ? ShiftRightBits(res.rem, shift) : res.rem;
+          rem_final = (shift > 0) ? ShiftRightBits(res.rem, shift, LimbBitsFor(base)) : res.rem;
           TrimZerosToOne(rem_final);
         }
         return {res.q, rem_final};
@@ -650,7 +605,7 @@ namespace BigMath
       vector<DataT> rem_final;
       if (computeRemainder)
       {
-        rem_final = (shift > 0) ? ShiftRightBits(rem, shift) : rem;
+        rem_final = (shift > 0) ? ShiftRightBits(rem, shift, LimbBitsFor(base)) : rem;
         TrimZerosToOne(rem_final);
       }
 
@@ -678,19 +633,9 @@ namespace BigMath
         if ((base != Base2_32 && base != Base2_64) || divisor.size() <= 1)
           return;
 
-        DataT b_top = divisor.back();
-#if BIGMATH_LIMB_64
-        const DataT topBitMask = 0x8000000000000000ULL;
-#else
-        const DataT topBitMask = 0x80000000U;
-#endif
-        while ((b_top & topBitMask) == 0)
-        {
-          b_top <<= 1;
-          ++shift;
-        }
+        shift = NormalizationShiftBits(divisor.back(), LimbBitsFor(base));
 
-        b_norm = (shift > 0) ? ShiftLeftBits(divisor, shift) : divisor;
+        b_norm = (shift > 0) ? ShiftLeftBits(divisor, shift, LimbBitsFor(base)) : divisor;
         TrimZeros(b_norm);
 
         // Precompute the high-precision reciprocal once. It is valid for both single-block
@@ -716,7 +661,7 @@ namespace BigMath
         if (!can_use_newton)
           return FastDivision::DivideAndRemainder(a, divisor, base, computeRemainder);
 
-        vector<DataT> a_norm = (shift > 0) ? ShiftLeftBits(a, shift) : a;
+        vector<DataT> a_norm = (shift > 0) ? ShiftLeftBits(a, shift, LimbBitsFor(base)) : a;
         TrimZeros(a_norm);
 
         return DivideNormalizedWithReciprocal(
@@ -775,21 +720,11 @@ namespace BigMath
         return FastDivision::DivideAndRemainder(a, b, base, computeRemainder);
 
       // Normalize: shift so top bit of b's top limb is set.
-      DataT b_top = b.back();
-      Int shift = 0;
-#if BIGMATH_LIMB_64
-      const DataT topBitMask = 0x8000000000000000ULL;
-#else
-      const DataT topBitMask = 0x80000000U;
-#endif
-      while ((b_top & topBitMask) == 0)
-      {
-        b_top <<= 1;
-        ++shift;
-      }
+      const int limbBits = LimbBitsFor(base);
+      Int shift = NormalizationShiftBits(b.back(), limbBits);
 
-      vector<DataT> a_norm = (shift > 0) ? ShiftLeftBits(a, shift) : a;
-      vector<DataT> b_norm = (shift > 0) ? ShiftLeftBits(b, shift) : b;
+      vector<DataT> a_norm = (shift > 0) ? ShiftLeftBits(a, shift, limbBits) : a;
+      vector<DataT> b_norm = (shift > 0) ? ShiftLeftBits(b, shift, limbBits) : b;
       TrimZeros(a_norm);
       TrimZeros(b_norm);
 

--- a/include/biginteger/algorithms/multiplication/NTTFinalize.h
+++ b/include/biginteger/algorithms/multiplication/NTTFinalize.h
@@ -1,0 +1,136 @@
+/**
+ * BigMath: Goldilocks-NTT result finalization — carry-propagate 16-bit
+ * convolution coefficients and pack them into base-2^32 or base-2^64 limbs.
+ *
+ * Shared by NTTMultiplication and NTTSquare, which previously carried
+ * duplicated (and, for the 2^64 case, divergent) private copies.
+ *
+ * S. M. Mahbub Murshed (murshed@gmail.com)
+ */
+
+#ifndef NTT_FINALIZE
+#define NTT_FINALIZE
+
+#include <vector>
+
+#include "../../common/Util.h"
+
+namespace BigMath
+{
+  // 2-into-1: pack pairs of carry-propagated 16-bit coefficients into
+  // base-2^32 limbs.
+  inline std::vector<DataT> NttFinalizeBase2_32(const std::vector<ULong> &coeffs, SizeT coeffCount)
+  {
+    std::vector<DataT> result;
+    result.reserve(coeffCount / 2 + 2);
+
+    ULong carry = 0;
+    ULong low = 0;
+    bool hasLow = false;
+
+    for (SizeT i = 0; i < coeffCount; ++i)
+    {
+      ULong total = coeffs[i] + carry;
+      ULong digit = total & 0xFFFFULL;
+      carry = total >> 16;
+
+      if (hasLow)
+      {
+        result.push_back((DataT)(low | (digit << 16)));
+        hasLow = false;
+      }
+      else
+      {
+        low = digit;
+        hasLow = true;
+      }
+    }
+
+    while (carry > 0)
+    {
+      ULong digit = carry & 0xFFFFULL;
+      carry >>= 16;
+
+      if (hasLow)
+      {
+        result.push_back((DataT)(low | (digit << 16)));
+        hasLow = false;
+      }
+      else
+      {
+        low = digit;
+        hasLow = true;
+      }
+    }
+
+    if (hasLow)
+      result.push_back((DataT)low);
+
+    TrimZeros(result);
+    return result;
+  }
+
+  // 4-into-1: pack quadruples of carry-propagated 16-bit coefficients into
+  // base-2^64 limbs. Unrolled main loop + slot rotor for the tail.
+  inline std::vector<DataT> NttFinalizeBase2_64(const std::vector<ULong> &coeffs, SizeT coeffCount)
+  {
+    std::vector<DataT> result;
+    result.reserve(coeffCount / 4 + 2);
+
+    ULong carry = 0;
+    SizeT i = 0;
+    for (; i + 3 < coeffCount; i += 4)
+    {
+      ULong total0 = coeffs[i] + carry;
+      ULong d0 = total0 & 0xFFFFULL;
+      carry = total0 >> 16;
+
+      ULong total1 = coeffs[i + 1] + carry;
+      ULong d1 = total1 & 0xFFFFULL;
+      carry = total1 >> 16;
+
+      ULong total2 = coeffs[i + 2] + carry;
+      ULong d2 = total2 & 0xFFFFULL;
+      carry = total2 >> 16;
+
+      ULong total3 = coeffs[i + 3] + carry;
+      ULong d3 = total3 & 0xFFFFULL;
+      carry = total3 >> 16;
+
+      result.push_back((DataT)(d0 | (d1 << 16) | (d2 << 32) | (d3 << 48)));
+    }
+
+    ULong limb_acc = 0;
+    int slot = 0;
+    for (; i < coeffCount; ++i)
+    {
+      ULong total = coeffs[i] + carry;
+      ULong digit = total & 0xFFFFULL;
+      carry = total >> 16;
+      limb_acc |= digit << (slot * 16);
+      ++slot;
+    }
+    while (carry > 0)
+    {
+      ULong digit = carry & 0xFFFFULL;
+      carry >>= 16;
+
+      limb_acc |= digit << (slot * 16);
+      ++slot;
+      if (slot == 4)
+      {
+        result.push_back((DataT)limb_acc);
+        limb_acc = 0;
+        slot = 0;
+      }
+    }
+
+    if (slot != 0)
+      result.push_back((DataT)limb_acc);
+
+    TrimZeros(result);
+    return result;
+  }
+}
+
+#endif

--- a/include/biginteger/algorithms/multiplication/NTTMultiplication.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplication.h
@@ -9,6 +9,7 @@
 #include "../../common/Util.h"
 #include "ClassicMultiplication.h"
 #include "NTTCore.h"
+#include "NTTFinalize.h"
 #include "NTTMultiplicationCrt.h"
 
 using namespace std;
@@ -18,120 +19,6 @@ namespace BigMath
     class NTTMultiplication
     {
     private:
-        static vector<DataT> FinalizeBase2_32(const vector<ULong> &coeffs, SizeT coeffCount)
-        {
-            vector<DataT> result;
-            result.reserve(coeffCount / 2 + 2);
-
-            ULong carry = 0;
-            ULong low = 0;
-            bool hasLow = false;
-
-            for (SizeT i = 0; i < coeffCount; ++i)
-            {
-                ULong total = coeffs[i] + carry;
-                ULong digit = total & 0xFFFFULL;
-                carry = total >> 16;
-
-                if (hasLow)
-                {
-                    result.push_back((DataT)(low | (digit << 16)));
-                    hasLow = false;
-                }
-                else
-                {
-                    low = digit;
-                    hasLow = true;
-                }
-            }
-
-            while (carry > 0)
-            {
-                ULong digit = carry & 0xFFFFULL;
-                carry >>= 16;
-
-                if (hasLow)
-                {
-                    result.push_back((DataT)(low | (digit << 16)));
-                    hasLow = false;
-                }
-                else
-                {
-                    low = digit;
-                    hasLow = true;
-                }
-            }
-
-            if (hasLow)
-                result.push_back((DataT)low);
-
-            TrimZeros(result);
-            return result;
-        }
-
-        // Packs four consecutive 16-bit NTT coefficients into one 64-bit limb,
-        // propagating carries through `carry`. Mirrors FinalizeBase2_32's 2-into-1
-        // pattern with a 4-slot rotor for the 64-bit case.
-        static vector<DataT> FinalizeBase2_64(const vector<ULong> &coeffs, SizeT coeffCount)
-        {
-            vector<DataT> result;
-            result.reserve(coeffCount / 4 + 2);
-
-            ULong carry = 0;
-            SizeT i = 0;
-            for (; i + 3 < coeffCount; i += 4)
-            {
-                ULong total0 = coeffs[i] + carry;
-                ULong d0 = total0 & 0xFFFFULL;
-                carry = total0 >> 16;
-
-                ULong total1 = coeffs[i + 1] + carry;
-                ULong d1 = total1 & 0xFFFFULL;
-                carry = total1 >> 16;
-
-                ULong total2 = coeffs[i + 2] + carry;
-                ULong d2 = total2 & 0xFFFFULL;
-                carry = total2 >> 16;
-
-                ULong total3 = coeffs[i + 3] + carry;
-                ULong d3 = total3 & 0xFFFFULL;
-                carry = total3 >> 16;
-
-                result.push_back((DataT)(d0 | (d1 << 16) | (d2 << 32) | (d3 << 48)));
-            }
-
-            ULong limb_acc = 0;
-            int slot = 0;
-            for (; i < coeffCount; ++i)
-            {
-                ULong total = coeffs[i] + carry;
-                ULong digit = total & 0xFFFFULL;
-                carry = total >> 16;
-                limb_acc |= digit << (slot * 16);
-                ++slot;
-            }
-            while (carry > 0)
-            {
-                ULong digit = carry & 0xFFFFULL;
-                carry >>= 16;
-
-                limb_acc |= digit << (slot * 16);
-                ++slot;
-                if (slot == 4)
-                {
-                    result.push_back((DataT)limb_acc);
-                    limb_acc = 0;
-                    slot = 0;
-                }
-            }
-
-            if (slot != 0)
-                result.push_back((DataT)limb_acc);
-
-            TrimZeros(result);
-            return result;
-        }
-
     public:
         using PreparedOperand = NttCrt::PreparedOperand;
 
@@ -235,7 +122,7 @@ namespace BigMath
                 }
                 NTTCore::Inverse(fa, plan);
 
-                return FinalizeBase2_32(fa, (SizeT)coeffCount);
+                return NttFinalizeBase2_32(fa, (SizeT)coeffCount);
             }
             else if (base == Base2_64)
             {
@@ -287,7 +174,7 @@ namespace BigMath
                 }
                 NTTCore::Inverse(fa, plan);
 
-                return FinalizeBase2_64(fa, (SizeT)coeffCount);
+                return NttFinalizeBase2_64(fa, (SizeT)coeffCount);
             }
             else
             {

--- a/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
+++ b/include/biginteger/algorithms/multiplication/NTTMultiplicationCrt.h
@@ -1252,6 +1252,116 @@ namespace BigMath
       return result;
     }
 
+
+    // ─── Shared whole-transform batch orchestration ─────────────────────────
+    // The plain (non-MFA) forward/pointwise/inverse ParallelDo blocks were
+    // duplicated across Multiply, MultiplyMod2km1 and the prepared-operand
+    // path; any future edit must happen here once.
+
+    // Forward transforms: always the three a-side buffers; the three b-side
+    // buffers too when fb1 != nullptr (one 6-unit batch). Squaring and the
+    // prepared paths pass fb1 == nullptr for a 3-unit batch.
+    inline void CrtForwardBatch(std::vector<UInt> &fa1, std::vector<UInt> &fa2, std::vector<UInt> &fa3,
+                                std::vector<UInt> *fb1, std::vector<UInt> *fb2, std::vector<UInt> *fb3,
+                                const Plan<F1> &plan1, const Plan<F2> &plan2, const Plan<F3> &plan3)
+    {
+#if BIGMATH_USE_THREADS
+      std::vector<UInt> *bufs[6] = {&fa1, fb1, &fa2, fb2, &fa3, fb3};
+      const Plan<F1> *p1 = &plan1;
+      const Plan<F2> *p2 = &plan2;
+      const Plan<F3> *p3 = &plan3;
+      if (fb1 == nullptr)
+      {
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Forward<F1>(*bufs[0], *p1); break;
+              case 1: Forward<F2>(*bufs[2], *p2); break;
+              case 2: Forward<F3>(*bufs[4], *p3); break;
+            }
+          }
+        };
+        ParallelDo(3, body);
+      }
+      else
+      {
+        auto body = [bufs, p1, p2, p3](Int s, Int e) {
+          for (Int idx = s; idx < e; ++idx)
+          {
+            switch (idx)
+            {
+              case 0: Forward<F1>(*bufs[0], *p1); break;
+              case 1: Forward<F1>(*bufs[1], *p1); break;
+              case 2: Forward<F2>(*bufs[2], *p2); break;
+              case 3: Forward<F2>(*bufs[3], *p2); break;
+              case 4: Forward<F3>(*bufs[4], *p3); break;
+              case 5: Forward<F3>(*bufs[5], *p3); break;
+            }
+          }
+        };
+        ParallelDo(6, body);
+      }
+#else
+      Forward<F1>(fa1, plan1);
+      Forward<F2>(fa2, plan2);
+      Forward<F3>(fa3, plan3);
+      if (fb1 != nullptr)
+      {
+        Forward<F1>(*fb1, plan1);
+        Forward<F2>(*fb2, plan2);
+        Forward<F3>(*fb3, plan3);
+      }
+#endif
+    }
+
+    // Pointwise product into the a-side buffers. Pass the a-side pointers as
+    // the b-side to square in place.
+    inline void CrtPointwiseMulInto(UInt *p1a, UInt *p2a, UInt *p3a,
+                                    const UInt *p1b, const UInt *p2b, const UInt *p3b,
+                                    Int n)
+    {
+      auto body = [p1a, p1b, p2a, p2b, p3a, p3b](Int s, Int e) {
+        for (Int i = s; i < e; ++i)
+        {
+          p1a[i] = F1::Mul(p1a[i], p1b[i]);
+          p2a[i] = F2::Mul(p2a[i], p2b[i]);
+          p3a[i] = F3::Mul(p3a[i], p3b[i]);
+        }
+      };
+      if ((SizeT)n >= ParallelMinSize()) ParallelFor(n, body);
+      else body(0, n);
+    }
+
+    // Inverse transforms of the three (already pointwise-multiplied) buffers.
+    inline void CrtInverseBatch(std::vector<UInt> &f1, std::vector<UInt> &f2, std::vector<UInt> &f3,
+                                const Plan<F1> &plan1, const Plan<F2> &plan2, const Plan<F3> &plan3)
+    {
+#if BIGMATH_USE_THREADS
+      std::vector<UInt> *bufs[3] = {&f1, &f2, &f3};
+      const Plan<F1> *p1 = &plan1;
+      const Plan<F2> *p2 = &plan2;
+      const Plan<F3> *p3 = &plan3;
+      auto body = [bufs, p1, p2, p3](Int s, Int e) {
+        for (Int idx = s; idx < e; ++idx)
+        {
+          switch (idx)
+          {
+            case 0: Inverse<F1>(*bufs[0], *p1); break;
+            case 1: Inverse<F2>(*bufs[1], *p2); break;
+            case 2: Inverse<F3>(*bufs[2], *p3); break;
+          }
+        }
+      };
+      ParallelDo(3, body);
+#else
+      Inverse<F1>(f1, plan1);
+      Inverse<F2>(f2, plan2);
+      Inverse<F3>(f3, plan3);
+#endif
+    }
+
     struct PreparedOperand
     {
       BaseT base = Base2_32;
@@ -1304,30 +1414,8 @@ namespace BigMath
       const auto &plan2 = GetPlan<F2, G2>(prepared.n);
       const auto &plan3 = GetPlan<F3, G3>(prepared.n);
 
-#if BIGMATH_USE_THREADS
-      {
-        PreparedOperand *p = &prepared;
-        const Plan<F1> *pl1 = &plan1;
-        const Plan<F2> *pl2 = &plan2;
-        const Plan<F3> *pl3 = &plan3;
-        auto body = [p, pl1, pl2, pl3](Int s, Int e) {
-          for (Int idx = s; idx < e; ++idx)
-          {
-            switch (idx)
-            {
-              case 0: Forward<F1>(p->f1, *pl1); break;
-              case 1: Forward<F2>(p->f2, *pl2); break;
-              case 2: Forward<F3>(p->f3, *pl3); break;
-            }
-          }
-        };
-        ParallelDo(3, body);
-      }
-#else
-      Forward<F1>(prepared.f1, plan1);
-      Forward<F2>(prepared.f2, plan2);
-      Forward<F3>(prepared.f3, plan3);
-#endif
+      CrtForwardBatch(prepared.f1, prepared.f2, prepared.f3,
+                      nullptr, nullptr, nullptr, plan1, plan2, plan3);
 
       return prepared;
     }
@@ -1353,72 +1441,13 @@ namespace BigMath
       const auto &plan2 = GetPlan<F2, G2>(prepared.n);
       const auto &plan3 = GetPlan<F3, G3>(prepared.n);
 
-#if BIGMATH_USE_THREADS
-      {
-        std::vector<UInt> *bufs[3] = {&fb1, &fb2, &fb3};
-        const Plan<F1> *p1 = &plan1;
-        const Plan<F2> *p2 = &plan2;
-        const Plan<F3> *p3 = &plan3;
-        auto body = [bufs, p1, p2, p3](Int s, Int e) {
-          for (Int idx = s; idx < e; ++idx)
-          {
-            switch (idx)
-            {
-              case 0: Forward<F1>(*bufs[0], *p1); break;
-              case 1: Forward<F2>(*bufs[1], *p2); break;
-              case 2: Forward<F3>(*bufs[2], *p3); break;
-            }
-          }
-        };
-        ParallelDo(3, body);
-      }
-#else
-      Forward<F1>(fb1, plan1);
-      Forward<F2>(fb2, plan2);
-      Forward<F3>(fb3, plan3);
-#endif
+      CrtForwardBatch(fb1, fb2, fb3, nullptr, nullptr, nullptr, plan1, plan2, plan3);
 
-      {
-        UInt *p1a = fb1.data(), *p2a = fb2.data(), *p3a = fb3.data();
-        const UInt *p1b = prepared.f1.data();
-        const UInt *p2b = prepared.f2.data();
-        const UInt *p3b = prepared.f3.data();
-        auto body = [p1a, p2a, p3a, p1b, p2b, p3b](Int s, Int e) {
-          for (Int i = s; i < e; ++i)
-          {
-            p1a[i] = F1::Mul(p1a[i], p1b[i]);
-            p2a[i] = F2::Mul(p2a[i], p2b[i]);
-            p3a[i] = F3::Mul(p3a[i], p3b[i]);
-          }
-        };
-        if ((SizeT)prepared.n >= ParallelMinSize()) ParallelFor(prepared.n, body);
-        else body(0, prepared.n);
-      }
+      CrtPointwiseMulInto(fb1.data(), fb2.data(), fb3.data(),
+                          prepared.f1.data(), prepared.f2.data(), prepared.f3.data(),
+                          prepared.n);
 
-#if BIGMATH_USE_THREADS
-      {
-        std::vector<UInt> *bufs[3] = {&fb1, &fb2, &fb3};
-        const Plan<F1> *p1 = &plan1;
-        const Plan<F2> *p2 = &plan2;
-        const Plan<F3> *p3 = &plan3;
-        auto body = [bufs, p1, p2, p3](Int s, Int e) {
-          for (Int idx = s; idx < e; ++idx)
-          {
-            switch (idx)
-            {
-              case 0: Inverse<F1>(*bufs[0], *p1); break;
-              case 1: Inverse<F2>(*bufs[1], *p2); break;
-              case 2: Inverse<F3>(*bufs[2], *p3); break;
-            }
-          }
-        };
-        ParallelDo(3, body);
-      }
-#else
-      Inverse<F1>(fb1, plan1);
-      Inverse<F2>(fb2, plan2);
-      Inverse<F3>(fb3, plan3);
-#endif
+      CrtInverseBatch(fb1, fb2, fb3, plan1, plan2, plan3);
 
       return FinalizeProduct(
           fb1, fb2, fb3, coeffCount, prepared.base, prepared.operandLimbs + other.size() + 2);
@@ -2409,56 +2438,12 @@ namespace BigMath
           fb1.assign(n, 0); fb2.assign(n, 0); fb3.assign(n, 0);
           PackOperand(b, base, fb1, fb2, fb3);
         }
-#if BIGMATH_USE_THREADS
         // Cross-prime parallelism: 6 forwards as one batch (3 when squaring).
-        std::vector<UInt> *bufs[6] = {&fa1, &fb1, &fa2, &fb2, &fa3, &fb3};
-        const Plan<F1> *p1 = &plan1;
-        const Plan<F2> *p2 = &plan2;
-        const Plan<F3> *p3 = &plan3;
-        if (sameOperand)
-        {
-          auto body = [bufs, p1, p2, p3](Int s, Int e) {
-            for (Int idx = s; idx < e; ++idx)
-            {
-              switch (idx)
-              {
-                case 0: Forward<F1>(*bufs[0], *p1); break;
-                case 1: Forward<F2>(*bufs[2], *p2); break;
-                case 2: Forward<F3>(*bufs[4], *p3); break;
-              }
-            }
-          };
-          ParallelDo(3, body);
-        }
-        else
-        {
-          auto body = [bufs, p1, p2, p3](Int s, Int e) {
-            for (Int idx = s; idx < e; ++idx)
-            {
-              switch (idx)
-              {
-                case 0: Forward<F1>(*bufs[0], *p1); break;
-                case 1: Forward<F1>(*bufs[1], *p1); break;
-                case 2: Forward<F2>(*bufs[2], *p2); break;
-                case 3: Forward<F2>(*bufs[3], *p2); break;
-                case 4: Forward<F3>(*bufs[4], *p3); break;
-                case 5: Forward<F3>(*bufs[5], *p3); break;
-              }
-            }
-          };
-          ParallelDo(6, body);
-        }
-#else
-        Forward<F1>(fa1, plan1);
-        Forward<F2>(fa2, plan2);
-        Forward<F3>(fa3, plan3);
-        if (!sameOperand)
-        {
-          Forward<F1>(fb1, plan1);
-          Forward<F2>(fb2, plan2);
-          Forward<F3>(fb3, plan3);
-        }
-#endif
+        CrtForwardBatch(fa1, fa2, fa3,
+                        sameOperand ? nullptr : &fb1,
+                        sameOperand ? nullptr : &fb2,
+                        sameOperand ? nullptr : &fb3,
+                        plan1, plan2, plan3);
       }
 
       // The fused MFA path already multiplied fb into fa during forward
@@ -2468,19 +2453,11 @@ namespace BigMath
       if (!pointwiseFused)
 #endif
       {
-        UInt *p1a = fa1.data(), *p1b = sameOperand ? fa1.data() : fb1.data();
-        UInt *p2a = fa2.data(), *p2b = sameOperand ? fa2.data() : fb2.data();
-        UInt *p3a = fa3.data(), *p3b = sameOperand ? fa3.data() : fb3.data();
-        auto body = [p1a, p1b, p2a, p2b, p3a, p3b](Int s, Int e) {
-          for (Int i = s; i < e; ++i)
-          {
-            p1a[i] = F1::Mul(p1a[i], p1b[i]);
-            p2a[i] = F2::Mul(p2a[i], p2b[i]);
-            p3a[i] = F3::Mul(p3a[i], p3b[i]);
-          }
-        };
-        if ((SizeT)n >= ParallelMinSize()) ParallelFor(n, body);
-        else body(0, n);
+        CrtPointwiseMulInto(fa1.data(), fa2.data(), fa3.data(),
+                            sameOperand ? fa1.data() : fb1.data(),
+                            sameOperand ? fa2.data() : fb2.data(),
+                            sameOperand ? fa3.data() : fb3.data(),
+                            n);
       }
 
 #if BIGMATH_NTT_MFA
@@ -2516,28 +2493,7 @@ namespace BigMath
       else
 #endif
       {
-#if BIGMATH_USE_THREADS
-        std::vector<UInt> *bufs[3] = {&fa1, &fa2, &fa3};
-        const Plan<F1> *p1 = &plan1;
-        const Plan<F2> *p2 = &plan2;
-        const Plan<F3> *p3 = &plan3;
-        auto body = [bufs, p1, p2, p3](Int s, Int e) {
-          for (Int idx = s; idx < e; ++idx)
-          {
-            switch (idx)
-            {
-              case 0: Inverse<F1>(*bufs[0], *p1); break;
-              case 1: Inverse<F2>(*bufs[1], *p2); break;
-              case 2: Inverse<F3>(*bufs[2], *p3); break;
-            }
-          }
-        };
-        ParallelDo(3, body);
-#else
-        Inverse<F1>(fa1, plan1);
-        Inverse<F2>(fa2, plan2);
-        Inverse<F3>(fa3, plan3);
-#endif
+        CrtInverseBatch(fa1, fa2, fa3, plan1, plan2, plan3);
       }
 
       return FinalizeProduct(fa1, fa2, fa3, coeffCount, base, a.size() + b.size() + 2);
@@ -2618,74 +2574,12 @@ namespace BigMath
         fa3.assign(n, 0); fb3.assign(n, 0);
         PackOperand(a, base, fa1, fa2, fa3);
         PackOperand(b, base, fb1, fb2, fb3);
-#if BIGMATH_USE_THREADS
-        {
-          std::vector<UInt> *bufs[6] = {&fa1, &fb1, &fa2, &fb2, &fa3, &fb3};
-          const Plan<F1> *p1 = &plan1;
-          const Plan<F2> *p2 = &plan2;
-          const Plan<F3> *p3 = &plan3;
-          auto body = [bufs, p1, p2, p3](Int s, Int e) {
-            for (Int idx = s; idx < e; ++idx)
-            {
-              switch (idx)
-              {
-                case 0: Forward<F1>(*bufs[0], *p1); break;
-                case 1: Forward<F1>(*bufs[1], *p1); break;
-                case 2: Forward<F2>(*bufs[2], *p2); break;
-                case 3: Forward<F2>(*bufs[3], *p2); break;
-                case 4: Forward<F3>(*bufs[4], *p3); break;
-                case 5: Forward<F3>(*bufs[5], *p3); break;
-              }
-            }
-          };
-          ParallelDo(6, body);
-        }
-#else
-        Forward<F1>(fa1, plan1); Forward<F1>(fb1, plan1);
-        Forward<F2>(fa2, plan2); Forward<F2>(fb2, plan2);
-        Forward<F3>(fa3, plan3); Forward<F3>(fb3, plan3);
-#endif
+        CrtForwardBatch(fa1, fa2, fa3, &fb1, &fb2, &fb3, plan1, plan2, plan3);
 
-        {
-          UInt *p1a = fa1.data(), *p1b = fb1.data();
-          UInt *p2a = fa2.data(), *p2b = fb2.data();
-          UInt *p3a = fa3.data(), *p3b = fb3.data();
-          auto body = [p1a, p1b, p2a, p2b, p3a, p3b](Int s, Int e) {
-            for (Int i = s; i < e; ++i)
-            {
-              p1a[i] = F1::Mul(p1a[i], p1b[i]);
-              p2a[i] = F2::Mul(p2a[i], p2b[i]);
-              p3a[i] = F3::Mul(p3a[i], p3b[i]);
-            }
-          };
-          if ((SizeT)n >= ParallelMinSize()) ParallelFor(n, body);
-          else body(0, n);
-        }
+        CrtPointwiseMulInto(fa1.data(), fa2.data(), fa3.data(),
+                            fb1.data(), fb2.data(), fb3.data(), n);
 
-#if BIGMATH_USE_THREADS
-        {
-          std::vector<UInt> *bufs[3] = {&fa1, &fa2, &fa3};
-          const Plan<F1> *p1 = &plan1;
-          const Plan<F2> *p2 = &plan2;
-          const Plan<F3> *p3 = &plan3;
-          auto body = [bufs, p1, p2, p3](Int s, Int e) {
-            for (Int idx = s; idx < e; ++idx)
-            {
-              switch (idx)
-              {
-                case 0: Inverse<F1>(*bufs[0], *p1); break;
-                case 1: Inverse<F2>(*bufs[1], *p2); break;
-                case 2: Inverse<F3>(*bufs[2], *p3); break;
-              }
-            }
-          };
-          ParallelDo(3, body);
-        }
-#else
-        Inverse<F1>(fa1, plan1);
-        Inverse<F2>(fa2, plan2);
-        Inverse<F3>(fa3, plan3);
-#endif
+        CrtInverseBatch(fa1, fa2, fa3, plan1, plan2, plan3);
       }
 
       // Garner-recombine and carry across exactly N coefficients (L limbs);

--- a/include/biginteger/algorithms/multiplication/NTTSquare.h
+++ b/include/biginteger/algorithms/multiplication/NTTSquare.h
@@ -16,6 +16,7 @@
 #include "../../common/Util.h"
 #include "NTTMultiplication.h"
 #include "NTTCore.h"
+#include "NTTFinalize.h"
 #include "ClassicSquare.h"
 
 using namespace std;
@@ -25,101 +26,6 @@ namespace BigMath
   class NTTSquare
   {
   private:
-    static vector<DataT> FinalizeBase2_32(const vector<ULong> &coeffs, SizeT coeffCount)
-    {
-      vector<DataT> result;
-      result.reserve(coeffCount / 2 + 2);
-
-      ULong carry = 0;
-      ULong low = 0;
-      bool hasLow = false;
-
-      for (SizeT i = 0; i < coeffCount; ++i)
-      {
-        ULong total = coeffs[i] + carry;
-        ULong digit = total & 0xFFFFULL;
-        carry = total >> 16;
-
-        if (hasLow)
-        {
-          result.push_back((DataT)(low | (digit << 16)));
-          hasLow = false;
-        }
-        else
-        {
-          low = digit;
-          hasLow = true;
-        }
-      }
-
-      while (carry > 0)
-      {
-        ULong digit = carry & 0xFFFFULL;
-        carry >>= 16;
-
-        if (hasLow)
-        {
-          result.push_back((DataT)(low | (digit << 16)));
-          hasLow = false;
-        }
-        else
-        {
-          low = digit;
-          hasLow = true;
-        }
-      }
-
-      if (hasLow)
-        result.push_back((DataT)low);
-
-      TrimZeros(result);
-      return result;
-    }
-
-    // 4-into-1 rotor: combine four consecutive 16-bit coefficients into one
-    // 64-bit limb, propagating carries.
-    static vector<DataT> FinalizeBase2_64(const vector<ULong> &coeffs, SizeT coeffCount)
-    {
-      vector<DataT> result;
-      result.reserve(coeffCount / 4 + 2);
-
-      ULong carry = 0;
-      ULong limb_acc = 0;
-      int slot = 0;
-
-      auto flush = [&result, &limb_acc, &slot](bool force)
-      {
-        if (slot == 4 || (force && slot != 0))
-        {
-          result.push_back((DataT)limb_acc);
-          limb_acc = 0;
-          slot = 0;
-        }
-      };
-
-      for (SizeT i = 0; i < coeffCount; ++i)
-      {
-        ULong total = coeffs[i] + carry;
-        ULong digit = total & 0xFFFFULL;
-        carry = total >> 16;
-        limb_acc |= digit << (slot * 16);
-        ++slot;
-        flush(false);
-      }
-      while (carry > 0)
-      {
-        ULong digit = carry & 0xFFFFULL;
-        carry >>= 16;
-        limb_acc |= digit << (slot * 16);
-        ++slot;
-        flush(false);
-      }
-      flush(true);
-
-      TrimZeros(result);
-      return result;
-    }
-
   public:
     static vector<DataT> Square(vector<DataT> const &a, BaseT base)
     {
@@ -180,7 +86,7 @@ namespace BigMath
         }
         NTTCore::Inverse(fa, plan);
 
-        return FinalizeBase2_32(fa, (SizeT)coeffCount);
+        return NttFinalizeBase2_32(fa, (SizeT)coeffCount);
       }
       else if (base == Base2_64)
       {
@@ -216,7 +122,7 @@ namespace BigMath
         }
         NTTCore::Inverse(fa, plan);
 
-        return FinalizeBase2_64(fa, (SizeT)coeffCount);
+        return NttFinalizeBase2_64(fa, (SizeT)coeffCount);
       }
       else
       {

--- a/include/biginteger/common/BitShifts.h
+++ b/include/biginteger/common/BitShifts.h
@@ -1,0 +1,101 @@
+/**
+ * BigMath: Limb-vector bit-shift helpers for power-of-two bases.
+ *
+ * Shared by FastDivision, BurnikelZieglerDivision and NewtonDivision, which
+ * previously carried three near-identical private copies (two of them
+ * compile-time-width, silently wrong for the non-default base). The limb
+ * width is a runtime parameter derived from the base, so the same code
+ * serves Base2_32 and Base2_64 builds and cross-base calls.
+ *
+ * S. M. Mahbub Murshed (murshed@gmail.com)
+ */
+
+#ifndef BIGMATH_BIT_SHIFTS
+#define BIGMATH_BIT_SHIFTS
+
+#include <span>
+#include <vector>
+
+#include "Constants.h"
+#include "Util.h"
+
+namespace BigMath
+{
+  // Limb width in bits for a power-of-two base. Callers guarantee
+  // base ∈ {Base2_32, Base2_64}.
+  inline int LimbBitsFor(BaseT base)
+  {
+    return base == Base2_64 ? 64 : 32;
+  }
+
+  // Knuth-style normalization count: bits to shift left so `top` (nonzero)
+  // gets its high bit set within a limbBits-wide limb. Replaces the
+  // topBitMask while-loops that were copy-pasted across the dividers.
+  inline Int NormalizationShiftBits(DataT top, int limbBits)
+  {
+    return limbBits == 64 ? (Int)__builtin_clzll((unsigned long long)top)
+                          : (Int)__builtin_clz((unsigned)top);
+  }
+
+  // v << bits at the bit level, bits ∈ [0, limbBits]. Result is trimmed to
+  // the canonical (≥ 1 limb) form. 128-bit intermediates make bits == limbBits
+  // well-defined for both widths.
+  inline std::vector<DataT> ShiftLeftBits(std::span<const DataT> v, Int bits, int limbBits)
+  {
+    if (bits == 0 || IsZero(v))
+      return std::vector<DataT>(v.begin(), v.end());
+
+    const DataT mask = (limbBits == 64) ? (DataT)0xFFFFFFFFFFFFFFFFULL
+                                        : (DataT)0xFFFFFFFFULL;
+    std::vector<DataT> out(v.size() + 1, 0);
+    for (SizeT i = 0; i < (SizeT)v.size(); ++i)
+    {
+      ULong128 cur = (ULong128)v[i] << bits;
+      out[i] |= (DataT)(cur & mask);
+      out[i + 1] |= (DataT)((cur >> limbBits) & mask);
+    }
+    TrimZerosToOne(out);
+    return out;
+  }
+
+  // v >> bits at the bit level, bits ∈ [0, limbBits). Result is trimmed to
+  // the canonical (≥ 1 limb) form.
+  inline std::vector<DataT> ShiftRightBits(std::span<const DataT> v, Int bits, int limbBits)
+  {
+    if (bits == 0 || IsZero(v))
+      return std::vector<DataT>(v.begin(), v.end());
+
+    const DataT mask = (limbBits == 64) ? (DataT)0xFFFFFFFFFFFFFFFFULL
+                                        : (DataT)0xFFFFFFFFULL;
+    const SizeT n = (SizeT)v.size();
+    std::vector<DataT> out(n, 0);
+    for (SizeT i = 0; i < n; ++i)
+    {
+      ULong128 cur = (ULong128)v[i];
+      if (i + 1 < n)
+        cur |= (ULong128)v[i + 1] << limbBits;
+      out[i] = (DataT)((cur >> bits) & mask);
+    }
+    TrimZerosToOne(out);
+    return out;
+  }
+
+  // r >>= bits in place, bits ∈ [0, limbBits). Does not trim — remainder
+  // denormalization wants the limb count preserved.
+  inline void ShiftRightBitsInPlace(std::vector<DataT> &r, Int bits, int limbBits)
+  {
+    if (bits == 0)
+      return;
+    const DataT mask = (limbBits == 64) ? (DataT)0xFFFFFFFFFFFFFFFFULL
+                                        : (DataT)0xFFFFFFFFULL;
+    const SizeT n = (SizeT)r.size();
+    for (SizeT i = 0; i < n; ++i)
+    {
+      DataT hi = (i + 1 < n) ? r[i + 1] : 0;
+      ULong128 cur = (ULong128)r[i] | ((ULong128)hi << limbBits);
+      r[i] = (DataT)((cur >> bits) & mask);
+    }
+  }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Stacked on #122. Fixes audit recommendation (b) — the three copy-paste families:

1. **`ShiftLeftBits`/`ShiftRightBits` ×3** → one runtime-width pair in `common/BitShifts.h` (+ `ShiftRightBitsInPlace`, `LimbBitsFor`, `NormalizationShiftBits`). BZ and Newton carried compile-time `BIGMATH_LIMB_64` copies — the cross-base width assumption the audit flagged; FastDivision's runtime-width style won. The three copy-pasted `topBitMask` normalize while-loops became one `countl_zero`-style helper.
2. **`FinalizeBase2_32/64` duplicated** between `NTTMultiplication` and `NTTSquare`, with *divergent* 2^64 implementations of the same semantics → one pair in `multiplication/NTTFinalize.h` (kept the unrolled hot-path version).
3. **Plain CRT forward/pointwise/inverse `ParallelDo` blocks** repeated across `NttCrt::Multiply`, `MultiplyMod2km1`, `PrepareOperand`, and the prepared-operand `Multiply` → `CrtForwardBatch` / `CrtPointwiseMulInto` / `CrtInverseBatch`, shared by all five sites (incl. the squaring 3-forward variant from #122). Future butterfly-orchestration edits now happen once.

Intentional divergence preserved: cyclic path keeps its raw MFA threshold gate vs the linear path's skew-aware `UseMfaForShape` (noted in a comment, not silently aligned).

Net −300 lines of duplicated hot-path code.

## Test plan

- ctest 4/4 (unit_tests 280, mfa_roundtrip), `mult_correctness` + `div_correctness` full matrices
- GMP division dispatch fuzz, 200 adversarial cases
- Interleaved A/B vs main: `divperf_simple` and square benches identical within noise; `multperf_simple` NTT 3.2 ms unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)